### PR TITLE
Release v0.12.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.1
+current_version = 0.12.2
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,18 @@
 History
 -------
 
+0.12.2 (2021-02-16)
++++++++++++++++++++++++
+
+* (PR #177, 2021-02-16) build(deps): bump lxml from 4.5.0 to 4.6.2
+* (PR #188, 2021-02-16) build(deps): bump cryptography from 3.3.1 to 3.3.2
+* (PR #176, 2021-02-16) build(deps): bump zipp from 3.1.0 to 3.4.0
+* (PR #167, 2021-02-16) build(deps): bump py from 1.8.1 to 1.10.0
+* (PR #189, 2021-02-16) build(deps): bump certifi from 2020.4.5.1 to 2020.12.5
+* (PR #185, 2021-02-16) build(deps): bump pkginfo from 1.5.0.1 to 1.7.0
+* (PR #191, 2021-02-16) build(deps): bump pyrsistent from 0.16.0 to 0.17.3
+* (PR #190, 2021-02-16) build(deps): bump typed-ast from 1.4.1 to 1.4.2
+
 0.12.1 (2021-02-09)
 +++++++++++++++++++++++
 

--- a/cl_sii/__init__.py
+++ b/cl_sii/__init__.py
@@ -5,4 +5,4 @@ cl-sii Python lib
 """
 
 
-__version__ = '0.12.1'
+__version__ = '0.12.2'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -39,7 +39,7 @@ eight==1.0.0
 future==0.18.2
 importlib-metadata==1.6.0; python_version<'3.8'
 pycparser==2.20
-pyrsistent==0.16.0
+pyrsistent==0.17.3
 # setuptools
 six==1.15.0
 zipp==3.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,4 +42,4 @@ pycparser==2.20
 pyrsistent==0.16.0
 # setuptools
 six==1.15.0
-zipp==3.1.0
+zipp==3.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 # note: it is mandatory to register all dependencies of the required packages.
 
 # Required packages:
-cryptography==3.3.1
+cryptography==3.3.2
 defusedxml==0.6.0
 jsonschema==3.2.0
 lxml==4.6.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,7 +33,7 @@ signxml==2.8.1
 #       - pyOpenSSL
 #           - six
 attrs==20.3.0
-certifi==2020.4.5.1
+certifi==2020.12.5
 cffi==1.14.0
 eight==1.0.0
 future==0.18.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@
 cryptography==3.3.1
 defusedxml==0.6.0
 jsonschema==3.2.0
-lxml==4.5.0
+lxml==4.6.2
 marshmallow==2.19.5
 pydantic==1.6.1
 pyOpenSSL==18.0.0

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -43,7 +43,7 @@ wheel==0.35.1
 importlib-metadata==1.6.0
 # jeepney
 keyring==21.4.0
-pkginfo==1.5.0.1
+pkginfo==1.7.0
 # Pygments
 readme-renderer==25.0
 requests==2.23.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -54,7 +54,7 @@ mccabe==0.6.1
 mypy-extensions==0.4.3
 packaging==20.4
 pluggy==0.13.1
-py==1.8.1
+py==1.10.0
 pycodestyle==2.6.0
 pyflakes==2.2.0
 # pyparsing

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -61,7 +61,7 @@ pyflakes==2.2.0
 # requests
 # six
 toml==0.10.1
-typed-ast==1.4.1
+typed-ast==1.4.2
 typing-extensions==3.7.4.3
 # urllib3
 virtualenv==20.0.31


### PR DESCRIPTION
- (PR #177, 2021-02-16) build(deps): bump lxml from 4.5.0 to 4.6.2
- (PR #188, 2021-02-16) build(deps): bump cryptography from 3.3.1 to 3.3.2
- (PR #176, 2021-02-16) build(deps): bump zipp from 3.1.0 to 3.4.0
- (PR #167, 2021-02-16) build(deps): bump py from 1.8.1 to 1.10.0
- (PR #189, 2021-02-16) build(deps): bump certifi from 2020.4.5.1 to 2020.12.5
- (PR #185, 2021-02-16) build(deps): bump pkginfo from 1.5.0.1 to 1.7.0
- (PR #191, 2021-02-16) build(deps): bump pyrsistent from 0.16.0 to 0.17.3
- (PR #190, 2021-02-16) build(deps): bump typed-ast from 1.4.1 to 1.4.2