### PR TITLE
rtc: Make AEC field 'nombre persona autorizada cedente' optional

### DIFF
--- a/cl_sii/rtc/data_models_aec.py
+++ b/cl_sii/rtc/data_models_aec.py
@@ -174,17 +174,25 @@ class CesionAecXml:
         '..//Cesion//DocumentoCesion//Cedente//RUTAutorizado//RUT'
     """
 
-    cedente_persona_autorizada_nombre: str
+    cedente_persona_autorizada_nombre: Optional[str]
     """
     "Persona Autorizada" by the "cedente" to "Firmar la Transferencia" (name).
 
-    .. note:: It might be the "cedente" itself, a "persona natural", etc.
+    .. note:: It might be the "cedente" itself, a "persona natural", etc. There is a
+    contradiction regarding the element ``Nombre de la persona autorizada`` about what
+    the technical documentation states and how it was implemented in the XML schema.
+    Although the former defines the field as required, the XML schema does not set a
+    minimum required length, so the field can be empty.
 
     First of the
     > Lista de Personas Autorizadas por el Cedente a Firmar la Transferencia
 
     AEC doc XML element (1..3 occurrences of 'RUTAutorizado'):
         '..//Cesion//DocumentoCesion//Cedente//RUTAutorizado//Nombre'
+
+    .. seealso::
+        https://github.com/cl-sii-extraoficial/archivos-oficiales/blob/99b15aff252836e1ac311d243636aa3a9e6b89c6/src/docs/rtc/2013-02-11-formato-archivo-electronico-cesion.pdf
+        https://github.com/cl-sii-extraoficial/archivos-oficiales/blob/99b15aff252836e1ac311d243636aa3a9e6b89c6/src/code/rtc/2019-12-12-schema_cesion/schema_cesion/SiiTypes_v10.xsd#L682-L689
     """
 
     cesionario_razon_social: str

--- a/cl_sii/rtc/parse_aec.py
+++ b/cl_sii/rtc/parse_aec.py
@@ -238,7 +238,7 @@ class _RutAutorizado(pydantic.BaseModel):
     ###########################################################################
 
     rut: Rut
-    nombre: str
+    nombre: Optional[str]
 
     ###########################################################################
     # Custom Methods
@@ -258,6 +258,10 @@ class _RutAutorizado(pydantic.BaseModel):
     ###########################################################################
     # Validators
     ###########################################################################
+
+    _empty_str_to_none = pydantic.validator(  # type: ignore[pydantic-field]
+        'nombre', pre=True, allow_reuse=True,
+    )(_empty_str_to_none)
 
     _validate_rut = pydantic.validator(  # type: ignore[pydantic-field]
         'rut', pre=True, allow_reuse=True,

--- a/cl_sii/rtc/parse_aec.py
+++ b/cl_sii/rtc/parse_aec.py
@@ -84,6 +84,16 @@ def parse_aec_xml(xml_doc: XmlElement) -> data_models_aec.AecXml:
 # Parser Functions and Models
 ###############################################################################
 
+def _empty_str_to_none(v: object) -> object:
+    """
+    Reusable Pydantic validator that converts empty strings to ``None``.
+    """
+    if isinstance(v, str):
+        if not v.strip():
+            v = None
+    return v
+
+
 def _validate_rut(v: object) -> object:
     """
     Reusable Pydantic validator for fields of type :class:`Rut`.


### PR DESCRIPTION
- There is a contradiction regarding the element `Nombre de la persona autorizada` about what the technical documentation states and how it was implemented in the XML schema. Although the former defines the field as required, the XML schema does not set a minimum required length, so the field can be empty.
- Add validator to parser `.parse_aec._RutAutorizado` that converts empty strings in its `nombre` attribute to `None`.
- Make field `.parse_aec._RutAutorizado.nombre` optional.
- Make field `.data_models_aec.CesionAecXml.cedente_persona_autorizada_nombre` optional.
- Add reusable Pydantic validator that converts empty strings to `None`.

Ref: [FORMATO ARCHIVO ELECTRÓNICO DE CESIÓN](https://github.com/cl-sii-extraoficial/archivos-oficiales/blob/99b15aff252836e1ac311d243636aa3a9e6b89c6/src/docs/rtc/2013-02-11-formato-archivo-electronico-cesion.pdf)

Note: The reusable Pydantic validator will be useful for fixing https://github.com/fyntex/fd-cl-data/issues/744.

Replaces: https://github.com/fyntex/lib-cl-sii-python/pull/240