### PR TITLE
Release v0.12.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.4
+current_version = 0.12.5
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,16 @@
 History
 -------
 
+0.12.5 (2021-06-15)
++++++++++++++++++++++++
+
+* (PR #226, 2021-06-15) requirements: Remove Django upper bound constraint
+* (PR #224, 2021-06-15) requirements: Upgrade 'Django'
+* (PR #223, 2021-06-08) requirements: Upgrade 'Django'
+* (PR #221, 2021-05-14) requirements: Upgrade Pydantic
+* (PR #216, 2021-04-22) docs: Add creation of release branch to instructions for new releases
+* (PR #213, 2021-04-21) build(deps): bump toml from 0.10.1 to 0.10.2
+
 0.12.4 (2021-04-15)
 +++++++++++++++++++++++
 

--- a/cl_sii/__init__.py
+++ b/cl_sii/__init__.py
@@ -5,4 +5,4 @@ cl-sii Python lib
 """
 
 
-__version__ = '0.12.4'
+__version__ = '0.12.5'

--- a/docs/project-maintenance.rst
+++ b/docs/project-maintenance.rst
@@ -53,6 +53,12 @@ Push commit ``abcd1234`` and tag ``vX.Y.Z`` automatically created by ``bumpversi
     git push
     git push --tags
 
+Create branch ``release/vX.Y.Z`` that points to tag ``vX.Y.Z`` and push it::
+
+    git checkout vX.Y.Z
+    git checkout -b release/vX.Y.Z
+    git push origin HEAD
+
 3) Create pull request and new release
 +++++++++++++++++++
 
@@ -60,6 +66,10 @@ Push commit ``abcd1234`` and tag ``vX.Y.Z`` automatically created by ``bumpversi
 
 * Create PR for
   `master...develop <https://github.com/fyntex/lib-cl-sii-python/compare/master...develop>`_.
+
+  * Base branch: ``master``.
+
+  * Head branch: ``release/vX.Y.Z`` (instead of ``develop``).
 
   * Name: "Release".
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ defusedxml==0.6.0
 jsonschema==3.2.0
 lxml==4.6.3
 marshmallow==2.19.5
-pydantic==1.6.1
+pydantic==1.6.2
 pyOpenSSL==18.0.0
 pytz==2019.3
 signxml==2.8.1

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,7 +1,7 @@
 # note: it is NOT mandatory to register all dependencies of the required packages.
 
 # Required packages:
-Django>=2.2.21,<3
+Django>=2.2.24,<3
 djangorestframework>=3.10.3,<3.13
 
 # Packages dependencies:

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,7 +1,7 @@
 # note: it is NOT mandatory to register all dependencies of the required packages.
 
 # Required packages:
-Django>=2.2.24,<3
+Django>=2.2.24
 djangorestframework>=3.10.3,<3.13
 
 # Packages dependencies:

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,7 +1,7 @@
 # note: it is NOT mandatory to register all dependencies of the required packages.
 
 # Required packages:
-Django>=2.2.18,<3
+Django>=2.2.21,<3
 djangorestframework>=3.10.3,<3.13
 
 # Packages dependencies:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -60,7 +60,7 @@ pyflakes==2.2.0
 # pyparsing
 # requests
 # six
-toml==0.10.1
+toml==0.10.2
 typed-ast==1.4.2
 typing-extensions==3.7.4.3
 # urllib3

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requirements = [
 ]
 
 extras_requirements = {
-    'django': ['Django>=2.2.24,<3'],
+    'django': ['Django>=2.2.24'],
     'djangorestframework': ['djangorestframework>=3.10.3,<3.13'],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requirements = [
 ]
 
 extras_requirements = {
-    'django': ['Django>=2.2.21,<3'],
+    'django': ['Django>=2.2.24,<3'],
     'djangorestframework': ['djangorestframework>=3.10.3,<3.13'],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
     'jsonschema>=3.1.1',
     'lxml>=4.5.0,<5',
     'marshmallow>=2.19.2,<3',
-    'pydantic>=1.6.1',
+    'pydantic>=1.6.2',
     # TODO: remove upper-bound after a new release of 'signxml' drops the requirement 'pyOpenSSL<20'
     'pyOpenSSL>=18.0.0,<20',
     'pytz>=2019.3',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requirements = [
 ]
 
 extras_requirements = {
-    'django': ['Django>=2.2.18,<3'],
+    'django': ['Django>=2.2.21,<3'],
     'djangorestframework': ['djangorestframework>=3.10.3,<3.13'],
 }
 


### PR DESCRIPTION
- (PR #213, 2021-04-21) build(deps): bump toml from 0.10.1 to 0.10.2
- (PR #216, 2021-04-22) docs: Add creation of release branch to instructions for new releases
- (PR #221, 2021-05-14) requirements: Upgrade Pydantic
- (PR #223, 2021-06-08) requirements: Upgrade 'Django'
- (PR #224, 2021-06-15) requirements: Upgrade 'Django'
- (PR #226, 2021-06-15) requirements: Remove Django upper bound constraint