### PR TITLE
chore(rtc.parse): Disable validation that AEC signature cert is loadable

### DIFF
--- a/cl_sii/rtc/parse_aec.py
+++ b/cl_sii/rtc/parse_aec.py
@@ -28,7 +28,7 @@ import cl_sii.dte.parse
 from cl_sii.dte.constants import TipoDteEnum
 from cl_sii.dte.data_models import DteXmlData
 from cl_sii.dte.parse import DTE_XMLNS_MAP
-from cl_sii.libs import crypto_utils, encoding_utils, tz_utils, xml_utils
+from cl_sii.libs import encoding_utils, tz_utils, xml_utils
 from cl_sii.libs.xml_utils import XmlElement
 from cl_sii.rut import Rut
 
@@ -167,11 +167,14 @@ class _XmlSignature(pydantic.BaseModel):
             v = encoding_utils.decode_base64_strict(v)  # Raises ValueError.
         return v
 
-    @pydantic.validator('key_info_x509_data_x509_cert')
-    def validate_certificate_is_loadable(cls, v: object) -> object:
-        if isinstance(v, bytes):
-            _ = crypto_utils.load_der_x509_cert(v)  # Raises ValueError.
-        return v
+    # Note: Even though this validation seems to make perfect sense, there are some
+    # real cases of SII-approved AEC where this is not fulfilled.
+    # We will keep this validation in case we need it in the future.
+    # @pydantic.validator('key_info_x509_data_x509_cert')
+    # def validate_certificate_is_loadable(cls, v: object) -> object:
+    #     if isinstance(v, bytes):
+    #         _ = crypto_utils.load_der_x509_cert(v)  # Raises ValueError.
+    #     return v
 
 
 class _Cesionario(pydantic.BaseModel):


### PR DESCRIPTION
There is a high number of AEC documents approved by the SII that cannot be instantiated because the validation that the AEC signature certificate is loadable fails (see https://github.com/fyntex/lib-cl-sii-python/pull/242#issuecomment-932675576). For the moment we will disable this validation so we can instantiate the AEC documents while we look for a solution to the issue loading the AEC signature certificate.

Ref: https://cordada.aha.io/features/COMPCLDATA-13