### PR TITLE
rcv.data_models: remove unnecessary fields

### DIFF
--- a/cl_sii/rcv/data_models.py
+++ b/cl_sii/rcv/data_models.py
@@ -224,11 +224,6 @@ class RvDetalleEntry(RcvDetalleEntry):
     RCV_KIND = RcvKind.VENTAS
     RC_ESTADO_CONTABLE = None
 
-    emisor_razon_social: Optional[str] = dc_field()
-    """
-    "Razón social" (legal name) of the "emisor" of the "documento".
-    """
-
     # TODO: docstring
     # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
     receptor_razon_social: str = dc_field()
@@ -243,11 +238,6 @@ class RvDetalleEntry(RcvDetalleEntry):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-
-        if self.emisor_razon_social is not None:
-            if not isinstance(self.emisor_razon_social, str):
-                raise TypeError("Inappropriate type of 'emisor_razon_social'.")
-            cl_sii.dte.data_models.validate_contribuyente_razon_social(self.emisor_razon_social)
 
         if not isinstance(self.receptor_razon_social, str):
             raise TypeError("Inappropriate type of 'receptor_razon_social'.")
@@ -280,10 +270,6 @@ class RcRegistroDetalleEntry(RcvDetalleEntry):
     """
 
     # TODO: docstring
-    # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
-    receptor_razon_social: Optional[str] = dc_field()
-
-    # TODO: docstring
     # note: must be timezone-aware.
     fecha_acuse_dt: Optional[datetime] = dc_field()
 
@@ -293,11 +279,6 @@ class RcRegistroDetalleEntry(RcvDetalleEntry):
         if not isinstance(self.emisor_razon_social, str):
             raise TypeError("Inappropriate type of 'emisor_razon_social'.")
         cl_sii.dte.data_models.validate_contribuyente_razon_social(self.emisor_razon_social)
-
-        if self.receptor_razon_social is not None:
-            if not isinstance(self.receptor_razon_social, str):
-                raise TypeError("Inappropriate type of 'receptor_razon_social'.")
-            cl_sii.dte.data_models.validate_contribuyente_razon_social(self.receptor_razon_social)
 
         if self.fecha_acuse_dt is not None:
             if not isinstance(self.fecha_acuse_dt, datetime):
@@ -332,10 +313,6 @@ class RcReclamadoDetalleEntry(RcvDetalleEntry):
     """
 
     # TODO: docstring
-    # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
-    receptor_razon_social: Optional[str] = dc_field()
-
-    # TODO: docstring
     # note: must be timezone-aware.
     fecha_reclamo_dt: Optional[datetime] = dc_field()
 
@@ -345,11 +322,6 @@ class RcReclamadoDetalleEntry(RcvDetalleEntry):
         if not isinstance(self.emisor_razon_social, str):
             raise TypeError("Inappropriate type of 'emisor_razon_social'.")
         cl_sii.dte.data_models.validate_contribuyente_razon_social(self.emisor_razon_social)
-
-        if self.receptor_razon_social is not None:
-            if not isinstance(self.receptor_razon_social, str):
-                raise TypeError("Inappropriate type of 'receptor_razon_social'.")
-            cl_sii.dte.data_models.validate_contribuyente_razon_social(self.receptor_razon_social)
 
         if self.fecha_reclamo_dt is not None:
             if not isinstance(self.fecha_reclamo_dt, datetime):
@@ -372,18 +344,9 @@ class RcPendienteDetalleEntry(RcvDetalleEntry):
     "Razón social" (legal name) of the "emisor" of the "documento".
     """
 
-    # TODO: docstring
-    # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
-    receptor_razon_social: Optional[str] = dc_field()
-
     def __post_init__(self) -> None:
         super().__post_init__()
 
         if not isinstance(self.emisor_razon_social, str):
             raise TypeError("Inappropriate type of 'emisor_razon_social'.")
         cl_sii.dte.data_models.validate_contribuyente_razon_social(self.emisor_razon_social)
-
-        if self.receptor_razon_social is not None:
-            if not isinstance(self.receptor_razon_social, str):
-                raise TypeError("Inappropriate type of 'receptor_razon_social'.")
-            cl_sii.dte.data_models.validate_contribuyente_razon_social(self.receptor_razon_social)

--- a/cl_sii/rcv/parse_csv.py
+++ b/cl_sii/rcv/parse_csv.py
@@ -656,8 +656,6 @@ class RcvVentaCsvRowSchema(_RcvCsvRowSchemaBase):
                 receptor_rut=receptor_rut,
                 monto_total=monto_total,
                 receptor_razon_social=receptor_razon_social,
-                # FIXME: remove after field 'emisor_razon_social' is removed from the dataclass
-                emisor_razon_social=None,
                 fecha_recepcion_dt=fecha_recepcion_dt,
                 fecha_acuse_dt=fecha_acuse_dt,
                 fecha_reclamo_dt=fecha_reclamo_dt,
@@ -791,8 +789,6 @@ class RcvCompraRegistroCsvRowSchema(_RcvCsvRowSchemaBase):
                 receptor_rut=receptor_rut,
                 monto_total=monto_total,
                 emisor_razon_social=emisor_razon_social,
-                # FIXME: remove after field 'receptor_razon_social' is removed from the dataclass
-                receptor_razon_social=None,
                 fecha_recepcion_dt=fecha_recepcion_dt,
                 fecha_acuse_dt=fecha_acuse_dt,
             )
@@ -827,8 +823,6 @@ class RcvCompraNoIncluirCsvRowSchema(RcvCompraRegistroCsvRowSchema):
                 receptor_rut=receptor_rut,
                 monto_total=monto_total,
                 emisor_razon_social=emisor_razon_social,
-                # FIXME: remove after field 'receptor_razon_social' is removed from the dataclass
-                receptor_razon_social=None,
                 fecha_recepcion_dt=fecha_recepcion_dt,
                 fecha_acuse_dt=fecha_acuse_dt,
             )
@@ -967,8 +961,6 @@ class RcvCompraReclamadoCsvRowSchema(_RcvCsvRowSchemaBase):
                 receptor_rut=receptor_rut,
                 monto_total=monto_total,
                 emisor_razon_social=emisor_razon_social,
-                # FIXME: remove after field 'receptor_razon_social' is removed from the dataclass
-                receptor_razon_social=None,
                 fecha_recepcion_dt=fecha_recepcion_dt,
                 fecha_reclamo_dt=fecha_reclamo_dt,
             )
@@ -1090,8 +1082,6 @@ class RcvCompraPendienteCsvRowSchema(_RcvCsvRowSchemaBase):
                 receptor_rut=receptor_rut,
                 monto_total=monto_total,
                 emisor_razon_social=emisor_razon_social,
-                # FIXME: remove after field 'receptor_razon_social' is removed from the dataclass
-                receptor_razon_social=None,
                 fecha_recepcion_dt=fecha_recepcion_dt,
             )
         except (TypeError, ValueError):


### PR DESCRIPTION
For subclasses of `RcvDetalleEntry` only one of these fields is necessary, which depends on the specific class.

- `emisor_razon_social`
- `receptor_razon_social`

These fields had been made optional in #112 (commit 1f21463).