### PR TITLE
dte: Convert stdlib dataclass `DteXmlData` into pydantic dataclass

### DIFF
--- a/cl_sii/dte/data_models.py
+++ b/cl_sii/dte/data_models.py
@@ -20,6 +20,8 @@ from dataclasses import field as dc_field
 from datetime import date, datetime
 from typing import Mapping, Optional
 
+import pydantic
+
 import cl_sii.contribuyente.constants
 import cl_sii.rut.constants
 from cl_sii.base.constants import SII_OFFICIAL_TZ
@@ -466,7 +468,12 @@ class DteDataL2(DteDataL1):
             monto_total=self.monto_total)
 
 
-@dataclasses.dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(
+    frozen=True,
+    config=type('Config', (), dict(
+        arbitrary_types_allowed=True,
+    ))
+)
 class DteXmlData(DteDataL1):
 
     """
@@ -495,32 +502,32 @@ class DteXmlData(DteDataL1):
     # fields
     ###########################################################################
 
-    emisor_razon_social: str = dc_field()
+    emisor_razon_social: str
     """
     "Razón social" (legal name) of the "emisor" of the DTE.
     """
 
-    receptor_razon_social: str = dc_field()
+    receptor_razon_social: str
     """
     "Razón social" (legal name) of the "receptor" of the DTE.
     """
 
-    fecha_vencimiento_date: Optional[date] = dc_field(default=None)
+    fecha_vencimiento_date: Optional[date] = None
     """
     "Fecha de vencimiento (pago)" of the DTE.
     """
 
-    firma_documento_dt: Optional[datetime] = dc_field(default=None)
+    firma_documento_dt: Optional[datetime] = None
     """
     Datetime on which the "documento" was digitally signed.
     """
 
-    signature_value: Optional[bytes] = dc_field(default=None)
+    signature_value: Optional[bytes] = None
     """
     DTE's digital signature's value (raw bytes, without base64 encoding).
     """
 
-    signature_x509_cert_der: Optional[bytes] = dc_field(default=None)
+    signature_x509_cert_der: Optional[bytes] = None
     """
     DTE's digital signature's DER-encoded X.509 cert.
 
@@ -529,78 +536,20 @@ class DteXmlData(DteDataL1):
         and :func:`cl_sii.libs.crypto_utils.x509_cert_der_to_pem`.
     """
 
-    emisor_giro: Optional[str] = dc_field(default=None)
+    emisor_giro: Optional[str] = None
     """
     "Giro" of the "emisor" of the DTE.
     """
 
-    emisor_email: Optional[str] = dc_field(default=None)
+    emisor_email: Optional[str] = None
     """
     Email address of the "emisor" of the DTE.
     """
 
-    receptor_email: Optional[str] = dc_field(default=None)
+    receptor_email: Optional[str] = None
     """
     Email address of the "receptor" of the DTE.
     """
-
-    def __post_init__(self) -> None:
-        """
-        Run validation automatically after setting the fields values.
-
-        :raises TypeError, ValueError:
-
-        """
-        super().__post_init__()
-
-        if not isinstance(self.emisor_razon_social, str):
-            raise TypeError("Inappropriate type of 'emisor_razon_social'.")
-        validate_contribuyente_razon_social(self.emisor_razon_social)
-
-        if not isinstance(self.receptor_razon_social, str):
-            raise TypeError("Inappropriate type of 'receptor_razon_social'.")
-        validate_contribuyente_razon_social(self.receptor_razon_social)
-
-        if self.fecha_vencimiento_date is not None:
-            if not isinstance(self.fecha_vencimiento_date, date):
-                raise TypeError("Inappropriate type of 'fecha_vencimiento_date'.")
-
-        if self.firma_documento_dt is not None:
-            if not isinstance(self.firma_documento_dt, datetime):
-                raise TypeError("Inappropriate type of 'firma_documento_dt'.")
-            tz_utils.validate_dt_tz(self.firma_documento_dt, self.DATETIME_FIELDS_TZ)
-
-        if self.signature_value is not None:
-            if not isinstance(self.signature_value, bytes):
-                raise TypeError("Inappropriate type of 'signature_value'.")
-            # warning: do NOT strip a bytes value because "strip" implies an ASCII-encoded text,
-            #   which in this case it is not.
-            validate_non_empty_bytes(self.signature_value)
-
-        if self.signature_x509_cert_der is not None:
-            if not isinstance(self.signature_x509_cert_der, bytes):
-                raise TypeError("Inappropriate type of 'signature_x509_cert_der'.")
-            # warning: do NOT strip a bytes value because "strip" implies an ASCII-encoded text,
-            #   which in this case it is not.
-            validate_non_empty_bytes(self.signature_x509_cert_der)
-
-        if self.emisor_giro is not None:
-            if not isinstance(self.emisor_giro, str):
-                raise TypeError("Inappropriate type of 'emisor_giro'.")
-            validate_clean_str(self.emisor_giro)
-            validate_non_empty_str(self.emisor_giro)
-
-        if self.emisor_email is not None:
-            if not isinstance(self.emisor_email, str):
-                raise TypeError("Inappropriate type of 'emisor_email'.")
-            validate_clean_str(self.emisor_email)
-            validate_non_empty_str(self.emisor_email)
-
-        if self.receptor_email is not None:
-            if not isinstance(self.receptor_email, str):
-                raise TypeError("Inappropriate type of 'receptor_email'.")
-            validate_clean_str(self.receptor_email)
-            validate_non_empty_str(self.receptor_email)
 
     def as_dte_data_l1(self) -> DteDataL1:
         return DteDataL1(
@@ -629,3 +578,37 @@ class DteXmlData(DteDataL1):
             emisor_email=self.emisor_email,
             receptor_email=self.receptor_email,
         )
+
+    ###########################################################################
+    # Validators
+    ###########################################################################
+
+    @pydantic.validator('emisor_razon_social', 'receptor_razon_social')
+    def validate_contribuyente_razon_social(cls, v: object) -> object:
+        if isinstance(v, str):
+            validate_contribuyente_razon_social(v)
+        return v
+
+    @pydantic.validator('firma_documento_dt')
+    def validate_datetime_tz(cls, v: object) -> object:
+        if isinstance(v, datetime):
+            tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
+        return v
+
+    @pydantic.validator('signature_value', 'signature_x509_cert_der')
+    def validate_non_empty_bytes(cls, v: object) -> object:
+        if isinstance(v, bytes):
+            validate_non_empty_bytes(v)
+        return v
+
+    @pydantic.validator('emisor_giro', 'emisor_email', 'receptor_email')
+    def validate_no_leading_or_trailing_whitespace_characters(cls, v: object) -> object:
+        if isinstance(v, str):
+            validate_clean_str(v)
+        return v
+
+    @pydantic.validator('emisor_giro', 'emisor_email', 'receptor_email')
+    def validate_non_empty_stripped_str(cls, v: object) -> object:
+        if isinstance(v, str):
+            validate_non_empty_str(v)
+        return v

--- a/tests/test_dte_data_models.py
+++ b/tests/test_dte_data_models.py
@@ -3,6 +3,8 @@ import dataclasses
 import unittest
 from datetime import date, datetime
 
+import pydantic
+
 from cl_sii.libs import encoding_utils
 from cl_sii.libs import tz_utils
 from cl_sii.rut import Rut  # noqa: F401
@@ -417,77 +419,303 @@ class DteXmlDataTest(unittest.TestCase):
             DteDataL2.DATETIME_FIELDS_TZ,
         )
 
-    def test_init_fail(self) -> None:
-        # TODO: implement for 'DteXmlData()'
-        pass
+    def test_validate_emisor_razon_social_empty(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('emisor_razon_social',),
+                'msg': "Value must not be empty.",
+                'type': 'value_error',
+            },
+        ]
 
-    def test_init_fail_razon_social_empty(self) -> None:
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 emisor_razon_social='',
             )
-        self.assertEqual(cm.exception.args, ("Value must not be empty.", ))
-        with self.assertRaises(ValueError) as cm:
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_receptor_razon_social_empty(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('receptor_razon_social',),
+                'msg': "Value must not be empty.",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 receptor_razon_social='',
             )
-        self.assertEqual(cm.exception.args, ("Value must not be empty.", ))
 
-    def test_init_fail_razon_social_none(self) -> None:
-        with self.assertRaises(TypeError) as cm:
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_emisor_razon_social_none(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('emisor_razon_social',),
+                'msg': "none is not an allowed value",
+                'type': 'type_error.none.not_allowed',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 emisor_razon_social=None,
             )
-        self.assertEqual(cm.exception.args, ("Inappropriate type of 'emisor_razon_social'.", ))
-        with self.assertRaises(TypeError) as cm:
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_receptor_razon_social_none(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('receptor_razon_social',),
+                'msg': "none is not an allowed value",
+                'type': 'type_error.none.not_allowed',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
             dataclasses.replace(
                 self.dte_xml_data_1,
                 receptor_razon_social=None,
             )
-        self.assertEqual(cm.exception.args, ("Inappropriate type of 'receptor_razon_social'.", ))
 
-    def test_init_fail_regression_signature_value_bytes_with_x20(self) -> None:
-        bytes_value_with_x20_as_base64 = 'IN2pkDBxqDnGl4Pfvboi'
-        bytes_value_with_x20 = b'\x20\xdd\xa9\x900q\xa89\xc6\x97\x83\xdf\xbd\xba"'
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
 
-        self.assertEqual(b'\x20', b' ')
-        self.assertEqual(
-            bytes_value_with_x20,
-            base64.b64decode(bytes_value_with_x20_as_base64, validate=True))
+    def test_validate_datetime_tz(self) -> None:
+        # Test TZ-awareness:
 
-        init_kwars = self.dte_xml_data_1.as_dict()
-        init_kwars.update(dict(signature_value=bytes_value_with_x20))
+        expected_validation_errors = [
+            {
+                'loc': ('firma_documento_dt',),
+                'msg': 'Value must be a timezone-aware datetime object.',
+                'type': 'value_error',
+            },
+        ]
 
-        # with self.assertRaises(ValueError) as cm:
-        #     _ = DteXmlData(**init_kwars)
-        # self.assertEqual(
-        #     cm.exception.args,
-        #     ('Value has leading or trailing whitespace characters.', bytes_value_with_x20)
-        # )
-        _ = DteXmlData(**init_kwars)
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.dte_xml_data_1,
+                firma_documento_dt=datetime(2019, 4, 5, 12, 57, 32),
+            )
 
-    def test_init_fail_regression_signature_cert_der_bytes_with_x20(self) -> None:
-        bytes_value_with_x20_as_base64 = 'IN2pkDBxqDnGl4Pfvboi'
-        bytes_value_with_x20 = b'\x20\xdd\xa9\x900q\xa89\xc6\x97\x83\xdf\xbd\xba"'
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
 
-        self.assertEqual(b'\x20', b' ')
-        self.assertEqual(
-            bytes_value_with_x20,
-            base64.b64decode(bytes_value_with_x20_as_base64, validate=True))
+        # Test TZ-value:
 
-        init_kwars = self.dte_xml_data_1.as_dict()
-        init_kwars.update(dict(signature_x509_cert_der=bytes_value_with_x20))
+        expected_validation_errors = [
+            {
+                'loc': ('firma_documento_dt',),
+                'msg':
+                    '('
+                    '''"Timezone of datetime value must be 'America/Santiago'.",'''
+                    ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
+                    ')',
+                'type': 'value_error',
+            },
+        ]
 
-        # with self.assertRaises(ValueError) as cm:
-        #     _ = DteXmlData(**init_kwars)
-        # self.assertEqual(
-        #     cm.exception.args,
-        #     ('Value has leading or trailing whitespace characters.', bytes_value_with_x20)
-        # )
-        _ = DteXmlData(**init_kwars)
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.dte_xml_data_1,
+                firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                    dt=datetime(2019, 4, 5, 12, 57, 32),
+                    tz=tz_utils.TZ_UTC,
+                ),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_non_empty_bytes_signature_value(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('signature_value',),
+                'msg': 'Bytes value length is 0.',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.dte_xml_data_1,
+                signature_value=b'',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_non_empty_bytes_signature_x509_cert_der(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('signature_x509_cert_der',),
+                'msg': 'Bytes value length is 0.',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.dte_xml_data_1,
+                signature_x509_cert_der=b'',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_no_leading_or_trailing_whitespace_characters_emisor_giro(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('emisor_giro',),
+                'msg': "('Value has leading or trailing whitespace characters.', ' NASA ')",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.dte_xml_data_1,
+                emisor_giro=' NASA ',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_no_leading_or_trailing_whitespace_characters_emisor_email(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('emisor_email',),
+                'msg':
+                    "("
+                    "'Value has leading or trailing whitespace characters.', "
+                    "' fake_emisor_email@test.cl '"
+                    ")",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.dte_xml_data_1,
+                emisor_email=' fake_emisor_email@test.cl ',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_no_leading_or_trailing_whitespace_characters_receptor_email(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('receptor_email',),
+                'msg':
+                    "("
+                    "'Value has leading or trailing whitespace characters.', "
+                    "' fake_receptor_email@test.cl '"
+                    ")",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.dte_xml_data_1,
+                receptor_email=' fake_receptor_email@test.cl ',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_non_empty_stripped_str_emisor_giro(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('emisor_giro',),
+                'msg': "String value length (stripped) is 0.",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.dte_xml_data_1,
+                emisor_giro='',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_non_empty_stripped_str_emisor_email(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('emisor_email',),
+                'msg': "String value length (stripped) is 0.",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.dte_xml_data_1,
+                emisor_email='',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_non_empty_stripped_str_receptor_email(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('receptor_email',),
+                'msg': "String value length (stripped) is 0.",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.dte_xml_data_1,
+                receptor_email='',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
 
     def test_as_dict(self) -> None:
         self.assertDictEqual(


### PR DESCRIPTION
- Remove uses of `dataclasses.field` (see comment https://github.com/fyntex/lib-cl-sii-python/pull/218/commits/b7b9854e8de7455f6cc0649ad7b0014a7c948e17#r627092839 by @jtrobles-cdd )
- Refactor validations performed in `__post_init__` as Pydantic validators
- Update tests

Resolves: #229
Ref: https://cordada.aha.io/features/COMPCLDATA-1