### PR TITLE
Release v0.10.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0.a2
+current_version = 0.10.0.a3
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0.a3
+current_version = 0.10.0
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,28 @@
 History
 -------
 
+0.10.0 (2020-04-14)
++++++++++++++++++++++++
+
+0.10.0.a3
+~~~~~~~~~~~~~~~~~~~~~~
+
+* (PR #116, 2020-04-14) rcv.data_models: remove unnecessary fields
+* (PR #114, 2020-04-14) rcv.parse_csv: remove param ``razon_social`` from parse functions
+
+0.10.0.a2
+~~~~~~~~~~~~~~~~~~~~~~
+
+* (PR #112, 2020-04-14) data_models: make some fields optional
+
+0.10.0.a1
+~~~~~~~~~~~~~~~~~~~~~~
+
+* (PR #110, 2020-04-13) rcv.data_models: move some fields to subclasses
+* (PR #109, 2020-04-13) rcv.parse_csv: move code from 'fd-cl-data' in here
+* (PR #108, 2020-04-13) dte.data_models: add 'DteXmlData'
+* (PR #107, 2020-04-10) requirements: several updates
+
 0.9.1 (2020-03-20)
 +++++++++++++++++++++++
 

--- a/cl_sii/__init__.py
+++ b/cl_sii/__init__.py
@@ -5,4 +5,4 @@ cl-sii Python lib
 """
 
 
-__version__ = '0.10.0.a3'
+__version__ = '0.10.0'

--- a/cl_sii/__init__.py
+++ b/cl_sii/__init__.py
@@ -5,4 +5,4 @@ cl-sii Python lib
 """
 
 
-__version__ = '0.10.0.a2'
+__version__ = '0.10.0.a3'

--- a/cl_sii/rcv/data_models.py
+++ b/cl_sii/rcv/data_models.py
@@ -224,11 +224,6 @@ class RvDetalleEntry(RcvDetalleEntry):
     RCV_KIND = RcvKind.VENTAS
     RC_ESTADO_CONTABLE = None
 
-    emisor_razon_social: Optional[str] = dc_field()
-    """
-    "Razón social" (legal name) of the "emisor" of the "documento".
-    """
-
     # TODO: docstring
     # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
     receptor_razon_social: str = dc_field()
@@ -243,11 +238,6 @@ class RvDetalleEntry(RcvDetalleEntry):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-
-        if self.emisor_razon_social is not None:
-            if not isinstance(self.emisor_razon_social, str):
-                raise TypeError("Inappropriate type of 'emisor_razon_social'.")
-            cl_sii.dte.data_models.validate_contribuyente_razon_social(self.emisor_razon_social)
 
         if not isinstance(self.receptor_razon_social, str):
             raise TypeError("Inappropriate type of 'receptor_razon_social'.")
@@ -280,10 +270,6 @@ class RcRegistroDetalleEntry(RcvDetalleEntry):
     """
 
     # TODO: docstring
-    # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
-    receptor_razon_social: Optional[str] = dc_field()
-
-    # TODO: docstring
     # note: must be timezone-aware.
     fecha_acuse_dt: Optional[datetime] = dc_field()
 
@@ -293,11 +279,6 @@ class RcRegistroDetalleEntry(RcvDetalleEntry):
         if not isinstance(self.emisor_razon_social, str):
             raise TypeError("Inappropriate type of 'emisor_razon_social'.")
         cl_sii.dte.data_models.validate_contribuyente_razon_social(self.emisor_razon_social)
-
-        if self.receptor_razon_social is not None:
-            if not isinstance(self.receptor_razon_social, str):
-                raise TypeError("Inappropriate type of 'receptor_razon_social'.")
-            cl_sii.dte.data_models.validate_contribuyente_razon_social(self.receptor_razon_social)
 
         if self.fecha_acuse_dt is not None:
             if not isinstance(self.fecha_acuse_dt, datetime):
@@ -332,10 +313,6 @@ class RcReclamadoDetalleEntry(RcvDetalleEntry):
     """
 
     # TODO: docstring
-    # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
-    receptor_razon_social: Optional[str] = dc_field()
-
-    # TODO: docstring
     # note: must be timezone-aware.
     fecha_reclamo_dt: Optional[datetime] = dc_field()
 
@@ -345,11 +322,6 @@ class RcReclamadoDetalleEntry(RcvDetalleEntry):
         if not isinstance(self.emisor_razon_social, str):
             raise TypeError("Inappropriate type of 'emisor_razon_social'.")
         cl_sii.dte.data_models.validate_contribuyente_razon_social(self.emisor_razon_social)
-
-        if self.receptor_razon_social is not None:
-            if not isinstance(self.receptor_razon_social, str):
-                raise TypeError("Inappropriate type of 'receptor_razon_social'.")
-            cl_sii.dte.data_models.validate_contribuyente_razon_social(self.receptor_razon_social)
 
         if self.fecha_reclamo_dt is not None:
             if not isinstance(self.fecha_reclamo_dt, datetime):
@@ -372,18 +344,9 @@ class RcPendienteDetalleEntry(RcvDetalleEntry):
     "Razón social" (legal name) of the "emisor" of the "documento".
     """
 
-    # TODO: docstring
-    # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
-    receptor_razon_social: Optional[str] = dc_field()
-
     def __post_init__(self) -> None:
         super().__post_init__()
 
         if not isinstance(self.emisor_razon_social, str):
             raise TypeError("Inappropriate type of 'emisor_razon_social'.")
         cl_sii.dte.data_models.validate_contribuyente_razon_social(self.emisor_razon_social)
-
-        if self.receptor_razon_social is not None:
-            if not isinstance(self.receptor_razon_social, str):
-                raise TypeError("Inappropriate type of 'receptor_razon_social'.")
-            cl_sii.dte.data_models.validate_contribuyente_razon_social(self.receptor_razon_social)

--- a/cl_sii/rcv/parse_csv.py
+++ b/cl_sii/rcv/parse_csv.py
@@ -656,8 +656,6 @@ class RcvVentaCsvRowSchema(_RcvCsvRowSchemaBase):
                 receptor_rut=receptor_rut,
                 monto_total=monto_total,
                 receptor_razon_social=receptor_razon_social,
-                # FIXME: remove after field 'emisor_razon_social' is removed from the dataclass
-                emisor_razon_social=None,
                 fecha_recepcion_dt=fecha_recepcion_dt,
                 fecha_acuse_dt=fecha_acuse_dt,
                 fecha_reclamo_dt=fecha_reclamo_dt,
@@ -791,8 +789,6 @@ class RcvCompraRegistroCsvRowSchema(_RcvCsvRowSchemaBase):
                 receptor_rut=receptor_rut,
                 monto_total=monto_total,
                 emisor_razon_social=emisor_razon_social,
-                # FIXME: remove after field 'receptor_razon_social' is removed from the dataclass
-                receptor_razon_social=None,
                 fecha_recepcion_dt=fecha_recepcion_dt,
                 fecha_acuse_dt=fecha_acuse_dt,
             )
@@ -827,8 +823,6 @@ class RcvCompraNoIncluirCsvRowSchema(RcvCompraRegistroCsvRowSchema):
                 receptor_rut=receptor_rut,
                 monto_total=monto_total,
                 emisor_razon_social=emisor_razon_social,
-                # FIXME: remove after field 'receptor_razon_social' is removed from the dataclass
-                receptor_razon_social=None,
                 fecha_recepcion_dt=fecha_recepcion_dt,
                 fecha_acuse_dt=fecha_acuse_dt,
             )
@@ -967,8 +961,6 @@ class RcvCompraReclamadoCsvRowSchema(_RcvCsvRowSchemaBase):
                 receptor_rut=receptor_rut,
                 monto_total=monto_total,
                 emisor_razon_social=emisor_razon_social,
-                # FIXME: remove after field 'receptor_razon_social' is removed from the dataclass
-                receptor_razon_social=None,
                 fecha_recepcion_dt=fecha_recepcion_dt,
                 fecha_reclamo_dt=fecha_reclamo_dt,
             )
@@ -1090,8 +1082,6 @@ class RcvCompraPendienteCsvRowSchema(_RcvCsvRowSchemaBase):
                 receptor_rut=receptor_rut,
                 monto_total=monto_total,
                 emisor_razon_social=emisor_razon_social,
-                # FIXME: remove after field 'receptor_razon_social' is removed from the dataclass
-                receptor_razon_social=None,
                 fecha_recepcion_dt=fecha_recepcion_dt,
             )
         except (TypeError, ValueError):

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,11 @@ disallow_untyped_defs = True
 check_untyped_defs = True
 warn_return_any = True
 
+show_column_numbers = True
+show_error_codes = True
+show_error_context = True
+error_summary = True
+
 [mypy-cryptography.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
- (PR #116, 2020-04-14) rcv.data_models: remove unnecessary fields
- (PR #114, 2020-04-14) rcv.parse_csv: remove param `razon_social` from parse functions
- (PR #112, 2020-04-14) data_models: make some fields optional
- (PR #110, 2020-04-13) rcv.data_models: move some fields to subclasses
- (PR #109, 2020-04-13) rcv.parse_csv: move code from 'fd-cl-data' in here
- (PR #108, 2020-04-13) dte.data_models: add 'DteXmlData'
- (PR #107, 2020-04-10) requirements: several updates