### PR TITLE
Release v0.12.4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.3
+current_version = 0.12.4
 commit = True
 tag = True
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
 
   dist:
     docker:
-      - image: docker.io/library/python:3.8.5
+      - image: docker.io/library/python:3.8.9
 
     working_directory: ~/repo
 
@@ -119,7 +119,7 @@ jobs:
 
   deploy:
     docker:
-      - image: docker.io/library/python:3.8.5
+      - image: docker.io/library/python:3.8.9
         environment:
           <<: *x-deploy-environment
 
@@ -149,7 +149,7 @@ workflows:
             parameters:
               python_version:
                 - "3.7.9"
-                - "3.8.5"
+                - "3.8.9"
                 - "3.9.1"
       - dist:
           requires:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,19 @@
 History
 -------
 
+0.12.4 (2021-04-15)
++++++++++++++++++++++++
+
+* (PR #195, 2021-04-15) build(deps): bump requests from 2.23.0 to 2.25.1
+* (PR #212, 2021-04-14) config: Update Python version used in CI jobs to 3.8.9
+* (PR #210, 2021-04-13) rtc.data_models_aec: remove validation for the progression of
+  'monto_cesion' across the 'cesiones'
+* (PR #207, 2021-04-08) build(deps): bump virtualenv from 20.0.31 to 20.4.3
+* (PR #208, 2021-04-08) rtc.data_models_aec: remove match validation for 'fecha_firma_dt' and
+  'fecha_cesion_dt'
+* (PR #205, 2021-03-26) build(deps): bump lxml from 4.6.2 to 4.6.3
+* (PR #204, 2021-03-24) requirements: Upgrade 'Django'
+
 0.12.3 (2021-02-26)
 +++++++++++++++++++++++
 

--- a/cl_sii/__init__.py
+++ b/cl_sii/__init__.py
@@ -5,4 +5,4 @@ cl-sii Python lib
 """
 
 
-__version__ = '0.12.3'
+__version__ = '0.12.4'

--- a/cl_sii/rtc/data_models_aec.py
+++ b/cl_sii/rtc/data_models_aec.py
@@ -703,21 +703,24 @@ class AecXml:
                     raise ValueError("items must be ordered according to their 'seq'")
         return v
 
-    @pydantic.validator('cesiones')
-    def validate_cesiones_monto_cesion_must_not_increase(cls, v: object) -> object:
-        if isinstance(v, Sequence):
-            if len(v) >= 2:
-                previous_cesion: Optional[CesionAecXml] = None
-                for cesion in v:
-                    if previous_cesion is not None:
-                        if not (cesion.monto_cesion <= previous_cesion.monto_cesion):
-                            raise ValueError(
-                                "items must have a 'monto_cesion'"
-                                " that does not exceed the previous item's 'monto_cesion'.",
-                            )
-                    previous_cesion = cesion
+    # Note: Even though this validation seems to make perfect sense, there are some
+    # real cases of SII-approved AEC where this is not fulfilled.
+    # We will keep this validation in case we need it in the future.
+    # @pydantic.validator('cesiones')
+    # def validate_cesiones_monto_cesion_must_not_increase(cls, v: object) -> object:
+    #     if isinstance(v, Sequence):
+    #         if len(v) >= 2:
+    #             previous_cesion: Optional[CesionAecXml] = None
+    #             for cesion in v:
+    #                 if previous_cesion is not None:
+    #                     if not (cesion.monto_cesion <= previous_cesion.monto_cesion):
+    #                         raise ValueError(
+    #                             "items must have a 'monto_cesion'"
+    #                             " that does not exceed the previous item's 'monto_cesion'.",
+    #                         )
+    #                 previous_cesion = cesion
 
-        return v
+    #     return v
 
     @pydantic.root_validator(skip_on_failure=True)
     def validate_dte_matches_cesiones_dtes(

--- a/cl_sii/rtc/data_models_aec.py
+++ b/cl_sii/rtc/data_models_aec.py
@@ -746,7 +746,12 @@ class AecXml:
     ) -> Mapping[str, object]:
         field_validations: Sequence[Tuple[str, str]] = [
             # (AecXml field, CesionAecXml field):
-            ('fecha_firma_dt', 'fecha_cesion_dt'),
+            # Even though it seems reasonable to expect that the date in `fecha_firma_dt`
+            # in the AEC is later than the date in `fecha_cesion_dt`, we know of cases of
+            # AEC approved by the SII in which this is not fulfilled, we observe cases
+            # where the date in `fecha_firma_dt` was later or even before the date in
+            # `fecha_cesion_dt` by a difference of up to 6 hours.
+            # ('fecha_firma_dt', 'fecha_cesion_dt'),
             ('cedente_rut', 'cedente_rut'),
             ('cesionario_rut', 'cesionario_rut'),
         ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@
 cryptography==3.3.2
 defusedxml==0.6.0
 jsonschema==3.2.0
-lxml==4.6.2
+lxml==4.6.3
 marshmallow==2.19.5
 pydantic==1.6.1
 pyOpenSSL==18.0.0

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,7 +1,7 @@
 # note: it is NOT mandatory to register all dependencies of the required packages.
 
 # Required packages:
-Django>=2.2.10,<3
+Django>=2.2.18,<3
 djangorestframework>=3.10.3,<3.13
 
 # Packages dependencies:

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -46,7 +46,7 @@ keyring==21.4.0
 pkginfo==1.7.0
 # Pygments
 readme-renderer==25.0
-requests==2.23.0
+requests==2.25.1
 requests-toolbelt==0.9.1
 # SecretStorage
 # six

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -64,5 +64,5 @@ toml==0.10.1
 typed-ast==1.4.2
 typing-extensions==3.7.4.3
 # urllib3
-virtualenv==20.0.31
+virtualenv==20.4.3
 # zipp

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requirements = [
 ]
 
 extras_requirements = {
-    'django': ['Django>=2.2.10,<3'],
+    'django': ['Django>=2.2.18,<3'],
     'djangorestframework': ['djangorestframework>=3.10.3,<3.13'],
 }
 

--- a/tests/test_rtc_data_models_aec.py
+++ b/tests/test_rtc_data_models_aec.py
@@ -574,37 +574,37 @@ class AecXmlTest(unittest.TestCase):
         for expected_validation_error in expected_validation_errors:
             self.assertIn(expected_validation_error, validation_errors)
 
-    def test_validate_cesiones_monto_cesion_must_not_increase(self) -> None:
-        self._set_obj_1()
+    # def test_validate_cesiones_monto_cesion_must_not_increase(self) -> None:
+    #     self._set_obj_1()
 
-        obj = self.obj_1
+    #     obj = self.obj_1
 
-        expected_validation_errors = [
-            {
-                'loc': ('cesiones',),
-                'msg':
-                    "items must have a 'monto_cesion'"
-                    " that does not exceed the previous item's 'monto_cesion'.",
-                'type': 'value_error',
-            },
-        ]
+    #     expected_validation_errors = [
+    #         {
+    #             'loc': ('cesiones',),
+    #             'msg':
+    #                 "items must have a 'monto_cesion'"
+    #                 " that does not exceed the previous item's 'monto_cesion'.",
+    #             'type': 'value_error',
+    #         },
+    #     ]
 
-        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
-            dataclasses.replace(
-                obj,
-                cesiones=[
-                    dataclasses.replace(
-                        obj.cesiones[0],
-                        monto_cesion=obj.cesiones[1].monto_cesion - 1,
-                    ),
-                    obj.cesiones[1],
-                ],
-            )
+    #     with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+    #         dataclasses.replace(
+    #             obj,
+    #             cesiones=[
+    #                 dataclasses.replace(
+    #                     obj.cesiones[0],
+    #                     monto_cesion=obj.cesiones[1].monto_cesion - 1,
+    #                 ),
+    #                 obj.cesiones[1],
+    #             ],
+    #         )
 
-        validation_errors = assert_raises_cm.exception.errors()
-        self.assertEqual(len(validation_errors), len(expected_validation_errors))
-        for expected_validation_error in expected_validation_errors:
-            self.assertIn(expected_validation_error, validation_errors)
+    #     validation_errors = assert_raises_cm.exception.errors()
+    #     self.assertEqual(len(validation_errors), len(expected_validation_errors))
+    #     for expected_validation_error in expected_validation_errors:
+    #         self.assertIn(expected_validation_error, validation_errors)
 
     def test_validate_dte_matches_cesiones_dtes(self) -> None:
         self._set_obj_1()

--- a/tests/test_rtc_data_models_aec.py
+++ b/tests/test_rtc_data_models_aec.py
@@ -660,16 +660,10 @@ class AecXmlTest(unittest.TestCase):
             {
                 'loc': ('__root__',),
                 'msg':
-                    "'fecha_cesion_dt' of last 'cesion' must match 'fecha_firma_dt':"
-                    " datetime.datetime("
-                    "2019, 4, 5, 12, 57, 32,"
-                    " tzinfo=<DstTzInfo 'America/Santiago' -03-1 day, 21:00:00 DST>"
-                    ")"
+                    "'cedente_rut' of last 'cesion' must match 'cedente_rut':"
+                    " Rut('76389992-6')"
                     " !="
-                    " datetime.datetime("
-                    "2019, 4, 5, 12, 0, 32,"
-                    " tzinfo=<DstTzInfo 'America/Santiago' -03-1 day, 21:00:00 DST>"
-                    ").",
+                    " Rut('76598556-0').",
                 'type': 'value_error',
             },
         ]
@@ -677,7 +671,7 @@ class AecXmlTest(unittest.TestCase):
         with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 obj,
-                fecha_firma_dt=obj.fecha_firma_dt.replace(minute=0),  # Original minute is 57.
+                cedente_rut=obj.cesionario_rut,
             )
 
         validation_errors = assert_raises_cm.exception.errors()


### PR DESCRIPTION
-  (PR #195, 2021-04-15) build(deps): bump requests from 2.23.0 to 2.25.1
-  (PR #212, 2021-04-14) config: Update Python version used in CI jobs to 3.8.9
- (PR #210, 2021-04-13) rtc.data_models_aec: remove validation for the progression of 'monto_cesion' across the 'cesiones'
- (PR #207, 2021-04-08) build(deps): bump virtualenv from 20.0.31 to 20.4.3
- (PR #208, 2021-04-08) rtc.data_models_aec: remove match validation for 'fecha_firma_dt' and 'fecha_cesion_dt'
- (PR #205, 2021-03-26) build(deps): bump lxml from 4.6.2 to 4.6.3
- (PR #204, 2021-03-24) requirements: Upgrade 'Django'