### PR TITLE
requirements: update 'eight' (dependency of 'signxml')

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,8 +34,8 @@ signxml==2.8.0
 attrs==19.3.0
 certifi==2020.4.5.1
 cffi==1.14.0
-eight==0.4.2
-future==0.16.0
+eight==1.0.0
+future==0.18.2
 importlib-metadata==1.6.0; python_version<'3.8'
 pycparser==2.20
 pyrsistent==0.16.0


### PR DESCRIPTION
(plus its dependency `future`)

Changelog:

- 1.0.0 (2019-12-01)
  https://github.com/kislyuk/eight/blob/v1.0.0/Changes.rst#changes-for-v100-2019-12-01

Code diff: https://github.com/kislyuk/eight/compare/v0.4.2...v1.0.0

Replaces: https://github.com/fyntex/lib-cl-sii-python/pull/143.