### PR TITLE
rut: Fix RUT clean method to accept '0-0' value

### DIFF
--- a/cl_sii/rut/__init__.py
+++ b/cl_sii/rut/__init__.py
@@ -11,6 +11,7 @@ RUT "canonical format": no dots ('.'), with dash ('-'), uppercase K e.g.
 """
 import itertools
 import random
+import re
 
 from . import constants
 
@@ -144,7 +145,10 @@ class Rut:
     def clean_str(cls, value: str) -> str:
         # note: unfortunately `value.strip('.')` does not remove all the occurrences of '.' in
         #   'value' (only the leading and trailing ones).
-        return value.strip().lstrip('0').replace('.', '').upper()
+        clean_value = value.strip().replace('.', '').upper()
+        # Remove leading zeros except if zero is the only digit, so we can accept the RUT '0-0'.
+        leading_zero_free_value = re.sub(r'^0+(\d+)', r'\1', clean_value)
+        return leading_zero_free_value
 
     @classmethod
     def calc_dv(cls, rut_digits: str) -> str:

--- a/tests/test_rut.py
+++ b/tests/test_rut.py
@@ -12,6 +12,8 @@ class RutTest(unittest.TestCase):
     valid_rut_digits_with_dots: str
     valid_rut_verbose: str
     valid_rut_leading_zero: str
+    valid_rut_zero_zero: str
+    valid_rut_zero_zero_dv: str
 
     invalid_rut_canonical: str
     invalid_rut_dv: str
@@ -34,6 +36,8 @@ class RutTest(unittest.TestCase):
         cls.valid_rut_digits_with_dots = '6.824.160'
         cls.valid_rut_verbose = '6.824.160-K'
         cls.valid_rut_leading_zero = '06824160-K'
+        cls.valid_rut_zero_zero = '0-0'
+        cls.valid_rut_zero_zero_dv = '0'
 
         cls.invalid_rut_canonical = '6824160-0'
         cls.invalid_rut_dv = '0'
@@ -290,6 +294,26 @@ class RutTest(unittest.TestCase):
         rut_value = f'00000000{self.valid_rut_canonical}'
         clean_rut = rut.Rut.clean_str(rut_value)
         self.assertEqual(clean_rut, self.valid_rut_canonical)
+
+        # RUT 0-0
+        rut_value = self.valid_rut_zero_zero
+        clean_rut = rut.Rut.clean_str(rut_value)
+        self.assertEqual(clean_rut, self.valid_rut_zero_zero)
+
+        # RUT 0-0 with one extra leading zero
+        rut_value = f'0{self.valid_rut_zero_zero}'
+        clean_rut = rut.Rut.clean_str(rut_value)
+        self.assertEqual(clean_rut, self.valid_rut_zero_zero)
+
+        # RUT 0-0 with two extra leading zero
+        rut_value = f'00{self.valid_rut_zero_zero}'
+        clean_rut = rut.Rut.clean_str(rut_value)
+        self.assertEqual(clean_rut, self.valid_rut_zero_zero)
+
+        # RUT 0-0 with eight extra leading zero
+        rut_value = f'00000000{self.valid_rut_zero_zero}'
+        clean_rut = rut.Rut.clean_str(rut_value)
+        self.assertEqual(clean_rut, self.valid_rut_zero_zero)
 
     def test_calc_dv_ok(self) -> None:
         dv = rut.Rut.calc_dv(self.valid_rut_digits)


### PR DESCRIPTION
`0-0` is a syntactically valid RUT, but it is ignored because every time the `Rut.clean` method is executed, all the leading zeros are removed indiscriminately. These changes adjust the `Rut.clean` method to removes leading zeros except if zero is the only digit, so we can accept the RUT '0-0'.

Ref: https://cordada.aha.io/features/PLATCORE-232