### PR TITLE
docs: Add creation of release branch to instructions for new releases

### DIFF
--- a/docs/project-maintenance.rst
+++ b/docs/project-maintenance.rst
@@ -53,6 +53,12 @@ Push commit ``abcd1234`` and tag ``vX.Y.Z`` automatically created by ``bumpversi
     git push
     git push --tags
 
+Create branch ``release/vX.Y.Z`` that points to tag ``vX.Y.Z`` and push it::
+
+    git checkout vX.Y.Z
+    git checkout -b release/vX.Y.Z
+    git push origin HEAD
+
 3) Create pull request and new release
 +++++++++++++++++++
 
@@ -60,6 +66,10 @@ Push commit ``abcd1234`` and tag ``vX.Y.Z`` automatically created by ``bumpversi
 
 * Create PR for
   `master...develop <https://github.com/fyntex/lib-cl-sii-python/compare/master...develop>`_.
+
+  * Base branch: ``master``.
+
+  * Head branch: ``release/vX.Y.Z`` (instead of ``develop``).
 
   * Name: "Release".
 


### PR DESCRIPTION
The GitHub pull request for the new release uses `develop` as the head branch. Before the pull request is merged, additional commits may be pushed to `develop`, and those commits will be merged into the base branch when the pull request is finally merged, even though what we wanted to merge was not actually `develop`, but the tag of the new version.

The documentation is updated with a workaround that "freezes" `develop` by creating a branch that points to the tag of the new version, so that the new branch is used as head branch instead of `develop`.

Ref: https://github.com/fyntex/lib-cl-sii-api-python/pull/236.