### PR TITLE
data.ref: update XML schemas of "factura electrónica"

### DIFF
--- a/cl_sii/data/ref/factura_electronica/schemas-xml/DTE_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schemas-xml/DTE_v10.xsd
@@ -14,9 +14,19 @@ Fecha Actualizacion:  30-05-2011 12:00
 
 Descuento Recargo Global : se incorporar restricción en Tipo de Movimiento
 			   para que sea dato de largo 1
+			   
+
+Fecha Actualizacion:  (Se asume que es 12-2019 por el nombre del archivo)
+Fuente: https://www.sii.cl/factura_electronica/schema_cesion_201912.zip
+
+IdDoc: Se agrega elemento TipoFactEsp
+Receptor.Extranjero: Se agrega elemento TipoDocID
+IndServicio: Se agrega nuevo valor a la enumeración
+MntExeOtrMnda: Se cambia al tipo simple Dec14_4-0Type
+MntTotOtrMnda: Se cambia al tipo simple Dec14_4-0Type
 
   -->
-<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:SiiDte="http://www.sii.cl/SiiDte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:SiiDte="http://www.sii.cl/SiiDte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="SiiTypes_v10.xsd"/>
 	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
 	<xs:element name="DTE" type="SiiDte:DTEDefType"/>
@@ -364,6 +374,17 @@ Descuento Recargo Global : se incorporar restricción en Tipo de Movimiento
 															<xs:documentation>Fecha de Vencimiento del Pago (AAAA-MM-DD)</xs:documentation>
 														</xs:annotation>
 													</xs:element>
+													<xs:element name="TipoFactEsp" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de Factura Especial</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:nonNegativeInteger">
+																<xs:totalDigits value="1"/>
+																<xs:enumeration value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
 												</xs:sequence>
 											</xs:complexType>
 										</xs:element>
@@ -575,6 +596,17 @@ Descuento Recargo Global : se incorporar restricción en Tipo de Movimiento
 																		<xs:restriction base="xs:string">
 																			<xs:maxLength value="3"/>
 																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TipoDocID" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de Documento del Turista</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:nonNegativeInteger">
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
 																		</xs:restriction>
 																	</xs:simpleType>
 																</xs:element>
@@ -1017,8 +1049,7 @@ Descuento Recargo Global : se incorporar restricción en Tipo de Movimiento
 																</xs:element>
 																<xs:element name="CodPaisRecep" minOccurs="0">
 																	<xs:annotation>
-																		<xs:documentation>Código del país del receptor extranjero de la mercadería,
-según tabla Países aduana</xs:documentation>
+																		<xs:documentation>Código del país del receptor extranjero de la mercadería, según tabla Países aduana</xs:documentation>
 																	</xs:annotation>
 																	<xs:simpleType>
 																		<xs:restriction base="xs:positiveInteger">
@@ -1028,8 +1059,7 @@ según tabla Países aduana</xs:documentation>
 																</xs:element>
 																<xs:element name="CodPaisDestin" minOccurs="0">
 																	<xs:annotation>
-																		<xs:documentation>Código del país de destino extranjero de la mercadería,
-según tabla Países aduana</xs:documentation>
+																		<xs:documentation>Código del país de destino extranjero de la mercadería, según tabla Países aduana</xs:documentation>
 																	</xs:annotation>
 																	<xs:simpleType>
 																		<xs:restriction base="xs:positiveInteger">
@@ -3419,6 +3449,7 @@ según tabla Países aduana</xs:documentation>
 																</xs:enumeration>
 																<xs:enumeration value="4"/>
 																<xs:enumeration value="5"/>
+																<xs:enumeration value="6"/>
 															</xs:restriction>
 														</xs:simpleType>
 													</xs:element>
@@ -4215,8 +4246,7 @@ según tabla Países aduana</xs:documentation>
 																</xs:element>
 																<xs:element name="CodPaisRecep" minOccurs="0">
 																	<xs:annotation>
-																		<xs:documentation>Código del país del receptor extranjero de la mercadería,
-según tabla Países aduana</xs:documentation>
+																		<xs:documentation>Código del país del receptor extranjero de la mercadería, según tabla Países aduana</xs:documentation>
 																	</xs:annotation>
 																	<xs:simpleType>
 																		<xs:restriction base="xs:positiveInteger">
@@ -4226,8 +4256,7 @@ según tabla Países aduana</xs:documentation>
 																</xs:element>
 																<xs:element name="CodPaisDestin" minOccurs="0">
 																	<xs:annotation>
-																		<xs:documentation>Código del país de destino extranjero de la mercadería,
-según tabla Países aduana</xs:documentation>
+																		<xs:documentation>Código del país de destino extranjero de la mercadería, según tabla Países aduana</xs:documentation>
 																	</xs:annotation>
 																	<xs:simpleType>
 																		<xs:restriction base="xs:positiveInteger">
@@ -4297,12 +4326,12 @@ según tabla Países aduana</xs:documentation>
 															<xs:documentation>Tipo de Cambio fijado por el Banco Central de Chile</xs:documentation>
 														</xs:annotation>
 													</xs:element>
-													<xs:element name="MntExeOtrMnda" type="xs:decimal" minOccurs="0">
+													<xs:element name="MntExeOtrMnda" type="SiiDte:Dec14_4-0Type" minOccurs="0">
 														<xs:annotation>
 															<xs:documentation>Monto Exento del DTE en Otra Moneda  </xs:documentation>
 														</xs:annotation>
 													</xs:element>
-													<xs:element name="MntTotOtrMnda" type="xs:decimal">
+													<xs:element name="MntTotOtrMnda" type="SiiDte:Dec14_4-0Type">
 														<xs:annotation>
 															<xs:documentation>Monto Total Otra Moneda</xs:documentation>
 														</xs:annotation>

--- a/cl_sii/data/ref/factura_electronica/schemas-xml/SiiTypes_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schemas-xml/SiiTypes_v10.xsd
@@ -16,9 +16,13 @@ ImpAdicDTEType	: se agregan los codigos 54 y 55 (SDI-1092)
 Fecha Actualizacion:  30/09/2014 11:40
 ImpAdicDTEType	: se agregan el codigo de impuesto 271 (SDI-9342)
 
+Fecha Actualizacion:  19/02/2018
+root            : Se agrega tipo simple Dec14_4-0Type para decimales no negativos (admite 0 a diferencia de Dec14_4Type)
+TipoTransCOMPRA : Se cambia el tipo base y se agrega restricción de valor mínimo y máximo (1 - 7)
+TipoTransVENTA  : Se agrega restricción de valor mínimo y máximo (1 - 4)
 
 -->
-<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns1="http://www.sii.cl/SiiDte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:ns1="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:simpleType name="DOCType">
 		<xs:annotation>
 			<xs:documentation>Todos los tipos de Documentos Tributarios Electronicos</xs:documentation>
@@ -166,11 +170,7 @@ ImpAdicDTEType	: se agregan el codigo de impuesto 271 (SDI-9342)
 			<xs:maxLength value="18"/>
 			<xs:minLength value="1"/>
 		</xs:restriction>
-		<!-- Referencia a Documentos con Folio alfanumericos
-		<xs:restriction base="xs:nonNegativeInteger">
-			<xs:totalDigits value="10"/>
-		</xs:restriction>
--->
+		<!-- Referencia a Documentos con Folio alfanumericos 		<xs:restriction base="xs:nonNegativeInteger"> 			<xs:totalDigits value="10"/> 		</xs:restriction> -->
 	</xs:simpleType>
 	<xs:simpleType name="Dec16_2Type">
 		<xs:annotation>
@@ -191,6 +191,17 @@ ImpAdicDTEType	: se agregan el codigo de impuesto 271 (SDI-9342)
 			<xs:totalDigits value="18"/>
 			<xs:fractionDigits value="4"/>
 			<xs:minInclusive value="0.0001"/>
+			<xs:maxInclusive value="99999999999999.9999"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Dec14_4-0Type">
+		<xs:annotation>
+			<xs:documentation>Monto con 14 Digitos de Cuerpo y 4 Decimales partiendo de cero</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="4"/>
+			<xs:minInclusive value="0.0000"/>
 			<xs:maxInclusive value="99999999999999.9999"/>
 		</xs:restriction>
 	</xs:simpleType>
@@ -306,8 +317,7 @@ ImpAdicDTEType	: se agregan el codigo de impuesto 271 (SDI-9342)
 			</xs:enumeration>
 			<xs:enumeration value="29">
 				<xs:annotation>
-					<xs:documentation>Recuperación Impuesto Específico diesel Transportistas  Para transportistas de carga
- Art 2° Ley N°19.764/2001</xs:documentation>
+					<xs:documentation>Recuperación Impuesto Específico diesel Transportistas  Para transportistas de carga  Art 2° Ley N°19.764/2001</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="30">
@@ -828,7 +838,9 @@ ImpAdicDTEType	: se agregan el codigo de impuesto 271 (SDI-9342)
 		<xs:annotation>
 			<xs:documentation>Tipo de Transacción para el comprador</xs:documentation>
 		</xs:annotation>
-		<xs:restriction base="xs:nonNegativeInteger">
+		<xs:restriction base="xs:positiveInteger">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="7"/>
 			<xs:enumeration value="1">
 				<xs:annotation>
 					<xs:documentation>Del Giro</xs:documentation>
@@ -863,6 +875,8 @@ ImpAdicDTEType	: se agregan el codigo de impuesto 271 (SDI-9342)
 			<xs:documentation>Tipo de Transacción para el vendedor</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:positiveInteger">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="4"/>
 			<xs:enumeration value="1">
 				<xs:annotation>
 					<xs:documentation>Del Giro</xs:documentation>
@@ -886,3 +900,4 @@ ImpAdicDTEType	: se agregan el codigo de impuesto 271 (SDI-9342)
 		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>
+


### PR DESCRIPTION
Obtained from the SII's website from a more up-to-date source than the official one.
This page on the SII's website provides the information related to the specifications of the "Archivo electrónico de cesión (AEC)".

Source: Formato XML del Archivo Electrónico de Cesión at
https://www.sii.cl/factura_electronica/schema_cesion_201912.zip

NOTE: There are trivial changes such as the order of the namespaces or some new lines, but they were kept to maintain consistency with the original file, except for those comments added in the header.