### PR TITLE
rtc.data_models_aec: remove match validation for 'fecha_firma_dt' and 'fecha_cesion_dt'

### DIFF
--- a/cl_sii/rtc/data_models_aec.py
+++ b/cl_sii/rtc/data_models_aec.py
@@ -746,7 +746,12 @@ class AecXml:
     ) -> Mapping[str, object]:
         field_validations: Sequence[Tuple[str, str]] = [
             # (AecXml field, CesionAecXml field):
-            ('fecha_firma_dt', 'fecha_cesion_dt'),
+            # Even though it seems reasonable to expect that the date in `fecha_firma_dt`
+            # in the AEC is later than the date in `fecha_cesion_dt`, we know of cases of
+            # AEC approved by the SII in which this is not fulfilled, we observe cases
+            # where the date in `fecha_firma_dt` was later or even before the date in
+            # `fecha_cesion_dt` by a difference of up to 6 hours.
+            # ('fecha_firma_dt', 'fecha_cesion_dt'),
             ('cedente_rut', 'cedente_rut'),
             ('cesionario_rut', 'cesionario_rut'),
         ]

--- a/tests/test_rtc_data_models_aec.py
+++ b/tests/test_rtc_data_models_aec.py
@@ -660,16 +660,10 @@ class AecXmlTest(unittest.TestCase):
             {
                 'loc': ('__root__',),
                 'msg':
-                    "'fecha_cesion_dt' of last 'cesion' must match 'fecha_firma_dt':"
-                    " datetime.datetime("
-                    "2019, 4, 5, 12, 57, 32,"
-                    " tzinfo=<DstTzInfo 'America/Santiago' -03-1 day, 21:00:00 DST>"
-                    ")"
+                    "'cedente_rut' of last 'cesion' must match 'cedente_rut':"
+                    " Rut('76389992-6')"
                     " !="
-                    " datetime.datetime("
-                    "2019, 4, 5, 12, 0, 32,"
-                    " tzinfo=<DstTzInfo 'America/Santiago' -03-1 day, 21:00:00 DST>"
-                    ").",
+                    " Rut('76598556-0').",
                 'type': 'value_error',
             },
         ]
@@ -677,7 +671,7 @@ class AecXmlTest(unittest.TestCase):
         with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
-                fecha_firma_dt=obj.fecha_firma_dt.replace(minute=0),  # Original minute is 57.
+                cedente_rut=obj.cesionario_rut,
             )
 
         validation_errors = assert_raises_cm.exception.errors()


### PR DESCRIPTION
The coincidence between the fields `fecha_firma_dt` and `fecha_cesion_dt` in a 'cesion' is not mentioned among the validations that the SII performs to accept an AEC XML Document, in fact, there are known cases of valid AEC XML Documents where these fields do not have the same date, with a slight difference of a few seconds, but still, the AEC is valid for the SII.

Ref. [Instructivo Técnico Registro Público Electrónico de Transferencia de Crédito](https://github.com/cl-sii-extraoficial/archivos-oficiales/blob/master/src/docs/rtc/README.md#instructivo-t%C3%A9cnico)

ref https://github.com/fyntex/fd-cl-data/issues/671
