### PR TITLE
Add sub-package `rtc`

### DIFF
--- a/cl_sii/rtc/__init__.py
+++ b/cl_sii/rtc/__init__.py
@@ -1,0 +1,10 @@
+"""
+SII RTC/RPETC
+=============
+
+Concepts and acronyms used interchangeably:
+
+* "Registro Transferencia de Crédito" (RTC)
+* "Registro Público Electrónico de Transferencia de Crédito" (RPETC)
+* "Registro Electrónico de Cesión de Créditos"
+"""


### PR DESCRIPTION
For SII's "RTC/RPETC".

Concepts and acronyms used interchangeably:

- "Registro Transferencia de Crédito" (RTC)
- "Registro Público Electrónico de Transferencia de Crédito" (RPETC)
- "Registro Electrónico de Cesión de Créditos"

The commit was taken from https://github.com/fyntex/lib-cl-sii-api-python/commit/50470e85c7eca1dc7f9f3abc4623e26f77f87615.