### PR TITLE
rtc.data_models_aec: Remove min str length restriction in Config class

### DIFF
--- a/cl_sii/rtc/data_models_aec.py
+++ b/cl_sii/rtc/data_models_aec.py
@@ -24,7 +24,6 @@ from . import data_models
     config=type('Config', (), dict(
         anystr_strip_whitespace=True,
         arbitrary_types_allowed=True,
-        min_anystr_length=1,
     ))
 )
 class CesionAecXml:
@@ -178,13 +177,21 @@ class CesionAecXml:
     """
     "Persona Autorizada" by the "cedente" to "Firmar la Transferencia" (name).
 
-    .. note:: It might be the "cedente" itself, a "persona natural", etc.
+    .. note:: It might be the "cedente" itself, a "persona natural", etc. There is a
+    contradiction regarding the element ``Nombre de la persona autorizada`` about what
+    the technical documentation states and how it was implemented in the XML schema.
+    Although the former defines the field as required, the XML schema does not set a
+    minimum required length, so the field can be empty.
 
     First of the
     > Lista de Personas Autorizadas por el Cedente a Firmar la Transferencia
 
     AEC doc XML element (1..3 occurrences of 'RUTAutorizado'):
         '..//Cesion//DocumentoCesion//Cedente//RUTAutorizado//Nombre'
+
+    .. seealso::
+        https://github.com/cl-sii-extraoficial/archivos-oficiales/blob/master/src/docs/rtc/2013-02-11-formato-archivo-electronico-cesion.pdf
+        https://github.com/cl-sii-extraoficial/archivos-oficiales/blob/99b15aff252836e1ac311d243636aa3a9e6b89c6/src/code/rtc/2019-12-12-schema_cesion/schema_cesion/SiiTypes_v10.xsd#L682-L689
     """
 
     cesionario_razon_social: str

--- a/cl_sii/rtc/parse_aec.py
+++ b/cl_sii/rtc/parse_aec.py
@@ -221,7 +221,6 @@ class _RutAutorizado(pydantic.BaseModel):
         anystr_strip_whitespace = True
         arbitrary_types_allowed = True
         extra = pydantic.Extra.forbid
-        min_anystr_length = 1
 
     ###########################################################################
     # Fields

--- a/tests/test_rtc_data_models_aec.py
+++ b/tests/test_rtc_data_models_aec.py
@@ -168,6 +168,19 @@ class CesionAecXmlTest(unittest.TestCase):
         )
         self.assertEqual(obj.alt_natural_key, expected_output)
 
+    def test_is_ok_empty_cedente_persona_autorizada_nombre(self) -> None:
+        self._set_obj_1()
+
+        obj = self.obj_1
+
+        try:
+            dataclasses.replace(
+                obj,
+                cedente_persona_autorizada_nombre='',
+            )
+        except pydantic.ValidationError as exc:
+            self.fail(f'{exc.__class__.__name__} raised')
+
     def test_as_cesion_l2(self) -> None:
         self._set_obj_1()
 


### PR DESCRIPTION
There is a contradiction regarding the element ``Nombre de la persona autorizada`` about what the technical documentation states and how it was implemented in the XML schema. Although the former defines the field as required, the XML schema does not set a minimum required length, so the field can be empty. That is why we should use individual settings for each field instead of controlling through the Config class.

Ref. FORMATO ARCHIVO ELECTRÓNICO DE CESIÓN
Source: (https://github.com/cl-sii-extraoficial/archivos-oficiales/blob/master/src/docs/rtc/2013-02-11-formato-archivo-electronico-cesion.pdf)