### PR TITLE
Release v0.12.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.0
+current_version = 0.12.1
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+0.12.1 (2021-02-09)
++++++++++++++++++++++++
+
+* (PR #186, 2021-02-09) rtc: Add methods to build CesionL2, CesionL1, and CesionL0 from other data
+  models
+
 0.12.0 (2021-01-17)
 +++++++++++++++++++++++
 

--- a/cl_sii/__init__.py
+++ b/cl_sii/__init__.py
@@ -5,4 +5,4 @@ cl-sii Python lib
 """
 
 
-__version__ = '0.12.0'
+__version__ = '0.12.1'

--- a/cl_sii/rtc/data_models.py
+++ b/cl_sii/rtc/data_models.py
@@ -468,6 +468,15 @@ class CesionL1(CesionL0):
     # Custom Methods
     ###########################################################################
 
+    def as_cesion_l0(self) -> CesionL0:
+        return CesionL0(
+            dte_key=self.dte_key,
+            seq=self.seq,
+            cedente_rut=self.cedente_rut,
+            cesionario_rut=self.cesionario_rut,
+            fecha_cesion_dt=self.fecha_cesion_dt,
+        )
+
     def as_dte_data_l1(self) -> dte_data_models.DteDataL1:
         return dte_data_models.DteDataL1(
             emisor_rut=self.dte_key.emisor_rut,
@@ -631,6 +640,20 @@ class CesionL2(CesionL1):
     ###########################################################################
     # Custom Methods
     ###########################################################################
+
+    def as_cesion_l1(self) -> CesionL1:
+        return CesionL1(
+            dte_key=self.dte_key,
+            seq=self.seq,
+            cedente_rut=self.cedente_rut,
+            cesionario_rut=self.cesionario_rut,
+            fecha_cesion_dt=self.fecha_cesion_dt,
+            monto_cedido=self.monto_cedido,
+            fecha_ultimo_vencimiento=self.fecha_ultimo_vencimiento,
+            dte_fecha_emision=self.dte_fecha_emision,
+            dte_receptor_rut=self.dte_receptor_rut,
+            dte_monto_total=self.dte_monto_total,
+        )
 
     def as_dte_data_l2(self) -> dte_data_models.DteDataL2:
         return dte_data_models.DteDataL2(

--- a/cl_sii/rtc/data_models_aec.py
+++ b/cl_sii/rtc/data_models_aec.py
@@ -269,6 +269,30 @@ class CesionAecXml:
         )
 
     ###########################################################################
+    # Custom Methods
+    ###########################################################################
+
+    def as_cesion_l2(self) -> data_models.CesionL2:
+        return data_models.CesionL2(
+            dte_key=self.dte.natural_key,
+            seq=self.seq,
+            cedente_rut=self.cedente_rut,
+            cesionario_rut=self.cesionario_rut,
+            fecha_cesion_dt=self.fecha_cesion_dt,
+            monto_cedido=self.monto_cesion,
+            dte_receptor_rut=self.dte.receptor_rut,
+            dte_fecha_emision=self.dte.fecha_emision_date,
+            dte_monto_total=self.dte.monto_total,
+            fecha_ultimo_vencimiento=self.fecha_ultimo_vencimiento,
+            cedente_razon_social=self.cedente_razon_social,
+            cedente_email=self.cedente_email,
+            cesionario_razon_social=self.cesionario_razon_social,
+            cesionario_email=self.cesionario_email,
+            dte_deudor_email=self.dte_deudor_email,
+            cedente_declaracion_jurada=self.cedente_declaracion_jurada,
+        )
+
+    ###########################################################################
     # Validators
     ###########################################################################
 

--- a/tests/test_rtc_data_models.py
+++ b/tests/test_rtc_data_models.py
@@ -613,6 +613,26 @@ class CesionL1Test(CesionL0Test):
         )
         self.assertEqual(obj.as_dict(), expected_output)
 
+    def test_as_cesion_l0(self):
+        self._set_obj_1()
+
+        obj = self.obj_1
+        expected_output = CesionL0(
+            dte_key=DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ),
+            seq=32,
+            cedente_rut=Rut('76389992-6'),
+            cesionario_rut=Rut('76598556-0'),
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 5, 12, 57, 32),
+                tz=CesionL0.DATETIME_FIELDS_TZ,
+            ),
+        )
+        self.assertEqual(obj.as_cesion_l0(), expected_output)
+
     def test_as_dte_data_l1(self):
         self._set_obj_1()
 
@@ -812,6 +832,31 @@ class CesionL2Test(CesionL1Test):
             contacto_email='APrat@Financiaenlinea.com',
         )
         self.assertEqual(obj.as_dict(), expected_output)
+
+    def test_as_cesion_l1(self):
+        self._set_obj_1()
+
+        obj = self.obj_1
+        expected_output = CesionL1(
+            dte_key=DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ),
+            seq=32,
+            cedente_rut=Rut('76389992-6'),
+            cesionario_rut=Rut('76598556-0'),
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 5, 12, 57, 32),
+                tz=CesionL1.DATETIME_FIELDS_TZ,
+            ),
+            monto_cedido=2996301,
+            fecha_ultimo_vencimiento=date(2019, 5, 1),
+            dte_fecha_emision=date(2019, 4, 1),
+            dte_receptor_rut=Rut('96790240-3'),
+            dte_monto_total=2996301,
+        )
+        self.assertEqual(obj.as_cesion_l1(), expected_output)
 
     def test_as_dte_data_l2(self):
         self._set_obj_1()

--- a/tests/test_rtc_data_models_aec.py
+++ b/tests/test_rtc_data_models_aec.py
@@ -168,6 +168,48 @@ class CesionAecXmlTest(unittest.TestCase):
         )
         self.assertEqual(obj.alt_natural_key, expected_output)
 
+    def test_as_cesion_l2(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+        expected_output = CesionL2(
+            dte_key=DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ),
+            seq=1,
+            cedente_rut=Rut('76354771-K'),
+            cesionario_rut=Rut('76389992-6'),
+            fecha_cesion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 1, 10, 22, 2),
+                tz=CesionL2.DATETIME_FIELDS_TZ,
+            ),
+            monto_cedido=2996301,
+            dte_receptor_rut=Rut('96790240-3'),
+            dte_fecha_emision=date(2019, 4, 1),
+            dte_monto_total=2996301,
+            fecha_ultimo_vencimiento=date(2019, 5, 1),
+            cedente_razon_social='SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA LIMITADA',
+            cedente_email='enaconltda@gmail.com',
+            cesionario_razon_social='ST CAPITAL S.A.',
+            cesionario_email='fynpal-app-notif-st-capital@fynpal.com',
+            dte_deudor_email=None,
+            cedente_declaracion_jurada=(
+                'Se declara bajo juramento que SERVICIOS BONILLA Y LOPEZ Y COMPAÑIA '
+                'LIMITADA, RUT 76354771-K ha puesto a disposición del cesionario ST '
+                'CAPITAL S.A., RUT 76389992-6, el o los documentos donde constan los '
+                'recibos de las mercaderías entregadas o servicios prestados, entregados '
+                'por parte del deudor de la factura MINERA LOS PELAMBRES, RUT 96790240-3, '
+                'deacuerdo a lo establecido en la Ley N°19.983.'
+            ),
+        )
+        obj_cesion_l2 = obj.as_cesion_l2()
+        self.assertEqual(obj_cesion_l2, expected_output)
+        self.assertEqual(obj_cesion_l2.natural_key, obj.natural_key)
+        self.assertEqual(obj_cesion_l2.alt_natural_key, obj.alt_natural_key)
+        self.assertEqual(obj_cesion_l2.dte_key, obj.dte.natural_key)
+
 
 class AecXmlTest(unittest.TestCase):
     """


### PR DESCRIPTION
- (PR #186, 2021-02-09) rtc: Add methods to build CesionL2, CesionL1, and CesionL0 from other data models
