### PR TITLE
config: Make CI 'dist' job depend on 'test' jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,9 @@ workflows:
                 - "3.7.2"
                 - "3.7.6"
                 - "3.8.3"
-      - dist
+      - dist:
+          requires:
+            - test
       - deploy:
           requires:
             - dist


### PR DESCRIPTION
CI workflows will finish faster if we do not attempt to build distributable artifacts when tests fail.