### PR TITLE
chore: Increase lxml lower bound constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requirements = [
     'cryptography>=2.8,<4',
     'defusedxml>=0.6.0,<1',
     'jsonschema>=3.1.1',
-    'lxml>=4.5.0,<5',
+    'lxml>=4.6.5,<5',
     'marshmallow>=2.19.2,<3',
     'pydantic>=1.6.2',
     # TODO: remove upper-bound after a new release of 'signxml' drops the requirement 'pyOpenSSL<20'


### PR DESCRIPTION
Require the lxml version 4.6.5 or later to avoid vulnerability GHSA-55x5-fj6c-h6m8

Vulnerability: https://github.com/lxml/lxml/security/advisories/GHSA-55x5-fj6c-h6m8
Vulnerable versions: < 4.6.5
Ref: https://github.com/fyntex/lib-cl-sii-python/pull/255