### PR TITLE
rcv: Convert stdlib dataclasses into pydantic dataclasses

### DIFF
--- a/cl_sii/rcv/data_models.py
+++ b/cl_sii/rcv/data_models.py
@@ -288,7 +288,12 @@ class RcRegistroDetalleEntry(RcvDetalleEntry):
             tz_utils.validate_dt_tz(self.fecha_acuse_dt, SII_OFFICIAL_TZ)
 
 
-@dataclasses.dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(
+    frozen=True,
+    config=type('Config', (), dict(
+        arbitrary_types_allowed=True,
+    ))
+)
 class RcNoIncluirDetalleEntry(RcRegistroDetalleEntry):
 
     """

--- a/cl_sii/rcv/data_models.py
+++ b/cl_sii/rcv/data_models.py
@@ -216,44 +216,54 @@ class RcvDetalleEntry:
         return dte_data
 
 
-@dataclasses.dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(
+    frozen=True,
+    config=type('Config', (), dict(
+        arbitrary_types_allowed=True,
+    ))
+)
 class RvDetalleEntry(RcvDetalleEntry):
 
     """
     Entry of the "detalle" of an RV ("Registro de Ventas").
     """
 
+    ###########################################################################
+    # constants
+    ###########################################################################
+
+    DATETIME_FIELDS_TZ = SII_OFFICIAL_TZ
+
     RCV_KIND = RcvKind.VENTAS
     RC_ESTADO_CONTABLE = None
 
     # TODO: docstring
     # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
-    receptor_razon_social: str = dc_field()
+    receptor_razon_social: str
 
     # TODO: docstring
     # note: must be timezone-aware.
-    fecha_acuse_dt: Optional[datetime] = dc_field()
+    fecha_acuse_dt: Optional[datetime]
 
     # TODO: docstring
     # note: must be timezone-aware.
-    fecha_reclamo_dt: Optional[datetime] = dc_field()
+    fecha_reclamo_dt: Optional[datetime]
 
-    def __post_init__(self) -> None:
-        super().__post_init__()
+    ###########################################################################
+    # Validators
+    ###########################################################################
 
-        if not isinstance(self.receptor_razon_social, str):
-            raise TypeError("Inappropriate type of 'receptor_razon_social'.")
-        cl_sii.dte.data_models.validate_contribuyente_razon_social(self.receptor_razon_social)
+    @pydantic.validator('receptor_razon_social')
+    def validate_contribuyente_razon_social(cls, v: object) -> object:
+        if isinstance(v, str):
+            cl_sii.dte.data_models.validate_contribuyente_razon_social(v)
+        return v
 
-        if self.fecha_acuse_dt is not None:
-            if not isinstance(self.fecha_acuse_dt, datetime):
-                raise TypeError("Inappropriate type of 'fecha_acuse_dt'.")
-            tz_utils.validate_dt_tz(self.fecha_acuse_dt, SII_OFFICIAL_TZ)
-
-        if self.fecha_reclamo_dt is not None:
-            if not isinstance(self.fecha_reclamo_dt, datetime):
-                raise TypeError("Inappropriate type of 'fecha_reclamo_dt'.")
-            tz_utils.validate_dt_tz(self.fecha_reclamo_dt, SII_OFFICIAL_TZ)
+    @pydantic.validator('fecha_acuse_dt', 'fecha_reclamo_dt')
+    def validate_datetime_tz(cls, v: object) -> object:
+        if isinstance(v, datetime):
+            tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
+        return v
 
 
 @pydantic.dataclasses.dataclass(

--- a/cl_sii/rcv/data_models.py
+++ b/cl_sii/rcv/data_models.py
@@ -299,36 +299,55 @@ class RcNoIncluirDetalleEntry(RcRegistroDetalleEntry):
     RC_ESTADO_CONTABLE = RcEstadoContable.NO_INCLUIR
 
 
-@dataclasses.dataclass(frozen=True)
+@pydantic.dataclasses.dataclass(
+    frozen=True,
+    config=type('Config', (), dict(
+        arbitrary_types_allowed=True,
+    ))
+)
 class RcReclamadoDetalleEntry(RcvDetalleEntry):
 
     """
     Entry of the "detalle" of an RC ("Registro de Compras") / "reclamado".
     """
 
+    ###########################################################################
+    # constants
+    ###########################################################################
+
+    DATETIME_FIELDS_TZ = SII_OFFICIAL_TZ
+
+    ###########################################################################
+    # fields
+    ###########################################################################
+
     RCV_KIND = RcvKind.COMPRAS
     RC_ESTADO_CONTABLE = RcEstadoContable.RECLAMADO
 
-    emisor_razon_social: str = dc_field()
+    emisor_razon_social: str
     """
     "Razón social" (legal name) of the "emisor" of the "documento".
     """
 
     # TODO: docstring
     # note: must be timezone-aware.
-    fecha_reclamo_dt: Optional[datetime] = dc_field()
+    fecha_reclamo_dt: Optional[datetime]
 
-    def __post_init__(self) -> None:
-        super().__post_init__()
+    ###########################################################################
+    # Validators
+    ###########################################################################
 
-        if not isinstance(self.emisor_razon_social, str):
-            raise TypeError("Inappropriate type of 'emisor_razon_social'.")
-        cl_sii.dte.data_models.validate_contribuyente_razon_social(self.emisor_razon_social)
+    @pydantic.validator('emisor_razon_social')
+    def validate_contribuyente_razon_social(cls, v: object) -> object:
+        if isinstance(v, str):
+            cl_sii.dte.data_models.validate_contribuyente_razon_social(v)
+        return v
 
-        if self.fecha_reclamo_dt is not None:
-            if not isinstance(self.fecha_reclamo_dt, datetime):
-                raise TypeError("Inappropriate type of 'fecha_reclamo_dt'.")
-            tz_utils.validate_dt_tz(self.fecha_reclamo_dt, SII_OFFICIAL_TZ)
+    @pydantic.validator('fecha_reclamo_dt')
+    def validate_datetime_tz(cls, v: object) -> object:
+        if isinstance(v, datetime):
+            tz_utils.validate_dt_tz(v, cls.DATETIME_FIELDS_TZ)
+        return v
 
 
 @pydantic.dataclasses.dataclass(

--- a/tests/test_rcv_data_models.py
+++ b/tests/test_rcv_data_models.py
@@ -1,0 +1,50 @@
+import dataclasses
+import unittest
+from datetime import date, datetime
+
+import pydantic
+
+from cl_sii.base.constants import SII_OFFICIAL_TZ
+from cl_sii.libs import tz_utils
+from cl_sii.rcv.constants import RcvTipoDocto
+from cl_sii.rcv.data_models import RcPendienteDetalleEntry
+from cl_sii.rut import Rut
+
+
+class RcPendienteDetalleEntryTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.rc_pendiente_detalle_entry_1 = RcPendienteDetalleEntry(
+            emisor_rut=Rut('76354771-K'),
+            tipo_docto=RcvTipoDocto.FACTURA_ELECTRONICA,
+            folio=170,
+            fecha_emision_date=date(2019, 4, 1),
+            receptor_rut=Rut('96790240-3'),
+            monto_total=2996301,
+            emisor_razon_social='INGENIERIA ENACON SPA',
+            fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 1, 1, 36, 40),
+                tz=SII_OFFICIAL_TZ),
+        )
+
+    def test_validate_emisor_razon_social_empty(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('emisor_razon_social',),
+                'msg': "Value must not be empty.",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rc_pendiente_detalle_entry_1,
+                emisor_razon_social='',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)

--- a/tests/test_rcv_data_models.py
+++ b/tests/test_rcv_data_models.py
@@ -7,8 +7,100 @@ import pydantic
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.libs import tz_utils
 from cl_sii.rcv.constants import RcvTipoDocto
-from cl_sii.rcv.data_models import RcPendienteDetalleEntry
+from cl_sii.rcv.data_models import RcPendienteDetalleEntry, RcReclamadoDetalleEntry
 from cl_sii.rut import Rut
+
+
+class RcReclamadoDetalleEntryTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.rc_reclamado_detalle_entry_1 = RcReclamadoDetalleEntry(
+            emisor_rut=Rut('76354771-K'),
+            tipo_docto=RcvTipoDocto.FACTURA_ELECTRONICA,
+            folio=170,
+            fecha_emision_date=date(2019, 4, 1),
+            receptor_rut=Rut('96790240-3'),
+            monto_total=2996301,
+            emisor_razon_social='INGENIERIA ENACON SPA',
+            fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 1, 1, 36, 40),
+                tz=RcReclamadoDetalleEntry.DATETIME_FIELDS_TZ),
+            fecha_reclamo_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 8, 10, 21, 18),
+                tz=RcReclamadoDetalleEntry.DATETIME_FIELDS_TZ),
+        )
+
+    def test_validate_emisor_razon_social_empty(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('emisor_razon_social',),
+                'msg': "Value must not be empty.",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rc_reclamado_detalle_entry_1,
+                emisor_razon_social='',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_datetime_tz(self) -> None:
+        # Test TZ-awareness:
+
+        expected_validation_errors = [
+            {
+                'loc': ('fecha_reclamo_dt',),
+                'msg': 'Value must be a timezone-aware datetime object.',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rc_reclamado_detalle_entry_1,
+                fecha_reclamo_dt=datetime(2019, 4, 5, 12, 57, 32),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+        # Test TZ-value:
+
+        expected_validation_errors = [
+            {
+                'loc': ('fecha_reclamo_dt',),
+                'msg':
+                    '('
+                    '''"Timezone of datetime value must be 'America/Santiago'.",'''
+                    ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
+                    ')',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rc_reclamado_detalle_entry_1,
+                fecha_reclamo_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                    dt=datetime(2019, 4, 5, 12, 57, 32),
+                    tz=tz_utils.TZ_UTC,
+                ),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
 
 
 class RcPendienteDetalleEntryTest(unittest.TestCase):

--- a/tests/test_rcv_data_models.py
+++ b/tests/test_rcv_data_models.py
@@ -11,9 +11,156 @@ from cl_sii.rcv.data_models import (
     RcNoIncluirDetalleEntry,
     RcPendienteDetalleEntry,
     RcReclamadoDetalleEntry,
-    RcRegistroDetalleEntry
+    RcRegistroDetalleEntry,
+    RvDetalleEntry
 )
 from cl_sii.rut import Rut
+
+
+class RvDetalleEntryTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.rv_detalle_entry_1 = RvDetalleEntry(
+            emisor_rut=Rut('76354771-K'),
+            tipo_docto=RcvTipoDocto.FACTURA_ELECTRONICA,
+            folio=170,
+            fecha_emision_date=date(2019, 4, 1),
+            receptor_rut=Rut('96790240-3'),
+            monto_total=2996301,
+            receptor_razon_social='MINERA LOS PELAMBRES',
+            fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 1, 1, 36, 40),
+                tz=RvDetalleEntry.DATETIME_FIELDS_TZ),
+            fecha_acuse_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 8, 10, 21, 18),
+                tz=RvDetalleEntry.DATETIME_FIELDS_TZ),
+            fecha_reclamo_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 8, 10, 21, 18),
+                tz=RvDetalleEntry.DATETIME_FIELDS_TZ),
+        )
+
+    def test_validate_receptor_razon_social_empty(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('receptor_razon_social',),
+                'msg': "Value must not be empty.",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rv_detalle_entry_1,
+                receptor_razon_social='',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_datetime_tz(self) -> None:
+        # fecha_acuse_dt
+        # Test TZ-awareness:
+
+        expected_validation_errors = [
+            {
+                'loc': ('fecha_acuse_dt',),
+                'msg': 'Value must be a timezone-aware datetime object.',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rv_detalle_entry_1,
+                fecha_acuse_dt=datetime(2019, 4, 5, 12, 57, 32),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+        # Test TZ-value:
+
+        expected_validation_errors = [
+            {
+                'loc': ('fecha_acuse_dt',),
+                'msg':
+                    '('
+                    '''"Timezone of datetime value must be 'America/Santiago'.",'''
+                    ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
+                    ')',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rv_detalle_entry_1,
+                fecha_acuse_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                    dt=datetime(2019, 4, 5, 12, 57, 32),
+                    tz=tz_utils.TZ_UTC,
+                ),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+        # fecha_reclamo_dt
+        # Test TZ-awareness:
+
+        expected_validation_errors = [
+            {
+                'loc': ('fecha_reclamo_dt',),
+                'msg': 'Value must be a timezone-aware datetime object.',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rv_detalle_entry_1,
+                fecha_reclamo_dt=datetime(2019, 4, 5, 12, 57, 32),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+        # Test TZ-value:
+
+        expected_validation_errors = [
+            {
+                'loc': ('fecha_reclamo_dt',),
+                'msg':
+                    '('
+                    '''"Timezone of datetime value must be 'America/Santiago'.",'''
+                    ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
+                    ')',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rv_detalle_entry_1,
+                fecha_reclamo_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                    dt=datetime(2019, 4, 5, 12, 57, 32),
+                    tz=tz_utils.TZ_UTC,
+                ),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
 
 
 class RcRegistroDetalleEntryTest(unittest.TestCase):

--- a/tests/test_rcv_data_models.py
+++ b/tests/test_rcv_data_models.py
@@ -10,9 +10,102 @@ from cl_sii.rcv.constants import RcvTipoDocto
 from cl_sii.rcv.data_models import (
     RcNoIncluirDetalleEntry,
     RcPendienteDetalleEntry,
-    RcReclamadoDetalleEntry
+    RcReclamadoDetalleEntry,
+    RcRegistroDetalleEntry
 )
 from cl_sii.rut import Rut
+
+
+class RcRegistroDetalleEntryTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.rc_registro_detalle_entry_1 = RcRegistroDetalleEntry(
+            emisor_rut=Rut('76354771-K'),
+            tipo_docto=RcvTipoDocto.FACTURA_ELECTRONICA,
+            folio=170,
+            fecha_emision_date=date(2019, 4, 1),
+            receptor_rut=Rut('96790240-3'),
+            monto_total=2996301,
+            emisor_razon_social='INGENIERIA ENACON SPA',
+            fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 1, 1, 36, 40),
+                tz=RcRegistroDetalleEntry.DATETIME_FIELDS_TZ),
+            fecha_acuse_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 8, 10, 21, 18),
+                tz=RcRegistroDetalleEntry.DATETIME_FIELDS_TZ),
+        )
+
+    def test_validate_emisor_razon_social_empty(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('emisor_razon_social',),
+                'msg': "Value must not be empty.",
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rc_registro_detalle_entry_1,
+                emisor_razon_social='',
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_datetime_tz(self) -> None:
+        # Test TZ-awareness:
+
+        expected_validation_errors = [
+            {
+                'loc': ('fecha_acuse_dt',),
+                'msg': 'Value must be a timezone-aware datetime object.',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rc_registro_detalle_entry_1,
+                fecha_acuse_dt=datetime(2019, 4, 5, 12, 57, 32),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+        # Test TZ-value:
+
+        expected_validation_errors = [
+            {
+                'loc': ('fecha_acuse_dt',),
+                'msg':
+                    '('
+                    '''"Timezone of datetime value must be 'America/Santiago'.",'''
+                    ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
+                    ')',
+                'type': 'value_error',
+            },
+        ]
+
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.rc_registro_detalle_entry_1,
+                fecha_acuse_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                    dt=datetime(2019, 4, 5, 12, 57, 32),
+                    tz=tz_utils.TZ_UTC,
+                ),
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
 
 
 class RcNoIncluirDetalleEntryTest(unittest.TestCase):

--- a/tests/test_rcv_data_models.py
+++ b/tests/test_rcv_data_models.py
@@ -7,8 +7,34 @@ import pydantic
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.libs import tz_utils
 from cl_sii.rcv.constants import RcvTipoDocto
-from cl_sii.rcv.data_models import RcPendienteDetalleEntry, RcReclamadoDetalleEntry
+from cl_sii.rcv.data_models import (
+    RcNoIncluirDetalleEntry,
+    RcPendienteDetalleEntry,
+    RcReclamadoDetalleEntry
+)
 from cl_sii.rut import Rut
+
+
+class RcNoIncluirDetalleEntryTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.rc_no_incluir_detalle_entry_1 = RcNoIncluirDetalleEntry(
+            emisor_rut=Rut('76354771-K'),
+            tipo_docto=RcvTipoDocto.FACTURA_ELECTRONICA,
+            folio=170,
+            fecha_emision_date=date(2019, 4, 1),
+            receptor_rut=Rut('96790240-3'),
+            monto_total=2996301,
+            emisor_razon_social='INGENIERIA ENACON SPA',
+            fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 1, 1, 36, 40),
+                tz=SII_OFFICIAL_TZ),
+            fecha_acuse_dt=tz_utils.convert_naive_dt_to_tz_aware(
+                dt=datetime(2019, 4, 8, 10, 21, 18),
+                tz=SII_OFFICIAL_TZ),
+        )
 
 
 class RcReclamadoDetalleEntryTest(unittest.TestCase):

--- a/tests/test_rcv_data_models.py
+++ b/tests/test_rcv_data_models.py
@@ -9,6 +9,7 @@ from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.libs import tz_utils
 from cl_sii.rcv.constants import RcvTipoDocto
 from cl_sii.rcv.data_models import (
+    PeriodoTributario,
     RcNoIncluirDetalleEntry,
     RcPendienteDetalleEntry,
     RcReclamadoDetalleEntry,
@@ -17,6 +18,71 @@ from cl_sii.rcv.data_models import (
     RvDetalleEntry
 )
 from cl_sii.rut import Rut
+
+
+class PeriodoTributarioTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.periodo_tributario_1 = PeriodoTributario(
+            year=2019,
+            month=4
+        )
+
+    def test_validate_year_range(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('year',),
+                'msg': "Value is out of the valid range for 'year'.",
+                'type': 'value_error',
+            },
+        ]
+
+        # Validate the minimum value of the field year
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.periodo_tributario_1,
+                year=1899,
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+    def test_validate_month_range(self) -> None:
+        expected_validation_errors = [
+            {
+                'loc': ('month',),
+                'msg': "Value is out of the valid range for 'month'.",
+                'type': 'value_error',
+            },
+        ]
+
+        # Validate the minimum value of the field month
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.periodo_tributario_1,
+                month=0,
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
+
+        # Validate the maximum value of the field month
+        with self.assertRaises(pydantic.ValidationError) as assert_raises_cm:
+            dataclasses.replace(
+                self.periodo_tributario_1,
+                month=13,
+            )
+
+        validation_errors = assert_raises_cm.exception.errors()
+        self.assertEqual(len(validation_errors), len(expected_validation_errors))
+        for expected_validation_error in expected_validation_errors:
+            self.assertIn(expected_validation_error, validation_errors)
 
 
 class RcvDetalleEntryTest(unittest.TestCase):


### PR DESCRIPTION
- Remove uses of `dataclasses.field` (see comment https://github.com/fyntex/lib-cl-sii-python/pull/218/commits/b7b9854e8de7455f6cc0649ad7b0014a7c948e17#r627092839 by @jtrobles-cdd )
- Refactor validations performed in `__post_init__` as Pydantic validators
- Add tests

Resolves: #235
Ref: https://cordada.aha.io/features/COMPCLDATA-4