### PR TITLE
rtc.data_models_aec: remove validation for the progression of 'monto_cesion' across the 'cesiones'

### DIFF
--- a/cl_sii/rtc/data_models_aec.py
+++ b/cl_sii/rtc/data_models_aec.py
@@ -703,21 +703,24 @@ class AecXml:
                     raise ValueError("items must be ordered according to their 'seq'")
         return v
 
-    @pydantic.validator('cesiones')
-    def validate_cesiones_monto_cesion_must_not_increase(cls, v: object) -> object:
-        if isinstance(v, Sequence):
-            if len(v) >= 2:
-                previous_cesion: Optional[CesionAecXml] = None
-                for cesion in v:
-                    if previous_cesion is not None:
-                        if not (cesion.monto_cesion <= previous_cesion.monto_cesion):
-                            raise ValueError(
-                                "items must have a 'monto_cesion'"
-                                " that does not exceed the previous item's 'monto_cesion'.",
-                            )
-                    previous_cesion = cesion
+    # Note: Even though this validation seems to make perfect sense, there are some
+    # real cases of SII-approved AEC where this is not fulfilled.
+    # We will keep this validation in case we need it in the future.
+    # @pydantic.validator('cesiones')
+    # def validate_cesiones_monto_cesion_must_not_increase(cls, v: object) -> object:
+    #     if isinstance(v, Sequence):
+    #         if len(v) >= 2:
+    #             previous_cesion: Optional[CesionAecXml] = None
+    #             for cesion in v:
+    #                 if previous_cesion is not None:
+    #                     if not (cesion.monto_cesion <= previous_cesion.monto_cesion):
+    #                         raise ValueError(
+    #                             "items must have a 'monto_cesion'"
+    #                             " that does not exceed the previous item's 'monto_cesion'.",
+    #                         )
+    #                 previous_cesion = cesion
 
-        return v
+    #     return v
 
     @pydantic.root_validator(skip_on_failure=True)
     def validate_dte_matches_cesiones_dtes(

--- a/tests/test_rtc_data_models_aec.py
+++ b/tests/test_rtc_data_models_aec.py
@@ -574,37 +574,37 @@ class AecXmlTest(unittest.TestCase):
         for expected_validation_error in expected_validation_errors:
             self.assertIn(expected_validation_error, validation_errors)
 
-    def test_validate_cesiones_monto_cesion_must_not_increase(self) -> None:
-        self._set_obj_1()
+    # def test_validate_cesiones_monto_cesion_must_not_increase(self) -> None:
+    #     self._set_obj_1()
 
-        obj = self.obj_1
+    #     obj = self.obj_1
 
-        expected_validation_errors = [
-            {
-                'loc': ('cesiones',),
-                'msg':
-                    "items must have a 'monto_cesion'"
-                    " that does not exceed the previous item's 'monto_cesion'.",
-                'type': 'value_error',
-            },
-        ]
+    #     expected_validation_errors = [
+    #         {
+    #             'loc': ('cesiones',),
+    #             'msg':
+    #                 "items must have a 'monto_cesion'"
+    #                 " that does not exceed the previous item's 'monto_cesion'.",
+    #             'type': 'value_error',
+    #         },
+    #     ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
-            dataclasses.replace(
-                obj,
-                cesiones=[
-                    dataclasses.replace(
-                        obj.cesiones[0],
-                        monto_cesion=obj.cesiones[1].monto_cesion - 1,
-                    ),
-                    obj.cesiones[1],
-                ],
-            )
+    #     with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+    #         dataclasses.replace(
+    #             obj,
+    #             cesiones=[
+    #                 dataclasses.replace(
+    #                     obj.cesiones[0],
+    #                     monto_cesion=obj.cesiones[1].monto_cesion - 1,
+    #                 ),
+    #                 obj.cesiones[1],
+    #             ],
+    #         )
 
-        validation_errors = assert_raises_cm.exception.errors()
-        self.assertEqual(len(validation_errors), len(expected_validation_errors))
-        for expected_validation_error in expected_validation_errors:
-            self.assertIn(expected_validation_error, validation_errors)
+    #     validation_errors = assert_raises_cm.exception.errors()
+    #     self.assertEqual(len(validation_errors), len(expected_validation_errors))
+    #     for expected_validation_error in expected_validation_errors:
+    #         self.assertIn(expected_validation_error, validation_errors)
 
     def test_validate_dte_matches_cesiones_dtes(self) -> None:
         self._set_obj_1()


### PR DESCRIPTION
Although the validation of the progression of the value 'monto_cesion' through the 'cesiones' in an AECXml seems to make a lot of sense, there are known SII-approved AECs where the 'monto_cesion' of a 'cesion' exceeds the value of its predecessor.
This validation is not documented among those carried out by the SII at the time of uploading an AEC

Ref. Instructivo Técnico Registro Público Electrónico de Transferencia de Crédito
Source: (https://github.com/cl-sii-extraoficial/archivos-oficiales/blob/master/src/docs/rtc/README.md#instructivo-t%C3%A9cnico)