### PR TITLE
rtc.parse_aec: Convert to `None` the empty optional values in the Caratula

### DIFF
--- a/cl_sii/rtc/parse_aec.py
+++ b/cl_sii/rtc/parse_aec.py
@@ -733,6 +733,10 @@ class _Caratula(pydantic.BaseModel):
     # Validators
     ###########################################################################
 
+    _empty_str_to_none = pydantic.validator(  # type: ignore[pydantic-field]
+        'nmb_contacto', 'fono_contacto', 'mail_contacto', pre=True, allow_reuse=True,
+    )(_empty_str_to_none)
+
     _validate_rut_cedente = pydantic.validator(  # type: ignore[pydantic-field]
         'rut_cedente', pre=True, allow_reuse=True,
     )(_validate_rut)


### PR DESCRIPTION
- All the contact information elements included in the 'Caratula' of the AEC are optional, but sometimes the elements are added to the XML as empty tags which are parsed as empty strings. These changes replace those empty strings with `None`
- Contact information elements: 'NmbContacto', 'FonoContacto', 'MailContacto'.

Ref: https://cordada.aha.io/features/COMPCLDATA-8
Ref: [FORMATO ARCHIVO ELECTRÓNICO DE CESIÓN](https://github.com/cl-sii-extraoficial/archivos-oficiales/blob/99b15aff252836e1ac311d243636aa3a9e6b89c6/src/docs/rtc/2013-02-11-formato-archivo-electronico-cesion.pdf)
Fixes: https://github.com/fyntex/fd-cl-data/issues/744