### PR TITLE
rtc: Add data models and parser for AECs

### DIFF
--- a/cl_sii/rtc/data_models_aec.py
+++ b/cl_sii/rtc/data_models_aec.py
@@ -1,0 +1,763 @@
+"""
+Data models for RTC AEC XML docs/files
+======================================
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import date, datetime
+from typing import ClassVar, Mapping, Tuple, Optional, Sequence
+
+import pydantic
+
+from cl_sii.base.constants import SII_OFFICIAL_TZ
+from cl_sii.dte import data_models as dte_data_models
+from cl_sii.libs import tz_utils
+from cl_sii.rut import Rut
+
+from . import data_models
+
+
+@pydantic.dataclasses.dataclass(
+    frozen=True,
+    config=type('Config', (), dict(
+        anystr_strip_whitespace=True,
+        arbitrary_types_allowed=True,
+        min_anystr_length=1,
+    ))
+)
+class CesionAecXml:
+    """
+    Data in XML element ``sii-dte:Cesion`` in an AEC XML doc.
+
+    ..seealso::
+        XML schema of ``{http://www.sii.cl/SiiDte}/Cesion`` in
+        'data/ref/factura_electronica/schemas-xml/Cesion_v10.xsd' (c7adc5a2)
+
+    ..note:: An AEC XML doc includes one or more ``Cesion`` XML elements.
+
+    Excluded XML elements:
+
+    * ``sii-dte:DocumentoCesion/sii-dte:OtrasCondiciones`` (0..1 occurrences)
+    * ``ds:Signature`` (1..3 occurrences)
+    """
+
+    ###########################################################################
+    # Constants
+    ###########################################################################
+
+    DATETIME_FIELDS_TZ: ClassVar[tz_utils.PytzTimezone] = SII_OFFICIAL_TZ
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    dte: dte_data_models.DteDataL1
+    """
+    DTE of the "cesión".
+
+    AEC doc XML elements:
+    * '...//Cesion//DocumentoCesion//IdDTE//RUTEmisor'
+    * '...//Cesion//DocumentoCesion//IdDTE//TipoDTE'
+    * '...//Cesion//DocumentoCesion//IdDTE//Folio'
+    * '...//Cesion//DocumentoCesion//IdDTE//FchEmis'
+    * '...//Cesion//DocumentoCesion//IdDTE//RUTReceptor'
+    * '...//Cesion//DocumentoCesion//IdDTE//MntTotal'
+
+    RPETC email:
+    * attachment / 'Documento Cedido' / (initial text before ' - Monto Total')
+    * attachment / 'Documento Cedido' / 'Emisor'
+    * attachment / 'Documento Cedido' / 'Receptor'
+    * attachment / 'Documento Cedido' / 'Fecha Emision'
+    """
+
+    seq: int
+    """
+    Sequence number of the "cesión". Must be >= 1.
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//SeqCesion'
+
+    RPETC email: attachment / 'Cesion' / 'Seq'
+    """
+
+    cedente_rut: Rut
+    """
+    RUT of the "cedente".
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//Cedente//RUT'
+
+    RPETC email: attachment / 'Cedente' / 'Cedido por' (fraction)
+    """
+
+    cesionario_rut: Rut
+    """
+    RUT of the "cesionario".
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//Cesionario//RUT'
+
+    RPETC email: attachment / 'Cesionario' / 'Cedido a' (fraction)
+    """
+
+    monto_cesion: int
+    """
+    Amount of the "cesión".
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//MontoCesion'
+
+    RPETC email: attachment / 'Cesion' / 'Monto Cedido'
+    """
+
+    fecha_cesion_dt: datetime
+    """
+    Datetime of "cesión".
+
+    e.g. `2019-03-29T10:18:35` (XML), 2019-03-29 10:18:35 (txt)
+
+    > TimeStamp de la Cesion del DTE.
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//TmstCesion'
+
+    RPETC email: attachment / 'Cesion' / 'Fecha de la Cesion'
+    """
+
+    fecha_ultimo_vencimiento: date
+    """
+    Date of "Ultimo Vencimiento".
+
+    e.g. `2019-04-28` (XML), 2019-03-29 10:18:35 (txt)
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//UltimoVencimiento'
+
+    RPETC email: attachment / 'Cesion' / 'Ultimo Vencimiento'
+    """
+
+    cedente_razon_social: str
+    """
+    "Razón social" (legal name) of the "cedente".
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//Cedente//RazonSocial'
+
+    RPETC email: attachment / 'Cedente' / 'Cedido por' (fraction)
+    """
+
+    cedente_direccion: str = dataclasses.field(repr=False)
+    """
+    Address ("Dirección") of the "cedente".
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//Cedente//Direccion'
+
+    RPETC email: attachment / 'Cedente' / 'Direccion'
+    """
+
+    cedente_email: str = dataclasses.field(repr=False)
+    """
+    Email address of the "cedente".
+
+    .. warning:: Value may be an invalid email address.
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//Cedente//eMail'
+
+    RPETC email: attachment / 'Cedente' / 'eMail'
+    """
+
+    cedente_persona_autorizada_rut: Rut
+    """
+    "Persona Autorizada" by the "cedente" to "Firmar la Transferencia" (RUT).
+
+    .. note:: It might be the "cedente" itself, a "persona natural", etc.
+
+    First of the
+    > Lista de Personas Autorizadas por el Cedente a Firmar la Transferencia
+
+    AEC doc XML element (1..3 occurrences of 'RUTAutorizado'):
+        '..//Cesion//DocumentoCesion//Cedente//RUTAutorizado//RUT'
+    """
+
+    cedente_persona_autorizada_nombre: str
+    """
+    "Persona Autorizada" by the "cedente" to "Firmar la Transferencia" (name).
+
+    .. note:: It might be the "cedente" itself, a "persona natural", etc.
+
+    First of the
+    > Lista de Personas Autorizadas por el Cedente a Firmar la Transferencia
+
+    AEC doc XML element (1..3 occurrences of 'RUTAutorizado'):
+        '..//Cesion//DocumentoCesion//Cedente//RUTAutorizado//Nombre'
+    """
+
+    cesionario_razon_social: str
+    """
+    "Razón social" (legal name) of the "cesionario".
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//Cesionario//RazonSocial'
+
+    RPETC email: attachment / 'Cesionario' / 'Cedido a' (fraction)
+    """
+
+    cesionario_direccion: str = dataclasses.field(repr=False)
+    """
+    Address ("Dirección") of the "cesionario".
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//Cesionario//Direccion'
+
+    RPETC email: attachment / 'Cesionario' / 'Direccion'
+    """
+
+    cesionario_email: str = dataclasses.field(repr=False)
+    """
+    Email address of the "cesionario".
+
+    .. warning:: Value may be an invalid email address.
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//Cesionario//eMail'
+
+    RPETC email: attachment / 'Cesionario' / 'eMail'
+    """
+
+    dte_deudor_email: Optional[str] = dataclasses.field(default=None, repr=False)
+    """
+    Email address of the "deudor" of the DTE.
+
+    .. warning:: Value may be an invalid email address.
+
+    AEC doc XML element: '..//Cesion//DocumentoCesion//eMailDeudor'
+
+    RPETC email: no.
+    """
+
+    cedente_declaracion_jurada: Optional[str] = dataclasses.field(default=None, repr=False)
+    """
+    "Declaración Jurada" by the "cedente".
+
+    > Declaracion Jurada de Disponibilidad de Documentacion No Electronica.
+
+    .. note::
+        The RUT and "razón social" of the "deudor" of the DTE are included
+        in the text. However, this field is optional.
+
+    Example:
+        "Se declara bajo juramento que
+        COMERCIALIZADORA INNOVA MOBEL SPA, RUT 76399752-9
+        ha puesto a disposición del cesionario
+        ST CAPITAL S.A., RUT 76389992-6,
+        el o los documentos donde constan los recibos de las mercaderías
+        entregadas o servicios prestados, entregados por parte del deudor
+        de la factura
+        EMPRESAS LA POLAR S.A., RUT 96874030-K,
+        deacuerdo a lo establecido en la Ley N°19.983."
+
+    AEC doc XML element (optional): '..//Cesion//DocumentoCesion//Cedente//DeclaracionJurada'
+
+    RPETC email: attachment / 'Cesion' / 'Declaracion Jurada'
+    **but only whether "declaración jurada" was included or not**,
+    not the "declaración jurada" itself.
+    """
+
+    @property
+    def natural_key(self) -> data_models.CesionNaturalKey:
+        return data_models.CesionNaturalKey(dte_key=self.dte.natural_key, seq=self.seq)
+
+    @property
+    def alt_natural_key(self) -> data_models.CesionAltNaturalKey:
+        return data_models.CesionAltNaturalKey(
+            dte_key=self.dte.natural_key,
+            cedente_rut=self.cedente_rut,
+            cesionario_rut=self.cesionario_rut,
+            fecha_cesion_dt=self.fecha_cesion_dt,
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    @pydantic.validator('dte')
+    def validate_dte_tipo_dte(cls, v: object) -> object:
+        if isinstance(v, dte_data_models.DteDataL0):
+            data_models.validate_cesion_dte_tipo_dte(v.tipo_dte)
+        return v
+
+    @pydantic.validator('seq')
+    def validate_seq(cls, v: object) -> object:
+        if isinstance(v, int):
+            data_models.validate_cesion_seq(v)
+        return v
+
+    @pydantic.validator('monto_cesion')
+    def validate_monto_cesion(cls, v: object) -> object:
+        if isinstance(v, int):
+            data_models.validate_cesion_monto(v)
+        return v
+
+    @pydantic.validator(
+        'cedente_razon_social',
+        'cesionario_razon_social',
+    )
+    def validate_contribuyente_razon_social(cls, v: object) -> object:
+        if isinstance(v, str):
+            dte_data_models.validate_contribuyente_razon_social(v)
+        return v
+
+    @pydantic.validator('fecha_cesion_dt')
+    def validate_datetime_tz(cls, v: object) -> object:
+        if isinstance(v, datetime):
+            tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
+        return v
+
+    @pydantic.root_validator(skip_on_failure=True)
+    def validate_fecha_cesion_dt_is_consistent_with_dte(
+        cls, values: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        fecha_cesion_dt = values['fecha_cesion_dt']
+        dte = values['dte']
+
+        if isinstance(fecha_cesion_dt, datetime) and isinstance(dte, dte_data_models.DteDataL1):
+            pass  # TODO: Validate value of 'fecha_cesion_dt' in relation to the DTE data.
+
+        return values
+
+    @pydantic.root_validator(skip_on_failure=True)
+    def validate_monto_cesion_does_not_exceed_dte_monto_total(
+        cls, values: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        monto_cesion = values['monto_cesion']
+        dte = values['dte']
+
+        if isinstance(monto_cesion, int) and isinstance(dte, dte_data_models.DteDataL1):
+            data_models.validate_cesion_and_dte_montos(
+                cesion_value=monto_cesion,
+                dte_value=dte.monto_total,
+            )
+
+        return values
+
+    @pydantic.root_validator(skip_on_failure=True)
+    def validate_fecha_ultimo_vencimiento_is_consistent_with_dte(
+        cls, values: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        fecha_ultimo_vencimiento = values['fecha_ultimo_vencimiento']
+        dte = values['dte']
+
+        if (
+            isinstance(fecha_ultimo_vencimiento, date)
+            and isinstance(dte, dte_data_models.DteDataL1)
+        ):
+            pass  # TODO: Validate value of 'fecha_ultimo_vencimiento' in relation to the DTE data.
+
+        return values
+
+
+@pydantic.dataclasses.dataclass(
+    frozen=True,
+    config=type('Config', (), dict(
+        anystr_strip_whitespace=True,
+        arbitrary_types_allowed=True,
+        min_anystr_length=1,
+    ))
+)
+class AecXml:
+    """
+    Data in a "cesión"'s AEC XML doc.
+
+    ..seealso::
+        XML schema of ``{http://www.sii.cl/SiiDte}/AEC`` in
+        'data/ref/factura_electronica/schemas-xml/AEC_v10.xsd' (c7adc5a2)
+
+    XML signatures
+    --------------
+
+    For now, all the XML signatures are excluded from this model.
+
+    Inside the ``<AEC>`` XML element there are 3 XML signatures:
+
+    1) 'sii-dte:AEC/ds:Signature'
+      (over ``<DocumentoAEC>``)
+
+    2) 'sii-dte:AEC/sii-dte:DocumentoAEC/sii-dte:Cesiones/sii-dte:DTECedido/
+        ds:Signature'
+      (over ``<DocumentoDTECedido>``)
+
+    3) 'sii-dte:AEC/sii-dte:DocumentoAEC/sii-dte:Cesiones/sii-dte:DTECedido/
+        sii-dte:DocumentoDTECedido/sii-dte:DTE/ds:Signature'
+      (over ``<Documento>``)
+
+    Plus 1, 2 or 3 per "cesión":
+
+    'sii-dte:AEC/sii-dte:DocumentoAEC/sii-dte:Cesiones/sii-dte:Cesion/ds:Signature'
+      (over ``<DocumentoCesion>``)
+     Ref: data/ref/factura_electronica/schemas-xml/Cesion_v10.xsd#L222-L226 (c7adc5a2)
+
+    Thus the minimum total number of XML signatures is 4.
+    """
+
+    ###########################################################################
+    # Constants
+    ###########################################################################
+
+    DATETIME_FIELDS_TZ: ClassVar[tz_utils.PytzTimezone] = SII_OFFICIAL_TZ
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    dte: dte_data_models.DteXmlData
+    """
+    DTE that was "cedido".
+
+    AEC doc XML element: 'DocumentoAEC//Cesiones//DTECedido//DocumentoDTECedido//DTE'
+
+    RPETC email: attachment / 'Documento Cedido'
+    """
+
+    cedente_rut: Rut
+    """
+    RUT of the "cedente".
+
+    > RUT que Genera el Archivo de Transferencias.
+
+    AEC doc XML element: 'DocumentoAEC//Caratula//RutCedente'
+
+    RPETC email: attachment / 'Cedente' / 'Cedido por' (fraction)
+    """
+
+    cesionario_rut: Rut
+    """
+    RUT of the "cesionario".
+
+    > RUT a Quien Va Dirigido el Archivo de Transferencias.
+
+    AEC doc XML element: 'DocumentoAEC//Caratula//RutCesionario'
+
+    RPETC email: attachment / 'Cesionario' / 'Cedido a' (fraction)
+    """
+
+    fecha_firma_dt: datetime
+    """
+    Datetime of 'Firma del Archivo de Transferencias'
+
+    > Fecha y Hora de la Firma del Archivo de Transferencias.
+
+    e.g. `2019-03-29T10:18:35` (XML), 2019-03-29 10:18:35 (txt)
+
+    AEC doc XML element: 'DocumentoAEC//Caratula//TmstFirmaEnvio'
+
+    RPETC email: attachment / 'Cesion' / 'Fecha de la Cesion'
+    """
+
+    # signature_value: Optional[bytes] = dataclasses.field(repr=False)
+    """
+    AEC's digital signature's value (raw bytes, without base64 encoding).
+
+    Signature is over AEC doc XML element: 'DocumentoAEC'
+
+    AEC doc XML element: 'Signature/SignatureValue'
+    """
+
+    # signature_x509_cert_der: Optional[bytes] = dataclasses.field(repr=False)
+    """
+    AEC's digital signature's DER-encoded X.509 certificate.
+
+    Signature is over AEC doc XML element: 'DocumentoAEC'
+
+    AEC doc XML element: 'Signature/KeyInfo/X509Data/X509Certificate'
+
+    .. seealso::
+        Functions :func:`cl_sii.libs.crypto_utils.load_der_x509_cert`
+        and :func:`cl_sii.libs.crypto_utils.x509_cert_der_to_pem`.
+    """
+
+    cesiones: Sequence[CesionAecXml]
+    """
+    List of structs for ``sii-dte:Cesion`` XML elements.
+
+    ..warning::
+        The items MUST be ordered according to their ``seq``, starting with
+        the first "cesión" of the DTE (i.e. with ``seq = 1``).
+    """
+
+    contacto_nombre: Optional[str] = None
+    """
+    Name of the contact person.
+
+    > Persona de Contacto para aclarar dudas.
+
+    AEC doc XML element: 'DocumentoAEC//Caratula//NmbContacto'
+
+    RPETC email: none.
+    """
+
+    contacto_telefono: Optional[str] = None
+    """
+    Phone number of the contact person.
+
+    > Telefono de Contacto.
+
+    AEC doc XML element: 'DocumentoAEC//Caratula//FonoContacto'
+
+    RPETC email: none.
+    """
+
+    contacto_email: Optional[str] = None
+    """
+    Email address of the contact person.
+
+    > Correo Electronico de Contacto.
+
+    .. warning:: Value may be an invalid email address.
+
+    AEC doc XML element: 'DocumentoAEC//Caratula//MailContacto'
+
+    RPETC email: none.
+    """
+
+    @property
+    def _last_cesion(self) -> CesionAecXml:
+        return self.cesiones[-1]
+
+    @property
+    def seq(self) -> int:
+        """
+        Sequence number of the "cesión". Must be >= 1.
+
+        Value is not directly available from the XML element. It needs
+        to be extracted from the latest ``<Cesion>`` in 'DocumentoAEC//Cesiones'.
+
+        AEC doc XML element: no direct one.
+
+        RPETC email: attachment / 'Cesion' / 'Seq'
+        """
+        return self._last_cesion.seq
+
+    @property
+    def monto_cesion(self) -> int:
+        """
+        Amount of the "cesión".
+
+        Value is not directly available from the XML element. It needs
+        to be extracted from the latest ``<Cesion>`` in 'DocumentoAEC//Cesiones'.
+
+        AEC doc XML element: no direct one.
+
+        RPETC email: attachment / 'Cesion' / 'Monto Cedido'
+        """
+        return self._last_cesion.monto_cesion
+
+    @property
+    def fecha_cesion_dt(self) -> datetime:
+        return self._last_cesion.fecha_cesion_dt
+
+    @property
+    def fecha_ultimo_vencimiento(self) -> date:
+        return self._last_cesion.fecha_ultimo_vencimiento
+
+    @property
+    def cedente_razon_social(self) -> str:
+        return self._last_cesion.cedente_razon_social
+
+    @property
+    def cedente_direccion(self) -> str:
+        return self._last_cesion.cedente_direccion
+
+    @property
+    def cedente_email(self) -> str:
+        return self._last_cesion.cedente_email
+
+    @property
+    def cesionario_razon_social(self) -> str:
+        return self._last_cesion.cesionario_razon_social
+
+    @property
+    def cesionario_direccion(self) -> str:
+        return self._last_cesion.cesionario_direccion
+
+    @property
+    def cesionario_email(self) -> str:
+        return self._last_cesion.cesionario_email
+
+    @property
+    def dte_emisor_email(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def dte_receptor_email(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def dte_deudor_email(self) -> Optional[str]:
+        return self._last_cesion.dte_deudor_email
+
+    @property
+    def cedente_declaracion_jurada(self) -> Optional[str]:
+        return self._last_cesion.cedente_declaracion_jurada
+
+    @property
+    def natural_key(self) -> data_models.CesionNaturalKey:
+        return data_models.CesionNaturalKey(dte_key=self.dte.natural_key, seq=self.seq)
+
+    @property
+    def alt_natural_key(self) -> data_models.CesionAltNaturalKey:
+        return data_models.CesionAltNaturalKey(
+            dte_key=self.dte.natural_key,
+            cedente_rut=self.cedente_rut,
+            cesionario_rut=self.cesionario_rut,
+            fecha_cesion_dt=self.fecha_cesion_dt,
+        )
+
+    @property
+    def slug(self) -> str:
+        """
+        Return a slug representation (that preserves uniquess) of the instance.
+        """
+        # Note: Based on 'cl_sii.dte.data_models.DteNaturalKey.slug'.
+        return self.natural_key.slug
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    def as_dict(self) -> Mapping[str, object]:
+        return dataclasses.asdict(self)
+
+    def as_cesion_l2(self) -> data_models.CesionL2:
+        return data_models.CesionL2(
+            dte_key=self.dte.natural_key,
+            seq=self.seq,
+            cedente_rut=self.cedente_rut,
+            cesionario_rut=self.cesionario_rut,
+            fecha_cesion_dt=self.fecha_cesion_dt,
+            monto_cedido=self.monto_cesion,
+            fecha_firma_dt=self.fecha_firma_dt,
+            dte_receptor_rut=self.dte.receptor_rut,
+            dte_fecha_emision=self.dte.fecha_emision_date,
+            dte_monto_total=self.dte.monto_total,
+            fecha_ultimo_vencimiento=self.fecha_ultimo_vencimiento,
+            cedente_razon_social=self.cedente_razon_social,
+            cedente_email=self.cedente_email,
+            cesionario_razon_social=self.cesionario_razon_social,
+            cesionario_email=self.cesionario_email,
+            dte_emisor_razon_social=self.dte.emisor_razon_social,
+            # dte_emisor_email=None,
+            dte_receptor_razon_social=self.dte.receptor_razon_social,
+            # dte_receptor_email=None,
+            dte_deudor_email=self.dte_deudor_email,
+            cedente_declaracion_jurada=self.cedente_declaracion_jurada,
+            dte_fecha_vencimiento=self.dte.fecha_vencimiento_date,
+            contacto_nombre=self.contacto_nombre,
+            contacto_telefono=self.contacto_telefono,
+            contacto_email=self.contacto_email,
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    @pydantic.validator('dte')
+    def validate_dte_tipo_dte(cls, v: object) -> object:
+        if isinstance(v, dte_data_models.DteDataL0):
+            data_models.validate_cesion_dte_tipo_dte(v.tipo_dte)
+        return v
+
+    @pydantic.validator('fecha_firma_dt')
+    def validate_datetime_tz(cls, v: object) -> object:
+        if isinstance(v, datetime):
+            tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
+        return v
+
+    @pydantic.validator('cesiones')
+    def validate_cesiones_min_items(cls, v: object) -> object:
+        if isinstance(v, Sequence):
+            if len(v) < 1:
+                raise ValueError("must contain at least one item")
+        return v
+
+    @pydantic.validator('cesiones')
+    def validate_cesiones_seq_order(cls, v: object) -> object:
+        if isinstance(v, Sequence):
+            for idx, cesion in enumerate(v, start=1):
+                if cesion.seq != idx:
+                    raise ValueError("items must be ordered according to their 'seq'")
+        return v
+
+    @pydantic.validator('cesiones')
+    def validate_cesiones_monto_cesion_must_not_increase(cls, v: object) -> object:
+        if isinstance(v, Sequence):
+            if len(v) >= 2:
+                previous_cesion: Optional[CesionAecXml] = None
+                for cesion in v:
+                    if previous_cesion is not None:
+                        if not (cesion.monto_cesion <= previous_cesion.monto_cesion):
+                            raise ValueError(
+                                "items must have a 'monto_cesion'"
+                                " that does not exceed the previous item's 'monto_cesion'.",
+                            )
+                    previous_cesion = cesion
+
+        return v
+
+    @pydantic.root_validator(skip_on_failure=True)
+    def validate_dte_matches_cesiones_dtes(
+        cls, values: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        dte = values['dte']
+        cesiones = values['cesiones']
+
+        if isinstance(dte, dte_data_models.DteXmlData) and isinstance(cesiones, Sequence):
+            if cesiones:
+                dte_l1 = dte.as_dte_data_l1()
+
+                for cesion in cesiones:
+                    assert isinstance(cesion, CesionAecXml)
+                    if cesion.dte != dte_l1:
+                        raise ValueError(
+                            f"'dte' of {cesion.__class__.__name__} with {cesion.natural_key!r}"
+                            f" must match {dte_l1.__class__.__name__} with {dte_l1.natural_key}.",
+                        )
+
+        return values
+
+    @pydantic.root_validator(skip_on_failure=True)
+    def validate_last_cesion_matches_some_fields(
+        cls, values: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        field_validations: Sequence[Tuple[str, str]] = [
+            # (AecXml field, CesionAecXml field):
+            ('fecha_firma_dt', 'fecha_cesion_dt'),
+            ('cedente_rut', 'cedente_rut'),
+            ('cesionario_rut', 'cesionario_rut'),
+        ]
+
+        cesiones = values['cesiones']
+        if isinstance(cesiones, Sequence):
+            if cesiones:
+                last_cesion = cesiones[-1]
+
+                for self_field, last_cesion_field in field_validations:
+                    self_value = values.get(self_field)
+                    last_cesion_value = getattr(last_cesion, last_cesion_field)
+
+                    if self_value != last_cesion_value:
+                        raise ValueError(
+                            f"{last_cesion_field!r} of last 'cesion' must match {self_field!r}:"
+                            f" {last_cesion_value!r} != {self_value!r}.",
+                        )
+
+        return values
+
+    # @pydantic.root_validator
+    # def validate_signature_value_and_signature_x509_cert_der_may_only_be_none_together(
+    #     cls, values: Mapping[str, object],
+    # ) -> Mapping[str, object]:
+    #     signature_value = values.get('signature_value')
+    #     signature_x509_cert_der = values.get('signature_x509_cert_der')
+    #
+    #     if not (
+    #         (signature_value is None and signature_x509_cert_der is None)
+    #         or (signature_value is not None and signature_x509_cert_der is not None)
+    #     ):
+    #         raise TypeError(
+    #             "'signature_value' and 'signature_x509_cert_der'"
+    #             " must either both be None or both be not None."
+    #         )
+    #
+    #     return values

--- a/cl_sii/rtc/parse_aec.py
+++ b/cl_sii/rtc/parse_aec.py
@@ -1,0 +1,893 @@
+"""
+Helpers for parsing data from a "cesión"'s AEC XML doc.
+
+
+Usage:
+
+>>> from cl_sii.libs import xml_utils
+
+>>> aec_xml_file_path = '/dir/my_aec.xml'
+>>> with open(aec_xml_file_path, mode='rb') as f:
+...     xml_doc = xml_utils.parse_untrusted_xml(f.read())
+
+>>> validate_aec_xml(xml_doc)
+>>> aec_xml = parse_aec_xml(xml_doc)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from pathlib import Path
+from typing import Mapping, Optional, Sequence
+
+import pydantic
+
+import cl_sii.dte.data_models
+import cl_sii.dte.parse
+from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.data_models import DteXmlData
+from cl_sii.dte.parse import DTE_XMLNS_MAP
+from cl_sii.libs import crypto_utils, encoding_utils, tz_utils, xml_utils
+from cl_sii.libs.xml_utils import XmlElement
+from cl_sii.rut import Rut
+
+from . import data_models_aec
+
+
+logger = logging.getLogger(__name__)
+
+
+_AEC_XML_SCHEMA_PATH = Path(
+    Path(__file__).parent.parent,
+    Path('data/ref/factura_electronica/schemas-xml/AEC_v10.xsd'),
+).resolve()
+
+AEC_XML_SCHEMA_OBJ = xml_utils.read_xml_schema(str(_AEC_XML_SCHEMA_PATH))
+"""
+XML schema obj for AEC XML document validation.
+
+..seealso::
+    XML schema of ``{http://www.sii.cl/SiiDte}/AEC`` in
+    'data/ref/factura_electronica/schemas-xml/AEC_v10.xsd' (c7adc5a2)
+
+It is read from a file at import time to avoid unnecessary reads afterwards.
+"""
+
+
+###############################################################################
+# Main Functions
+###############################################################################
+
+def validate_aec_xml(xml_doc: XmlElement) -> None:
+    """
+    Validate ``xml_doc`` against AEC's XML schema.
+
+    :raises xml_utils.XmlSchemaDocValidationError:
+    """
+    # TODO: Add better and more precise exception handling.
+    xml_utils.validate_xml_doc(AEC_XML_SCHEMA_OBJ, xml_doc)
+
+
+def parse_aec_xml(xml_doc: XmlElement) -> data_models_aec.AecXml:
+    """
+    Parse data from a "cesión"'s AEC XML doc.
+
+    .. warning::
+        It is assumed that ``xml_doc`` is an ``{http://www.sii.cl/SiiDte}/AEC`` XML element.
+    """
+    aec_struct = _Aec.parse_xml(xml_doc)
+    return aec_struct.as_aec_xml()
+
+
+###############################################################################
+# Parser Functions and Models
+###############################################################################
+
+def _validate_rut(v: object) -> object:
+    """
+    Reusable Pydantic validator for fields of type :class:`Rut`.
+    """
+    if isinstance(v, str):
+        v = Rut(value=v, validate_dv=False)  # Raises ValueError if invalid.
+    return v
+
+
+class _XmlSignature(pydantic.BaseModel):
+    """
+    Parser for ``//Signature``.
+    """
+
+    class Config:
+        allow_mutation = False
+        anystr_strip_whitespace = True
+        extra = pydantic.Extra.forbid
+        min_anystr_length = 1
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    signature_value: bytes
+    key_info_x509_data_x509_cert: bytes
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: //Signature/KeyInfo
+        key_info_em = xml_em.find('ds:KeyInfo', namespaces=xml_utils.XML_DSIG_NS_MAP)
+
+        # XPath: //Signature/KeyInfo/X509Data
+        key_info_x509_data_em = (
+            key_info_em.find('ds:X509Data', namespaces=xml_utils.XML_DSIG_NS_MAP)
+        )
+
+        # XPath: //Signature
+        return dict(
+            # XPath: //Signature/SignatureValue
+            signature_value=xml_em.findtext(
+                'ds:SignatureValue',
+                namespaces=xml_utils.XML_DSIG_NS_MAP,
+            ),
+
+            # XPath: //Signature/KeyInfo/X509Data/X509Certificate
+            key_info_x509_data_x509_cert=key_info_x509_data_em.findtext(
+                'ds:X509Certificate',
+                namespaces=xml_utils.XML_DSIG_NS_MAP,
+            ),
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    @pydantic.validator(
+        'signature_value',
+        'key_info_x509_data_x509_cert',
+        pre=True,
+    )
+    def validate_base64(cls, v: object) -> object:
+        if isinstance(v, (str, bytes)):
+            v = encoding_utils.decode_base64_strict(v)  # Raises ValueError.
+        return v
+
+    @pydantic.validator('key_info_x509_data_x509_cert')
+    def validate_certificate_is_loadable(cls, v: object) -> object:
+        if isinstance(v, bytes):
+            _ = crypto_utils.load_der_x509_cert(v)  # Raises ValueError.
+        return v
+
+
+class _Cesionario(pydantic.BaseModel):
+    """
+    Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cesionario``.
+    """
+
+    class Config:
+        allow_mutation = False
+        anystr_strip_whitespace = True
+        arbitrary_types_allowed = True
+        extra = pydantic.Extra.forbid
+        min_anystr_length = 1
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    rut: Rut
+    razon_social: str
+    direccion: str
+    email: str
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cesionario
+        return dict(
+            rut=xml_em.findtext('sii-dte:RUT', namespaces=DTE_XMLNS_MAP),
+            razon_social=xml_em.findtext('sii-dte:RazonSocial', namespaces=DTE_XMLNS_MAP),
+            direccion=xml_em.findtext('sii-dte:Direccion', namespaces=DTE_XMLNS_MAP),
+            email=xml_em.findtext('sii-dte:eMail', namespaces=DTE_XMLNS_MAP),
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    _validate_rut = pydantic.validator(  # type: ignore[pydantic-field]
+        'rut', pre=True, allow_reuse=True,
+    )(_validate_rut)
+
+
+class _RutAutorizado(pydantic.BaseModel):
+    """
+    Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cedente/RUTAutorizado``.
+    """
+
+    class Config:
+        allow_mutation = False
+        anystr_strip_whitespace = True
+        arbitrary_types_allowed = True
+        extra = pydantic.Extra.forbid
+        min_anystr_length = 1
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    rut: Rut
+    nombre: str
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cedente/RUTAutorizado
+        return dict(
+            rut=xml_em.findtext('sii-dte:RUT', namespaces=DTE_XMLNS_MAP),
+            nombre=xml_em.findtext('sii-dte:Nombre', namespaces=DTE_XMLNS_MAP),
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    _validate_rut = pydantic.validator(  # type: ignore[pydantic-field]
+        'rut', pre=True, allow_reuse=True,
+    )(_validate_rut)
+
+
+class _Cedente(pydantic.BaseModel):
+    """
+    Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cedente``.
+    """
+
+    class Config:
+        allow_mutation = False
+        anystr_strip_whitespace = True
+        arbitrary_types_allowed = True
+        extra = pydantic.Extra.forbid
+        min_anystr_length = 1
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    rut: Rut
+    razon_social: str
+    direccion: str
+    email: str
+    ruts_autorizados: Sequence[_RutAutorizado]  # 1..3 occurrences
+    declaracion_jurada: Optional[str]
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cedente/RUTAutorizado
+        cedente_personas_autorizadas_em = xml_em.findall(
+            'sii-dte:RUTAutorizado',
+            namespaces=DTE_XMLNS_MAP,
+        )
+        cedente_persona_autorizada_dict_list = [
+            _RutAutorizado.parse_xml_to_dict(cedente_persona_autorizada)
+            for cedente_persona_autorizada in cedente_personas_autorizadas_em
+        ]
+
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cedente
+        return dict(
+            rut=xml_em.findtext('sii-dte:RUT', namespaces=DTE_XMLNS_MAP),
+            razon_social=xml_em.findtext('sii-dte:RazonSocial', namespaces=DTE_XMLNS_MAP),
+            direccion=xml_em.findtext('sii-dte:Direccion', namespaces=DTE_XMLNS_MAP),
+            email=xml_em.findtext('sii-dte:eMail', namespaces=DTE_XMLNS_MAP),
+            declaracion_jurada=xml_em.findtext(
+                'sii-dte:DeclaracionJurada',
+                namespaces=DTE_XMLNS_MAP,
+            ) or None,
+            ruts_autorizados=cedente_persona_autorizada_dict_list,
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    @pydantic.validator('rut', pre=True)
+    def validate_rut(cls, v: object) -> object:
+        if isinstance(v, str):
+            v = Rut(value=v, validate_dv=False)  # Raises ValueError if invalid.
+        return v
+
+    @pydantic.validator('ruts_autorizados')
+    def validate_ruts_autorizados_item_count(cls, v: object) -> object:
+        if isinstance(v, Sequence):
+            if len(v) < 1:
+                raise ValueError("must contain at least one item")
+            if len(v) > 3:
+                raise ValueError("must contain at most three items")
+        return v
+
+
+class _IdDte(pydantic.BaseModel):
+    """
+    Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/IdDTE``.
+    """
+
+    class Config:
+        allow_mutation = False
+        arbitrary_types_allowed = True
+        extra = pydantic.Extra.forbid
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    rut_emisor: Rut
+    tipo_dte: TipoDteEnum
+    folio: int
+    fch_emis: date
+    rut_receptor: Rut
+    mnt_total: int
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/IdDTE
+        return dict(
+            rut_emisor=xml_em.findtext('sii-dte:RUTEmisor', namespaces=DTE_XMLNS_MAP),
+            tipo_dte=xml_em.findtext('sii-dte:TipoDTE', namespaces=DTE_XMLNS_MAP),
+            folio=xml_em.findtext('sii-dte:Folio', namespaces=DTE_XMLNS_MAP),
+            fch_emis=xml_em.findtext('sii-dte:FchEmis', namespaces=DTE_XMLNS_MAP),
+            rut_receptor=xml_em.findtext('sii-dte:RUTReceptor', namespaces=DTE_XMLNS_MAP),
+            mnt_total=xml_em.findtext('sii-dte:MntTotal', namespaces=DTE_XMLNS_MAP),
+        )
+
+    def as_dte_data_l1(self) -> cl_sii.dte.data_models.DteDataL1:
+        return cl_sii.dte.data_models.DteDataL1(
+            emisor_rut=self.rut_emisor,
+            tipo_dte=self.tipo_dte,
+            folio=self.folio,
+            fecha_emision_date=self.fch_emis,
+            receptor_rut=self.rut_receptor,
+            monto_total=self.mnt_total,
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    _validate_rut_emisor = pydantic.validator(  # type: ignore[pydantic-field]
+        'rut_emisor', pre=True, allow_reuse=True,
+    )(_validate_rut)
+
+    _validate_rut_receptor = pydantic.validator(  # type: ignore[pydantic-field]
+        'rut_receptor', pre=True, allow_reuse=True,
+    )(_validate_rut)
+
+    @pydantic.validator('tipo_dte', pre=True)
+    def validate_tipo_dte(cls, v: object) -> object:
+        if isinstance(v, int):
+            v = TipoDteEnum(v)  # Raises ValueError if invalid.
+        return v
+
+
+class _DocumentoCesion(pydantic.BaseModel):
+    """
+    Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion``.
+    """
+
+    class Config:
+        allow_mutation = False
+        anystr_strip_whitespace = True
+        extra = pydantic.Extra.forbid
+        min_anystr_length = 1
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    # id: str
+    """
+    This value seems to be worthless (only useful for internal references in the XML doc).
+    e.g. 'CES7393a78afa6c4f709ee9e9e943cb50a3', 'HEF_CESION_T33F170_SEQ2'
+    """
+
+    seq_cesion: int
+    id_dte: _IdDte
+    cedente: _Cedente
+    cesionario: _Cesionario
+    monto_cesion: int
+    ultimo_vencimiento: date
+    tmst_cesion: datetime
+    email_deudor: Optional[str]
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/IdDTE
+        id_dte_em = xml_em.find('sii-dte:IdDTE', namespaces=DTE_XMLNS_MAP)
+        id_dte_dict = _IdDte.parse_xml_to_dict(id_dte_em)
+
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cedente
+        cedente_em = xml_em.find('sii-dte:Cedente', namespaces=DTE_XMLNS_MAP)
+        cedente_dict = _Cedente.parse_xml_to_dict(cedente_em)
+
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion/Cesionario
+        cesionario_em = xml_em.find('sii-dte:Cesionario', namespaces=DTE_XMLNS_MAP)
+        cesionario_dict = _Cesionario.parse_xml_to_dict(cesionario_em)
+
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion
+        return dict(
+            # id=xml_em.get('ID'),
+            seq_cesion=xml_em.findtext('sii-dte:SeqCesion', namespaces=DTE_XMLNS_MAP),
+            id_dte=id_dte_dict,
+            cedente=cedente_dict,
+            cesionario=cesionario_dict,
+            monto_cesion=xml_em.findtext('sii-dte:MontoCesion', namespaces=DTE_XMLNS_MAP),
+            ultimo_vencimiento=xml_em.findtext(
+                'sii-dte:UltimoVencimiento',
+                namespaces=DTE_XMLNS_MAP,
+            ),
+            tmst_cesion=xml_em.findtext('sii-dte:TmstCesion', namespaces=DTE_XMLNS_MAP),
+            email_deudor=xml_em.findtext('sii-dte:eMailDeudor', namespaces=DTE_XMLNS_MAP) or None,
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    @pydantic.validator('tmst_cesion')
+    def validate_datetime(cls, v: object) -> object:
+        if isinstance(v, str):
+            v = datetime.fromisoformat(v)
+
+        if isinstance(v, datetime):
+            v = tz_utils.convert_naive_dt_to_tz_aware(
+                dt=v,
+                tz=data_models_aec.CesionAecXml.DATETIME_FIELDS_TZ,
+            )
+        return v
+
+
+class _Cesion(pydantic.BaseModel):
+    """
+    Parser for ``/AEC/DocumentoAEC/Cesiones/Cesion``.
+    """
+
+    class Config:
+        allow_mutation = False
+        extra = pydantic.Extra.forbid
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    documento_cesion: _DocumentoCesion
+    # signature: _XmlSignature
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/DocumentoCesion
+        doc_cesion_em = xml_em.find('sii-dte:DocumentoCesion', namespaces=DTE_XMLNS_MAP)
+        doc_cesion_dict = _DocumentoCesion.parse_xml_to_dict(doc_cesion_em)
+
+        # Signature over 'DocumentoCesion'
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion/Signature
+        # signature_over_doc_cesion_em = xml_em.find(
+        #     'ds:Signature',
+        #     namespaces=xml_utils.XML_DSIG_NS_MAP,
+        # )
+        # signature_over_doc_cesion_dict = _XmlSignature.parse_xml_to_dict(
+        #     signature_over_doc_cesion_em,
+        # )
+
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion
+        return dict(
+            documento_cesion=doc_cesion_dict,
+            # signature=signature_over_doc_cesion_dict,
+        )
+
+    def as_cesion_aec_xml(self) -> data_models_aec.CesionAecXml:
+        doc_cesion_struct = self.documento_cesion
+        # signature_over_doc_cesion_struct = self.signature  # noqa: F841
+        cesion_dte_struct = doc_cesion_struct.id_dte.as_dte_data_l1()
+        cedente_persona_autorizada_struct_first = doc_cesion_struct.cedente.ruts_autorizados[0]
+
+        return data_models_aec.CesionAecXml(
+            dte=cesion_dte_struct,
+            seq=doc_cesion_struct.seq_cesion,
+            cedente_rut=doc_cesion_struct.cedente.rut,
+            cesionario_rut=doc_cesion_struct.cesionario.rut,
+            monto_cesion=doc_cesion_struct.monto_cesion,
+            fecha_cesion_dt=doc_cesion_struct.tmst_cesion,
+            fecha_ultimo_vencimiento=doc_cesion_struct.ultimo_vencimiento,
+            cedente_razon_social=doc_cesion_struct.cedente.razon_social,
+            cedente_direccion=doc_cesion_struct.cedente.direccion,
+            cedente_email=doc_cesion_struct.cedente.email,
+            cedente_persona_autorizada_rut=cedente_persona_autorizada_struct_first.rut,
+            cedente_persona_autorizada_nombre=cedente_persona_autorizada_struct_first.nombre,
+            cesionario_razon_social=doc_cesion_struct.cesionario.razon_social,
+            cesionario_direccion=doc_cesion_struct.cesionario.direccion,
+            cesionario_email=doc_cesion_struct.cesionario.email,
+            dte_deudor_email=doc_cesion_struct.email_deudor,
+            cedente_declaracion_jurada=doc_cesion_struct.cedente.declaracion_jurada,
+            # signature_value=signature_over_doc_cesion_struct.signature_value,
+            # signature_x509_cert_der=signature_over_doc_cesion_struct.key_info_x509_data_x509_cert,
+        )
+
+
+class _DocumentoDteCedido(pydantic.BaseModel):
+    """
+    Parser for ``/AEC/DocumentoAEC/Cesiones/DTECedido/DocumentoDTECedido``.
+    """
+
+    class Config:
+        allow_mutation = False
+        arbitrary_types_allowed = True
+        extra = pydantic.Extra.forbid
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    # id: str
+    """
+    This value seems to be worthless (only useful for internal references in the XML doc).
+      e.g. 'DTE6e0d95997db9489aa4cdd768a45852f6', 'DTE5716484782d745b6822257822a3536d1'
+    """
+
+    dte: DteXmlData
+    # tmst_firma: datetime
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: /AEC/DocumentoAEC/Cesiones/DTECedido/DocumentoDTECedido/DTE
+        dte_em = xml_em.find('sii-dte:DTE', namespaces=DTE_XMLNS_MAP)
+
+        # XPath: /AEC/DocumentoAEC/Cesiones/DTECedido/DocumentoDTECedido
+        return dict(
+            # id=xml_em.get('ID'),
+            dte=dte_em,
+            # tmst_firma=xml_em.findtext('sii-dte:TmstFirma', namespaces=DTE_XMLNS_MAP),
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    @pydantic.validator('dte', pre=True)
+    def validate_dte(cls, v: object) -> object:
+        if isinstance(v, XmlElement):
+            cl_sii.dte.parse.validate_dte_xml(v)
+            v = cl_sii.dte.parse.parse_dte_xml(v)
+        return v
+
+    # @pydantic.validator('tmst_firma')
+    # def validate_datetime(cls, v: object) -> object:
+    #     if isinstance(v, str):
+    #         v = datetime.fromisoformat(v)
+    #
+    #     if isinstance(v, datetime):
+    #         v = tz_utils.convert_naive_dt_to_tz_aware(
+    #             dt=v,
+    #             tz=data_models_aec.AecXml.DATETIME_FIELDS_TZ,
+    #         )
+    #     return v
+
+
+class _DteCedido(pydantic.BaseModel):
+    """
+    Parser for ``/AEC/DocumentoAEC/Cesiones/DTECedido``.
+    """
+
+    class Config:
+        allow_mutation = False
+        extra = pydantic.Extra.forbid
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    documento_dte_cedido: _DocumentoDteCedido
+    # signature: _XmlSignature
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: /AEC/DocumentoAEC/Cesiones/DTECedido/DocumentoDTECedido
+        doc_dte_cedido_em = xml_em.find(
+            'sii-dte:DocumentoDTECedido',
+            namespaces=DTE_XMLNS_MAP,
+        )
+
+        # Signature over 'DocumentoDTECedido'
+        # XPath: /AEC/DocumentoAEC/Cesiones/DTECedido/Signature
+        # signature_over_doc_dte_cedido_em = xml_em.find(
+        #     'ds:Signature',
+        #     namespaces=xml_utils.XML_DSIG_NS_MAP,
+        # )
+        # signature_over_doc_dte_cedido_dict = _XmlSignature.parse_xml_to_dict(
+        #     signature_over_doc_dte_cedido_em,
+        # )
+
+        # XPath: /AEC/DocumentoAEC/Cesiones/DTECedido/DocumentoDTECedido
+        doc_dte_cedido_dict = _DocumentoDteCedido.parse_xml_to_dict(doc_dte_cedido_em)
+
+        # XPath: /AEC/DocumentoAEC/Cesiones/DTECedido
+        return dict(
+            documento_dte_cedido=doc_dte_cedido_dict,
+            # signature=signature_over_doc_dte_cedido_dict,
+        )
+
+
+class _Caratula(pydantic.BaseModel):
+    """
+    Parser for ``/AEC/DocumentoAEC/Caratula``.
+    """
+
+    class Config:
+        allow_mutation = False
+        anystr_strip_whitespace = True
+        arbitrary_types_allowed = True
+        extra = pydantic.Extra.forbid
+        min_anystr_length = 1
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    rut_cedente: Rut
+    rut_cesionario: Rut
+    nmb_contacto: Optional[str]
+    fono_contacto: Optional[str]
+    mail_contacto: Optional[str]
+    tmst_firmaenvio: datetime
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: /AEC/DocumentoAEC/Caratula
+        return dict(
+            rut_cedente=xml_em.findtext('sii-dte:RutCedente', namespaces=DTE_XMLNS_MAP),
+            rut_cesionario=xml_em.findtext('sii-dte:RutCesionario', namespaces=DTE_XMLNS_MAP),
+            nmb_contacto=xml_em.findtext('sii-dte:NmbContacto', namespaces=DTE_XMLNS_MAP) or None,
+            fono_contacto=xml_em.findtext('sii-dte:FonoContacto', namespaces=DTE_XMLNS_MAP) or None,
+            mail_contacto=xml_em.findtext('sii-dte:MailContacto', namespaces=DTE_XMLNS_MAP) or None,
+            tmst_firmaenvio=xml_em.findtext('sii-dte:TmstFirmaEnvio', namespaces=DTE_XMLNS_MAP),
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    _validate_rut_cedente = pydantic.validator(  # type: ignore[pydantic-field]
+        'rut_cedente', pre=True, allow_reuse=True,
+    )(_validate_rut)
+
+    _validate_rut_cesionario = pydantic.validator(  # type: ignore[pydantic-field]
+        'rut_cesionario', pre=True, allow_reuse=True,
+    )(_validate_rut)
+
+    @pydantic.validator('tmst_firmaenvio')
+    def validate_datetime(cls, v: object) -> object:
+        if isinstance(v, str):
+            v = datetime.fromisoformat(v)
+
+        if isinstance(v, datetime):
+            v = tz_utils.convert_naive_dt_to_tz_aware(
+                dt=v,
+                tz=data_models_aec.AecXml.DATETIME_FIELDS_TZ,
+            )
+        return v
+
+
+class _DocumentoAec(pydantic.BaseModel):
+    """
+    Parser for ``/AEC/DocumentoAEC``.
+    """
+
+    class Config:
+        allow_mutation = False
+        extra = pydantic.Extra.forbid
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    # id: str
+    """
+    This value seems to be worthless (only useful for internal references in the XML doc).
+      e.g. 'HEF_AEC_T33F170_SEQ2', 'AEC1589423e81824cdcbfd2f0f4496f2dfb'
+    """
+
+    caratula: _Caratula
+    cesiones_dte_cedido: _DteCedido
+    cesiones_cesion: Sequence[_Cesion]
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @staticmethod
+    def parse_xml_to_dict(xml_em: XmlElement) -> Mapping[str, object]:
+        """
+        Parse XML element and return a dictionary.
+        """
+        # XPath: /AEC/DocumentoAEC/Caratula
+        caratula_em = xml_em.find('sii-dte:Caratula', namespaces=DTE_XMLNS_MAP)
+        caratula_dict = _Caratula.parse_xml_to_dict(caratula_em)
+
+        # XPath: /AEC/DocumentoAEC/Cesiones
+        cesiones_em = xml_em.find('sii-dte:Cesiones', namespaces=DTE_XMLNS_MAP)
+
+        # XPath: /AEC/DocumentoAEC/Cesiones/DTECedido
+        dte_cedido_em = cesiones_em.find('sii-dte:DTECedido', namespaces=DTE_XMLNS_MAP)
+        dte_cedido_dict = _DteCedido.parse_xml_to_dict(dte_cedido_em)
+
+        # XPath: /AEC/DocumentoAEC/Cesiones/Cesion
+        cesion_em_list: Sequence[XmlElement] = cesiones_em.findall(
+            'sii-dte:Cesion',
+            namespaces=DTE_XMLNS_MAP,
+        )
+        cesion_dict_list: Sequence[Mapping[str, object]]
+        cesion_dict_list = [
+            _Cesion.parse_xml_to_dict(cesion_em)
+            for cesion_em in cesion_em_list
+        ]
+
+        # XPath: /AEC/DocumentoAEC
+        return dict(
+            # id=xml_em.get('ID'),
+            caratula=caratula_dict,
+            cesiones_dte_cedido=dte_cedido_dict,
+            cesiones_cesion=cesion_dict_list,
+        )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    @pydantic.validator('cesiones_cesion')
+    def validate_cesiones_cesion_min_items(cls, v: object) -> object:
+        if isinstance(v, Sequence):
+            if len(v) < 1:
+                raise ValueError("must contain at least one item")
+        return v
+
+
+class _Aec(pydantic.BaseModel):
+    """
+    Parser for ``/AEC``.
+    """
+
+    class Config:
+        allow_mutation = False
+        extra = pydantic.Extra.forbid
+
+    ###########################################################################
+    # Fields
+    ###########################################################################
+
+    documento_aec: _DocumentoAec
+    # signature: _XmlSignature
+
+    ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    @classmethod
+    def parse_xml(cls, xml_doc: XmlElement) -> _Aec:
+        aec_dict = cls.parse_xml_to_dict(xml_doc)
+        return cls.parse_obj(aec_dict)
+
+    def as_aec_xml(self) -> data_models_aec.AecXml:
+        doc_aec_struct = self.documento_aec
+        # signature_over_doc_aec_struct = self.signature  # noqa: F841
+
+        caratula_struct = doc_aec_struct.caratula
+        dte = doc_aec_struct.cesiones_dte_cedido.documento_dte_cedido.dte
+        cesion_struct_list = doc_aec_struct.cesiones_cesion
+
+        aec_xml_cesion_list: Sequence[data_models_aec.CesionAecXml]
+        aec_xml_cesion_list = [
+            cesion_struct.as_cesion_aec_xml()
+            for cesion_struct in cesion_struct_list
+        ]
+
+        return data_models_aec.AecXml(
+            dte=dte,
+            cedente_rut=caratula_struct.rut_cedente,
+            cesionario_rut=caratula_struct.rut_cesionario,
+            fecha_firma_dt=caratula_struct.tmst_firmaenvio,
+            # signature_value=signature_over_doc_aec_struct.signature_value,
+            # signature_x509_cert_der=signature_over_doc_aec_struct.key_info_x509_data_x509_cert,
+            cesiones=aec_xml_cesion_list,
+            contacto_nombre=caratula_struct.nmb_contacto,
+            contacto_telefono=caratula_struct.fono_contacto,
+            contacto_email=caratula_struct.mail_contacto,
+        )
+
+    @staticmethod
+    def parse_xml_to_dict(xml_doc: XmlElement) -> Mapping[str, object]:
+        """
+        Parse data from a "cesión"'s AEC XML doc and return a dictionary.
+        """
+        # XPath: /AEC
+        aec_em = xml_doc
+
+        # XPath: /AEC/DocumentoAEC
+        doc_aec_em = aec_em.find('sii-dte:DocumentoAEC', namespaces=DTE_XMLNS_MAP)
+        doc_aec_dict = _DocumentoAec.parse_xml_to_dict(doc_aec_em)
+
+        # Signature over 'DocumentoAEC'
+        # XPath: /AEC/Signature
+        # signature_over_doc_aec_em = aec_em.find(
+        #     'ds:Signature',
+        #     namespaces=xml_utils.XML_DSIG_NS_MAP,
+        # )
+        # signature_over_doc_aec_dict = _XmlSignature.parse_xml_to_dict(signature_over_doc_aec_em)
+
+        # XPath: /AEC
+        return dict(
+            documento_aec=doc_aec_dict,
+            # signature=signature_over_doc_aec_dict,
+        )

--- a/tests/test_rtc_data_models_aec.py
+++ b/tests/test_rtc_data_models_aec.py
@@ -1,0 +1,644 @@
+from __future__ import annotations
+
+import dataclasses
+import unittest
+from datetime import date, datetime
+
+import pydantic
+
+from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.data_models import DteDataL1, DteNaturalKey, DteXmlData
+from cl_sii.libs import encoding_utils
+from cl_sii.libs import tz_utils
+from cl_sii.rtc.data_models import CesionL2, CesionNaturalKey, CesionAltNaturalKey
+from cl_sii.rtc.data_models_aec import CesionAecXml, AecXml
+from cl_sii.rut import Rut
+
+from .utils import read_test_file_bytes
+
+
+class CesionAecXmlTest(unittest.TestCase):
+    """
+    Tests for :class:`CesionAecXml`.
+    """
+
+    def _set_obj_1(self) -> None:
+        obj = CesionAecXml(
+            dte=DteDataL1(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+                fecha_emision_date=date(2019, 4, 1),
+                receptor_rut=Rut('96790240-3'),
+                monto_total=2996301,
+            ),
+            seq=1,
+            cedente_rut=Rut('76354771-K'),
+            cesionario_rut=Rut('76389992-6'),
+            monto_cesion=2996301,
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 1, 10, 22, 2),
+                tz=CesionAecXml.DATETIME_FIELDS_TZ,
+            ),
+            fecha_ultimo_vencimiento=date(2019, 5, 1),
+            cedente_razon_social='SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA LIMITADA',
+            cedente_direccion='MERCED 753  16 ARBOLEDA DE QUIILOTA',
+            cedente_email='enaconltda@gmail.com',
+            cedente_persona_autorizada_rut=Rut('76354771-K'),
+            cedente_persona_autorizada_nombre='SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA LIM',
+            cesionario_razon_social='ST CAPITAL S.A.',
+            cesionario_direccion='Isidora Goyenechea 2939 Oficina 602',
+            cesionario_email='fynpal-app-notif-st-capital@fynpal.com',
+            dte_deudor_email=None,
+            cedente_declaracion_jurada=(
+                'Se declara bajo juramento que SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA '
+                'LIMITADA, RUT 76354771-K ha puesto a disposición del cesionario ST '
+                'CAPITAL S.A., RUT 76389992-6, el o los documentos donde constan los '
+                'recibos de las mercaderías entregadas o servicios prestados, entregados '
+                'por parte del deudor de la factura MINERA LOS PELAMBRES, RUT 96790240-3, '
+                'deacuerdo a lo establecido en la Ley N°19.983.'
+            ),
+        )
+        self.assertIsInstance(obj, CesionAecXml)
+
+        self.obj_1 = obj
+
+    def _set_obj_2(self) -> None:
+        obj = CesionAecXml(
+            dte=DteDataL1(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+                fecha_emision_date=date(2019, 4, 1),
+                receptor_rut=Rut('96790240-3'),
+                monto_total=2996301,
+            ),
+            seq=2,
+            cedente_rut=Rut('76389992-6'),
+            cesionario_rut=Rut('76598556-0'),
+            monto_cesion=2996301,
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 5, 12, 57, 32),
+                tz=CesionAecXml.DATETIME_FIELDS_TZ,
+            ),
+            fecha_ultimo_vencimiento=date(2019, 5, 1),
+            cedente_razon_social='ST CAPITAL S.A.',
+            cedente_direccion='Isidora Goyenechea 2939 Oficina 602',
+            cedente_email='APrat@Financiaenlinea.com',
+            cedente_persona_autorizada_rut=Rut('16360379-9'),
+            cedente_persona_autorizada_nombre='ANDRES  PRATS VIAL',
+            cesionario_razon_social='Fondo de Inversión Privado Deuda y Facturas',
+            cesionario_direccion='Arrayan 2750 Oficina 703 Providencia',
+            cesionario_email='solicitudes@stcapital.cl',
+            dte_deudor_email=None,
+            cedente_declaracion_jurada=(
+                'Se declara bajo juramento que ST CAPITAL S.A., RUT 76389992-6 ha puesto '
+                'a disposicion del cesionario Fondo de Inversión Privado Deuda y Facturas, '
+                'RUT 76598556-0, el documento validamente emitido al deudor MINERA LOS '
+                'PELAMBRES, RUT 96790240-3.'
+            ),
+        )
+        self.assertIsInstance(obj, CesionAecXml)
+
+        self.obj_2 = obj
+
+    def test_create_new_empty_instance(self) -> None:
+        with self.assertRaises(TypeError):
+            CesionAecXml()
+
+    def test_natural_key(self) -> None:
+        self._set_obj_1()
+        self._set_obj_2()
+
+        obj = self.obj_1
+        expected_output = CesionNaturalKey(
+            dte_key=DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ),
+            seq=1,
+        )
+        self.assertEqual(obj.natural_key, expected_output)
+
+        obj = self.obj_2
+        expected_output = CesionNaturalKey(
+            dte_key=DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ),
+            seq=2,
+        )
+        self.assertEqual(obj.natural_key, expected_output)
+
+    def test_alt_natural_key(self) -> None:
+        self._set_obj_1()
+        self._set_obj_2()
+
+        obj = self.obj_1
+        expected_output = CesionAltNaturalKey(
+            dte_key=DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ),
+            cedente_rut=Rut('76354771-K'),
+            cesionario_rut=Rut('76389992-6'),
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 1, 10, 22),
+                tz=CesionAltNaturalKey.DATETIME_FIELDS_TZ,
+            ),
+        )
+        self.assertEqual(obj.alt_natural_key, expected_output)
+
+        obj = self.obj_2
+        expected_output = CesionAltNaturalKey(
+            dte_key=DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ),
+            cedente_rut=Rut('76389992-6'),
+            cesionario_rut=Rut('76598556-0'),
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 5, 12, 57),
+                tz=CesionAltNaturalKey.DATETIME_FIELDS_TZ,
+            ),
+        )
+        self.assertEqual(obj.alt_natural_key, expected_output)
+
+
+class AecXmlTest(unittest.TestCase):
+    """
+    Tests for :class:`AecXml`.
+    """
+
+    def _set_obj_1(self) -> None:
+        obj_dte_signature_value = encoding_utils.decode_base64_strict(
+            read_test_file_bytes(
+                'test_data/sii-crypto/DTE--76354771-K--33--170-signature-value-base64.txt',
+            ),
+        )
+        obj_dte_signature_x509_cert_der = read_test_file_bytes(
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der',
+        )
+        obj_dte = DteXmlData(
+            emisor_rut=Rut('76354771-K'),
+            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            folio=170,
+            fecha_emision_date=date(2019, 4, 1),
+            receptor_rut=Rut('96790240-3'),
+            monto_total=2996301,
+            emisor_razon_social='INGENIERIA ENACON SPA',
+            receptor_razon_social='MINERA LOS PELAMBRES',
+            fecha_vencimiento_date=None,
+            firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 1, 1, 36, 40),
+                tz=DteXmlData.DATETIME_FIELDS_TZ,
+            ),
+            signature_value=obj_dte_signature_value,
+            signature_x509_cert_der=obj_dte_signature_x509_cert_der,
+            emisor_giro='Ingenieria y Construccion',
+            emisor_email='ENACONLTDA@GMAIL.COM',
+            receptor_email=None,
+        )
+
+        obj_cesion_1 = CesionAecXml(
+            dte=DteDataL1(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+                fecha_emision_date=date(2019, 4, 1),
+                receptor_rut=Rut('96790240-3'),
+                monto_total=2996301,
+            ),
+            seq=1,
+            cedente_rut=Rut('76354771-K'),
+            cesionario_rut=Rut('76389992-6'),
+            monto_cesion=2996301,
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 1, 10, 22, 2),
+                tz=CesionAecXml.DATETIME_FIELDS_TZ,
+            ),
+            fecha_ultimo_vencimiento=date(2019, 5, 1),
+            cedente_razon_social='SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA LIMITADA',
+            cedente_direccion='MERCED 753  16 ARBOLEDA DE QUIILOTA',
+            cedente_email='enaconltda@gmail.com',
+            cedente_persona_autorizada_rut=Rut('76354771-K'),
+            cedente_persona_autorizada_nombre='SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA LIM',
+            cesionario_razon_social='ST CAPITAL S.A.',
+            cesionario_direccion='Isidora Goyenechea 2939 Oficina 602',
+            cesionario_email='fynpal-app-notif-st-capital@fynpal.com',
+            dte_deudor_email=None,
+            cedente_declaracion_jurada=(
+                'Se declara bajo juramento que SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA '
+                'LIMITADA, RUT 76354771-K ha puesto a disposición del cesionario ST '
+                'CAPITAL S.A., RUT 76389992-6, el o los documentos donde constan los '
+                'recibos de las mercaderías entregadas o servicios prestados, entregados '
+                'por parte del deudor de la factura MINERA LOS PELAMBRES, RUT 96790240-3, '
+                'deacuerdo a lo establecido en la Ley N°19.983.'
+            ),
+        )
+
+        obj_cesion_2 = CesionAecXml(
+            dte=DteDataL1(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+                fecha_emision_date=date(2019, 4, 1),
+                receptor_rut=Rut('96790240-3'),
+                monto_total=2996301,
+            ),
+            seq=2,
+            cedente_rut=Rut('76389992-6'),
+            cesionario_rut=Rut('76598556-0'),
+            monto_cesion=2996301,
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 5, 12, 57, 32),
+                tz=CesionAecXml.DATETIME_FIELDS_TZ,
+            ),
+            fecha_ultimo_vencimiento=date(2019, 5, 1),
+            cedente_razon_social='ST CAPITAL S.A.',
+            cedente_direccion='Isidora Goyenechea 2939 Oficina 602',
+            cedente_email='APrat@Financiaenlinea.com',
+            cedente_persona_autorizada_rut=Rut('16360379-9'),
+            cedente_persona_autorizada_nombre='ANDRES  PRATS VIAL',
+            cesionario_razon_social='Fondo de Inversión Privado Deuda y Facturas',
+            cesionario_direccion='Arrayan 2750 Oficina 703 Providencia',
+            cesionario_email='solicitudes@stcapital.cl',
+            dte_deudor_email=None,
+            cedente_declaracion_jurada=(
+                'Se declara bajo juramento que ST CAPITAL S.A., RUT 76389992-6 ha puesto '
+                'a disposicion del cesionario Fondo de Inversión Privado Deuda y Facturas, '
+                'RUT 76598556-0, el documento validamente emitido al deudor MINERA LOS '
+                'PELAMBRES, RUT 96790240-3.'
+            ),
+        )
+
+        obj = AecXml(
+            dte=obj_dte,
+            cedente_rut=Rut('76389992-6'),
+            cesionario_rut=Rut('76598556-0'),
+            fecha_firma_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 5, 12, 57, 32),
+                tz=AecXml.DATETIME_FIELDS_TZ,
+            ),
+            # signature_value=None,
+            # signature_x509_cert_der=None,
+            cesiones=[
+                obj_cesion_1,
+                obj_cesion_2,
+            ],
+            contacto_nombre='ST Capital Servicios Financieros',
+            contacto_telefono=None,
+            contacto_email='APrat@Financiaenlinea.com',
+        )
+        self.assertIsInstance(obj, AecXml)
+
+        self.obj_1 = obj
+        self.obj_1_dte = obj_dte
+        self.obj_1_cesion_1 = obj_cesion_1
+        self.obj_1_cesion_2 = obj_cesion_2
+
+    def test_create_new_empty_instance(self) -> None:
+        with self.assertRaises(TypeError):
+            AecXml()
+
+    def test_natural_key(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+        expected_output = CesionNaturalKey(
+            dte_key=DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ),
+            seq=2,
+        )
+        self.assertEqual(obj.natural_key, expected_output)
+
+    def test_alt_natural_key(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+        expected_output = CesionAltNaturalKey(
+            dte_key=DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ),
+            cedente_rut=Rut('76389992-6'),
+            cesionario_rut=Rut('76598556-0'),
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 5, 12, 57),
+                tz=CesionAltNaturalKey.DATETIME_FIELDS_TZ,
+            ),
+        )
+        self.assertEqual(obj.alt_natural_key, expected_output)
+
+    def test_slug(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+        expected_output = '76354771-K--33--170--2'
+        self.assertEqual(obj.slug, expected_output)
+
+    def test_last_cesion(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+        obj_cesion_2 = self.obj_1_cesion_2
+        self.assertEqual(obj.cesiones[-1], obj_cesion_2)
+        self.assertEqual(obj._last_cesion, obj.cesiones[-1])
+
+    def test_as_cesion_l2(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+        expected_output = CesionL2(
+            dte_key=DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ),
+            seq=2,
+            cedente_rut=Rut('76389992-6'),
+            cesionario_rut=Rut('76598556-0'),
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 5, 12, 57, 32),
+                tz=CesionL2.DATETIME_FIELDS_TZ,
+            ),
+            monto_cedido=2996301,
+            fecha_firma_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 5, 12, 57, 32),
+                tz=CesionL2.DATETIME_FIELDS_TZ,
+            ),
+            dte_receptor_rut=Rut('96790240-3'),
+            dte_fecha_emision=date(2019, 4, 1),
+            dte_monto_total=2996301,
+            fecha_ultimo_vencimiento=date(2019, 5, 1),
+            cedente_razon_social='ST CAPITAL S.A.',
+            cedente_email='APrat@Financiaenlinea.com',
+            cesionario_razon_social='Fondo de Inversión Privado Deuda y Facturas',
+            cesionario_email='solicitudes@stcapital.cl',
+            dte_emisor_razon_social='INGENIERIA ENACON SPA',
+            dte_receptor_razon_social='MINERA LOS PELAMBRES',
+            dte_deudor_email=None,
+            cedente_declaracion_jurada=(
+                'Se declara bajo juramento que ST CAPITAL S.A., RUT 76389992-6 ha puesto '
+                'a disposicion del cesionario Fondo de Inversión Privado Deuda y Facturas, '
+                'RUT 76598556-0, el documento validamente emitido al deudor MINERA LOS '
+                'PELAMBRES, RUT 96790240-3.'
+            ),
+            dte_fecha_vencimiento=None,
+            contacto_nombre='ST Capital Servicios Financieros',
+            contacto_telefono=None,
+            contacto_email='APrat@Financiaenlinea.com',
+        )
+        obj_cesion_l2 = obj.as_cesion_l2()
+        self.assertEqual(obj_cesion_l2, expected_output)
+        self.assertEqual(obj_cesion_l2.natural_key, obj.natural_key)
+        self.assertEqual(obj_cesion_l2.alt_natural_key, obj.alt_natural_key)
+        self.assertEqual(obj_cesion_l2.dte_key, obj.dte.natural_key)
+
+    def test_validate_dte_tipo_dte(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+        expected_validation_errors = [
+            {
+                'loc': ('dte',),
+                'msg':
+                    """('Value is not "cedible".', <TipoDteEnum.NOTA_CREDITO_ELECTRONICA: 61>)""",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                obj,
+                dte=dataclasses.replace(
+                    obj.dte,
+                    tipo_dte=TipoDteEnum.NOTA_CREDITO_ELECTRONICA,
+                ),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_datetime_tz(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+
+        # Test TZ-awareness:
+
+        expected_validation_errors = [
+            {
+                'loc': ('fecha_firma_dt',),
+                'msg': 'Value must be a timezone-aware datetime object.',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                obj,
+                fecha_firma_dt=datetime(2019, 4, 5, 12, 57, 32),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+        # Test TZ-value:
+
+        expected_validation_errors = [
+            {
+                'loc': ('fecha_firma_dt',),
+                'msg':
+                    '('
+                    '''"Timezone of datetime value must be 'America/Santiago'.",'''
+                    ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
+                    ')',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                obj,
+                fecha_firma_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                    dt=datetime(2019, 4, 5, 12, 57, 32),
+                    tz=tz_utils.TZ_UTC,
+                ),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_cesiones_min_items(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+
+        expected_validation_errors = [
+            {
+                'loc': ('cesiones',),
+                'msg': 'must contain at least one item',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                obj,
+                cesiones=[],
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_cesiones_seq_order(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+
+        expected_validation_errors = [
+            {
+                'loc': ('cesiones',),
+                'msg': "items must be ordered according to their 'seq'",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                obj,
+                cesiones=list(reversed(obj.cesiones)),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_cesiones_monto_cesion_must_not_increase(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+
+        expected_validation_errors = [
+            {
+                'loc': ('cesiones',),
+                'msg':
+                    "items must have a 'monto_cesion'"
+                    " that does not exceed the previous item's 'monto_cesion'.",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                obj,
+                cesiones=[
+                    dataclasses.replace(
+                        obj.cesiones[0],
+                        monto_cesion=obj.cesiones[1].monto_cesion - 1,
+                    ),
+                    obj.cesiones[1],
+                ],
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_dte_matches_cesiones_dtes(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+
+        expected_validation_errors = [
+            {
+                'loc': ('__root__',),
+                'msg':
+                    "'dte' of CesionAecXml with CesionNaturalKey("
+                    "dte_key=DteNaturalKey("
+                    "emisor_rut=Rut('76354771-K'),"
+                    " tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>,"
+                    " folio=171),"
+                    " seq=1"
+                    ")"
+                    " must match DteDataL1 with DteNaturalKey("
+                    "emisor_rut=Rut('76354771-K'),"
+                    " tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>,"
+                    " folio=170"
+                    ").",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                obj,
+                cesiones=[
+                    dataclasses.replace(
+                        obj.cesiones[0],
+                        dte=dataclasses.replace(
+                            obj.cesiones[0].dte,
+                            folio=obj.cesiones[0].dte.folio + 1,
+                        ),
+                    ),
+                    obj.cesiones[1],
+                ],
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_last_cesion_matches_some_fields(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+
+        expected_validation_errors = [
+            {
+                'loc': ('__root__',),
+                'msg':
+                    "'fecha_cesion_dt' of last 'cesion' must match 'fecha_firma_dt':"
+                    " datetime.datetime("
+                    "2019, 4, 5, 12, 57, 32,"
+                    " tzinfo=<DstTzInfo 'America/Santiago' -03-1 day, 21:00:00 DST>"
+                    ")"
+                    " !="
+                    " datetime.datetime("
+                    "2019, 4, 5, 12, 0, 32,"
+                    " tzinfo=<DstTzInfo 'America/Santiago' -03-1 day, 21:00:00 DST>"
+                    ").",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                obj,
+                fecha_firma_dt=obj.fecha_firma_dt.replace(minute=0),  # Original minute is 57.
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)

--- a/tests/test_rtc_parse_aec.py
+++ b/tests/test_rtc_parse_aec.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import unittest
+from datetime import date, datetime
+
+from cl_sii.dte.data_models import DteDataL1, DteXmlData
+from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.parse import DTE_XMLNS
+from cl_sii.libs import encoding_utils
+from cl_sii.libs import tz_utils
+from cl_sii.libs import xml_utils
+from cl_sii.rut import Rut
+
+from cl_sii.rtc.data_models_aec import CesionAecXml, AecXml
+from cl_sii.rtc.parse_aec import AEC_XML_SCHEMA_OBJ, parse_aec_xml, validate_aec_xml
+
+from .utils import read_test_file_bytes
+
+
+class AecXmlSchemaTest(unittest.TestCase):
+    """
+    Tests for AEC XML schema.
+    """
+
+    @unittest.skip("TODO: Implement for 'AEC_XML_SCHEMA_OBJ'.")
+    def test_AEC_XML_SCHEMA_OBJ(self):
+        self.assertIsNotNone(AEC_XML_SCHEMA_OBJ)
+
+
+class AecXmlValidatorTest(unittest.TestCase):
+    """
+    Tests for :func:`validate_aec_xml`.
+    """
+
+    def _set_obj_1(self) -> None:
+        aec_xml_bytes: bytes = read_test_file_bytes(
+            'test_data/sii-rtc/AEC--76354771-K--33--170--SEQ-2.xml',
+        )
+
+        self.aec_1_xml_bytes = aec_xml_bytes
+
+    def _set_obj_2(self) -> None:
+        aec_xml_bytes: bytes = read_test_file_bytes(
+            'test_data/sii-rtc/AEC--76399752-9--33--25568--SEQ-1.xml',
+        )
+
+        self.aec_2_xml_bytes = aec_xml_bytes
+
+    def test_validate_aec_xml_ok_1(self) -> None:
+        self._set_obj_1()
+
+        aec_xml_bytes = self.aec_1_xml_bytes
+        xml_doc = xml_utils.parse_untrusted_xml(aec_xml_bytes)
+        try:
+            validate_aec_xml(xml_doc)
+        except xml_utils.XmlSchemaDocValidationError as exc:
+            self.fail(f'{exc.__class__.__name__} raised')
+
+        expected_xml_root_tag = '{%s}AEC' % DTE_XMLNS
+        self.assertEqual(xml_doc.getroottree().getroot().tag, expected_xml_root_tag)
+
+    def test_validate_aec_xml_ok_2(self) -> None:
+        self._set_obj_2()
+
+        aec_xml_bytes = self.aec_2_xml_bytes
+        xml_doc = xml_utils.parse_untrusted_xml(aec_xml_bytes)
+        try:
+            validate_aec_xml(xml_doc)
+        except xml_utils.XmlSchemaDocValidationError as exc:
+            self.fail(f'{exc.__class__.__name__} raised')
+
+        expected_xml_root_tag = '{%s}AEC' % DTE_XMLNS
+        self.assertEqual(xml_doc.getroottree().getroot().tag, expected_xml_root_tag)
+
+    @unittest.skip("TODO: Implement for 'validate_aec_xml'.")
+    def test_validate_aec_xml_fail(self) -> None:
+        self.assertIsNotNone(validate_aec_xml)
+
+
+class AecXmlParserTest(unittest.TestCase):
+    """
+    Tests for :func:`parse_aec_xml`.
+    """
+
+    def _set_obj_1(self) -> None:
+        aec_xml_bytes: bytes = read_test_file_bytes(
+            'test_data/sii-rtc/AEC--76354771-K--33--170--SEQ-2.xml',
+        )
+
+        # aec_signature_value: bytes = encoding_utils.decode_base64_strict('Not Implemented')
+
+        # aec_1_cert_der_bytes: bytes = read_test_file_bytes('test_data/Not-Implemented.der')
+
+        aec_dte_cert_der_bytes: bytes = read_test_file_bytes(
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der',
+        )
+
+        aec_dte_signature_value: bytes = encoding_utils.decode_base64_strict(
+            read_test_file_bytes(
+                'test_data/sii-crypto/DTE--76354771-K--33--170-signature-value-base64.txt',
+            ),
+        )
+
+        self.aec_1_xml_bytes = aec_xml_bytes
+        # self.aec_1_signature_value = aec_signature_value
+        # self.aec_1_cert_der_bytes = aec_cert_der_bytes
+        self.aec_1_dte_cert_der_bytes = aec_dte_cert_der_bytes
+        self.aec_1_dte_signature_value = aec_dte_signature_value
+
+    def _set_obj_2(self) -> None:
+        aec_xml_bytes: bytes = read_test_file_bytes(
+            'test_data/sii-rtc/AEC--76399752-9--33--25568--SEQ-1.xml',
+        )
+
+        # aec_signature_value: bytes = encoding_utils.decode_base64_strict('Not Implemented')
+
+        # aec_cert_der_bytes: bytes = read_test_file_bytes('test_data/Not-Implemented.der')
+
+        aec_dte_cert_der_bytes: bytes = read_test_file_bytes(
+            'test_data/sii-crypto/DTE--76399752-9--33--25568-cert.der',
+        )
+
+        aec_dte_signature_value: bytes = encoding_utils.decode_base64_strict(
+            read_test_file_bytes(
+                'test_data/sii-crypto/DTE--76399752-9--33--25568-signature-value-base64.txt',
+            ),
+        )
+
+        self.aec_2_xml_bytes = aec_xml_bytes
+        # self.aec_2_signature_value = aec_signature_value
+        # self.aec_2_cert_der_bytes = aec_cert_der_bytes
+        self.aec_2_dte_cert_der_bytes = aec_dte_cert_der_bytes
+        self.aec_2_dte_signature_value = aec_dte_signature_value
+
+    def test_parse_aec_xml_ok_1(self) -> None:
+        self._set_obj_1()
+
+        aec_xml_bytes = self.aec_1_xml_bytes
+        aec_dte_signature_value = self.aec_1_dte_signature_value
+        aec_dte_cert_der_bytes = self.aec_1_dte_cert_der_bytes
+        expected_output = AecXml(
+            dte=DteXmlData(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+                fecha_emision_date=date(2019, 4, 1),
+                receptor_rut=Rut('96790240-3'),
+                monto_total=2996301,
+                emisor_razon_social='INGENIERIA ENACON SPA',
+                receptor_razon_social='MINERA LOS PELAMBRES',
+                fecha_vencimiento_date=None,
+                firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                    dt=datetime(2019, 4, 1, 1, 36, 40),
+                    tz=DteXmlData.DATETIME_FIELDS_TZ,
+                ),
+                signature_value=aec_dte_signature_value,
+                signature_x509_cert_der=aec_dte_cert_der_bytes,
+                emisor_giro='Ingenieria y Construccion',
+                emisor_email='ENACONLTDA@GMAIL.COM',
+                receptor_email=None,
+            ),
+            cedente_rut=Rut('76389992-6'),
+            cesionario_rut=Rut('76598556-0'),
+            fecha_firma_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 5, 12, 57, 32),
+                tz=AecXml.DATETIME_FIELDS_TZ,
+            ),
+            # signature_value=None,
+            # signature_x509_cert_der=None,
+            cesiones=[
+                CesionAecXml(
+                    dte=DteDataL1(
+                        emisor_rut=Rut('76354771-K'),
+                        tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                        folio=170,
+                        fecha_emision_date=date(2019, 4, 1),
+                        receptor_rut=Rut('96790240-3'),
+                        monto_total=2996301,
+                    ),
+                    seq=1,
+                    cedente_rut=Rut('76354771-K'),
+                    cesionario_rut=Rut('76389992-6'),
+                    monto_cesion=2996301,
+                    fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                        dt=datetime(2019, 4, 1, 10, 22, 2),
+                        tz=CesionAecXml.DATETIME_FIELDS_TZ,
+                    ),
+                    fecha_ultimo_vencimiento=date(2019, 5, 1),
+                    cedente_razon_social='SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA LIMITADA',
+                    cedente_direccion='MERCED 753  16 ARBOLEDA DE QUIILOTA',
+                    cedente_email='enaconltda@gmail.com',
+                    cedente_persona_autorizada_rut=Rut('76354771-K'),
+                    cedente_persona_autorizada_nombre='SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA LIM',
+                    cesionario_razon_social='ST CAPITAL S.A.',
+                    cesionario_direccion='Isidora Goyenechea 2939 Oficina 602',
+                    cesionario_email='fynpal-app-notif-st-capital@fynpal.com',
+                    dte_deudor_email=None,
+                    cedente_declaracion_jurada=(
+                        'Se declara bajo juramento que SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA '
+                        'LIMITADA, RUT 76354771-K ha puesto a disposición del cesionario ST '
+                        'CAPITAL S.A., RUT 76389992-6, el o los documentos donde constan los '
+                        'recibos de las mercaderías entregadas o servicios prestados, entregados '
+                        'por parte del deudor de la factura MINERA LOS PELAMBRES, RUT 96790240-3, '
+                        'deacuerdo a lo establecido en la Ley N°19.983.'
+                    ),
+                ),
+                CesionAecXml(
+                    dte=DteDataL1(
+                        emisor_rut=Rut('76354771-K'),
+                        tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                        folio=170,
+                        fecha_emision_date=date(2019, 4, 1),
+                        receptor_rut=Rut('96790240-3'),
+                        monto_total=2996301,
+                    ),
+                    seq=2,
+                    cedente_rut=Rut('76389992-6'),
+                    cesionario_rut=Rut('76598556-0'),
+                    monto_cesion=2996301,
+                    fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                        dt=datetime(2019, 4, 5, 12, 57, 32),
+                        tz=CesionAecXml.DATETIME_FIELDS_TZ,
+                    ),
+                    fecha_ultimo_vencimiento=date(2019, 5, 1),
+                    cedente_razon_social='ST CAPITAL S.A.',
+                    cedente_direccion='Isidora Goyenechea 2939 Oficina 602',
+                    cedente_email='APrat@Financiaenlinea.com',
+                    cesionario_razon_social='Fondo de Inversión Privado Deuda y Facturas',
+                    cesionario_direccion='Arrayan 2750 Oficina 703 Providencia',
+                    cesionario_email='solicitudes@stcapital.cl',
+                    cedente_persona_autorizada_rut=Rut('16360379-9'),
+                    cedente_persona_autorizada_nombre='ANDRES  PRATS VIAL',
+                    dte_deudor_email=None,
+                    cedente_declaracion_jurada=(
+                        'Se declara bajo juramento que ST CAPITAL S.A., RUT 76389992-6 ha puesto '
+                        'a disposicion del cesionario Fondo de Inversión Privado Deuda y Facturas, '
+                        'RUT 76598556-0, el documento validamente emitido al deudor MINERA LOS '
+                        'PELAMBRES, RUT 96790240-3.'
+                    ),
+                ),
+            ],
+            contacto_nombre='ST Capital Servicios Financieros',
+            contacto_telefono=None,
+            contacto_email='APrat@Financiaenlinea.com',
+        )
+
+        xml_doc = xml_utils.parse_untrusted_xml(aec_xml_bytes)
+        aec_xml = parse_aec_xml(xml_doc)
+        self.assertEqual(aec_xml, expected_output)
+
+    def test_parse_aec_xml_ok_2(self) -> None:
+        self._set_obj_2()
+
+        aec_xml_bytes = self.aec_2_xml_bytes
+        aec_dte_signature_value = self.aec_2_dte_signature_value
+        aec_dte_cert_der_bytes = self.aec_2_dte_cert_der_bytes
+        expected_output = AecXml(
+            dte=DteXmlData(
+                emisor_rut=Rut('76399752-9'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=25568,
+                fecha_emision_date=date(2019, 3, 29),
+                receptor_rut=Rut('96874030-K'),
+                monto_total=230992,
+                emisor_razon_social='COMERCIALIZADORA INNOVA MOBEL SPA',
+                receptor_razon_social='EMPRESAS LA POLAR S.A.',
+                fecha_vencimiento_date=None,
+                firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                    dt=datetime(2019, 3, 28, 13, 59, 52),
+                    tz=DteXmlData.DATETIME_FIELDS_TZ,
+                ),
+                signature_value=aec_dte_signature_value,
+                signature_x509_cert_der=aec_dte_cert_der_bytes,
+                emisor_giro='COMERCIALIZACION DE PRODUCTOS PARA EL HOGAR',
+                emisor_email='ANGEL.PEZO@APCASESORIAS.CL',
+                receptor_email=None,
+            ),
+            cedente_rut=Rut('76399752-9'),
+            cesionario_rut=Rut('76389992-6'),
+            fecha_firma_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 4, 9, 9, 52),
+                tz=AecXml.DATETIME_FIELDS_TZ,
+            ),
+            # signature_value=None,
+            # signature_x509_cert_der=None,
+            cesiones=[
+                CesionAecXml(
+                    dte=DteDataL1(
+                        emisor_rut=Rut('76399752-9'),
+                        tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                        folio=25568,
+                        fecha_emision_date=date(2019, 3, 29),
+                        receptor_rut=Rut('96874030-K'),
+                        monto_total=230992,
+                    ),
+                    seq=1,
+                    cedente_rut=Rut('76399752-9'),
+                    cesionario_rut=Rut('76389992-6'),
+                    monto_cesion=230992,
+                    fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                        dt=datetime(2019, 4, 4, 9, 9, 52),
+                        tz=CesionAecXml.DATETIME_FIELDS_TZ,
+                    ),
+                    fecha_ultimo_vencimiento=date(2019, 4, 28),
+                    cedente_razon_social='COMERCIALIZADORA INNOVA MOBEL SPA',
+                    cedente_direccion='LOS CIPRESES 2834',
+                    cedente_email='camilo.perez@innovamobel.cl',
+                    cedente_persona_autorizada_rut=Rut('76399752-9'),
+                    cedente_persona_autorizada_nombre='COMERCIALIZADORA INNOVA MOBEL SPA',
+                    cesionario_razon_social='ST CAPITAL S.A.',
+                    cesionario_direccion='Isidora Goyenechea 2939 Oficina 602',
+                    cesionario_email='fynpal-app-notif-st-capital@fynpal.com',
+                    dte_deudor_email=None,
+                    cedente_declaracion_jurada=(
+                        'Se declara bajo juramento que COMERCIALIZADORA INNOVA MOBEL SPA, RUT '
+                        '76399752-9 ha puesto a disposición del cesionario ST CAPITAL S.A., RUT '
+                        '76389992-6, el o los documentos donde constan los recibos de las '
+                        'mercaderías entregadas o servicios prestados, entregados por parte del '
+                        'deudor de la factura EMPRESAS LA POLAR S.A., RUT 96874030-K, deacuerdo a '
+                        'lo establecido en la Ley N°19.983.'
+                    ),
+                ),
+            ],
+            contacto_nombre=None,
+            contacto_telefono=None,
+            contacto_email='fynpal-app-notif-st-capital@fynpal.com',
+        )
+
+        xml_doc = xml_utils.parse_untrusted_xml(aec_xml_bytes)
+        aec_xml = parse_aec_xml(xml_doc)
+        self.assertEqual(aec_xml, expected_output)


### PR DESCRIPTION
- Add data model for the SII's "Archivo Electrónico de Cesión" (AEC) in XML format.
- Add data model for the "cesiones" contained in an AEC.
- Add parser for AECs in XML format.
- Add tests.