### PR TITLE
Release v0.15.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.1
+current_version = 0.15.2
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+0.15.2 (2021-12-23)
++++++++++++++++++++++++
+
+* (PR #258, 2021-12-22) chore: Increase lxml lower bound constraint
+* (PR #259, 2021-12-23) requirements: Update 'signxml'
+
 0.15.1 (2021-12-21)
 +++++++++++++++++++++++
 

--- a/cl_sii/__init__.py
+++ b/cl_sii/__init__.py
@@ -5,4 +5,4 @@ cl-sii Python lib
 """
 
 
-__version__ = '0.15.1'
+__version__ = '0.15.2'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ marshmallow==2.19.5
 pydantic==1.6.2
 pyOpenSSL==18.0.0
 pytz==2019.3
-signxml==2.8.1
+signxml==2.9.0
 
 # Packages dependencies:
 #   - cryptography:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requirements = [
     'cryptography>=2.8,<4',
     'defusedxml>=0.6.0,<1',
     'jsonschema>=3.1.1',
-    'lxml>=4.5.0,<5',
+    'lxml>=4.6.5,<5',
     'marshmallow>=2.19.2,<3',
     'pydantic>=1.6.2',
     # TODO: remove upper-bound after a new release of 'signxml' drops the requirement 'pyOpenSSL<20'

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,14 @@ readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 requirements = [
-    'cryptography>=2.8,<4',
+    'cryptography>=2.8',
     'defusedxml>=0.6.0,<1',
     'jsonschema>=3.1.1',
     'lxml>=4.6.5,<5',
     'marshmallow>=2.19.2,<3',
     'pydantic>=1.6.2',
-    # TODO: remove upper-bound after a new release of 'signxml' drops the requirement 'pyOpenSSL<20'
-    'pyOpenSSL>=18.0.0,<20',
+    # TODO: remove upper-bound after a new release of 'signxml' drops the requirement 'pyOpenSSL<21'
+    'pyOpenSSL>=18.0.0,<21',
     'pytz>=2019.3',
     'signxml>=2.8.0',
 ]


### PR DESCRIPTION
- (PR #258, 2021-12-22) chore: Increase lxml lower bound constraint
- (PR #259, 2021-12-23) requirements: Update 'signxml'