### PR TITLE
Release v0.16.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.2
+current_version = 0.16.0
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+0.16.0 (2021-12-24)
++++++++++++++++++++++++
+
+* (PR #261, 2021-12-24) chore(rtc.parse): Disable validation that AEC signature cert is loadable
+* (PR #253, 2021-12-24) Rename of the enum class for `TipoDte` object
+
 0.15.2 (2021-12-23)
 +++++++++++++++++++++++
 

--- a/cl_sii/__init__.py
+++ b/cl_sii/__init__.py
@@ -5,4 +5,4 @@ cl-sii Python lib
 """
 
 
-__version__ = '0.15.2'
+__version__ = '0.16.0'

--- a/cl_sii/dte/constants.py
+++ b/cl_sii/dte/constants.py
@@ -84,7 +84,7 @@ DTE_TIPO_DTE_FIELD_MIN_VALUE = 1
 
 
 @enum.unique
-class TipoDteEnum(enum.IntEnum):
+class TipoDte(enum.IntEnum):
 
     """
     Enum of "Tipo de DTE".
@@ -156,13 +156,13 @@ class TipoDteEnum(enum.IntEnum):
 
     @property
     def is_factura(self) -> bool:
-        if self is TipoDteEnum.FACTURA_ELECTRONICA:
+        if self is TipoDte.FACTURA_ELECTRONICA:
             result = True
-        elif self is TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA:
+        elif self is TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA:
             result = True
-        elif self is TipoDteEnum.FACTURA_COMPRA_ELECTRONICA:
+        elif self is TipoDte.FACTURA_COMPRA_ELECTRONICA:
             result = True
-        elif self is TipoDteEnum.LIQUIDACION_FACTURA_ELECTRONICA:
+        elif self is TipoDte.LIQUIDACION_FACTURA_ELECTRONICA:
             result = True
         else:
             result = False
@@ -171,11 +171,11 @@ class TipoDteEnum(enum.IntEnum):
 
     @property
     def is_factura_venta(self) -> bool:
-        if self is TipoDteEnum.FACTURA_ELECTRONICA:
+        if self is TipoDte.FACTURA_ELECTRONICA:
             result = True
-        elif self is TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA:
+        elif self is TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA:
             result = True
-        elif self is TipoDteEnum.LIQUIDACION_FACTURA_ELECTRONICA:
+        elif self is TipoDte.LIQUIDACION_FACTURA_ELECTRONICA:
             result = True
         else:
             result = False
@@ -184,7 +184,7 @@ class TipoDteEnum(enum.IntEnum):
 
     @property
     def is_factura_compra(self) -> bool:
-        if self is TipoDteEnum.FACTURA_COMPRA_ELECTRONICA:
+        if self is TipoDte.FACTURA_COMPRA_ELECTRONICA:
             result = True
         else:
             result = False
@@ -193,9 +193,9 @@ class TipoDteEnum(enum.IntEnum):
 
     @property
     def is_nota(self) -> bool:
-        if self is TipoDteEnum.NOTA_DEBITO_ELECTRONICA:
+        if self is TipoDte.NOTA_DEBITO_ELECTRONICA:
             result = True
-        elif self is TipoDteEnum.NOTA_CREDITO_ELECTRONICA:
+        elif self is TipoDte.NOTA_CREDITO_ELECTRONICA:
             result = True
         else:
             result = False

--- a/cl_sii/dte/data_models.py
+++ b/cl_sii/dte/data_models.py
@@ -28,7 +28,7 @@ from cl_sii.libs import tz_utils
 from cl_sii.rut import Rut
 
 from . import constants
-from .constants import TipoDteEnum
+from .constants import TipoDte
 
 
 def validate_dte_folio(value: int) -> None:
@@ -45,7 +45,7 @@ def validate_dte_folio(value: int) -> None:
         raise ValueError("Value is out of the valid range for 'folio'.")
 
 
-def validate_dte_monto_total(value: int, tipo_dte: TipoDteEnum) -> None:
+def validate_dte_monto_total(value: int, tipo_dte: TipoDte) -> None:
     """
     Validate value for DTE field ``monto_total``.
 
@@ -58,7 +58,7 @@ def validate_dte_monto_total(value: int, tipo_dte: TipoDteEnum) -> None:
             or value > constants.DTE_MONTO_TOTAL_FIELD_MAX_VALUE):  # type: ignore
         raise ValueError("Value is out of the valid range for 'monto_total'.")
 
-    if value < 0 and tipo_dte != TipoDteEnum.LIQUIDACION_FACTURA_ELECTRONICA:
+    if value < 0 and tipo_dte != TipoDte.LIQUIDACION_FACTURA_ELECTRONICA:
         raise ValueError("Value is out of the valid range for 'monto_total'.")
 
 
@@ -113,11 +113,11 @@ class DteNaturalKey:
 
     This group of fields uniquely identifies a DTE.
 
-    >>> instance = DteNaturalKey(Rut('60910000-1'), TipoDteEnum.FACTURA_ELECTRONICA, 2093465)
+    >>> instance = DteNaturalKey(Rut('60910000-1'), TipoDte.FACTURA_ELECTRONICA, 2093465)
 
     >>> str(instance)
     "DteNaturalKey(" \
-    "emisor_rut=Rut('60910000-1'), tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>, folio=2093465)"
+    "emisor_rut=Rut('60910000-1'), tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>, folio=2093465)"
     >>> str(instance) == repr(instance)
     True
     >>> instance.slug
@@ -130,7 +130,7 @@ class DteNaturalKey:
     RUT of the "emisor" of the DTE.
     """
 
-    tipo_dte: TipoDteEnum
+    tipo_dte: TipoDte
     """
     The kind of DTE.
     """
@@ -184,12 +184,12 @@ class DteDataL0(DteNaturalKey):
     The class instances are immutable.
 
     >>> instance = DteDataL0(
-    ...     Rut('60910000-1'), TipoDteEnum.FACTURA_ELECTRONICA, 2093465, date(2018, 5, 7),
+    ...     Rut('60910000-1'), TipoDte.FACTURA_ELECTRONICA, 2093465, date(2018, 5, 7),
     ...     Rut('60910000-1'), 10403)
 
     >>> str(instance)
     "DteDataL0(" \
-    "emisor_rut=Rut('60910000-1'), tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>, " \
+    "emisor_rut=Rut('60910000-1'), tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>, " \
     "folio=2093465)"
     >>> str(instance) == repr(instance)
     True
@@ -197,7 +197,7 @@ class DteDataL0(DteNaturalKey):
     '60910000-1--33--2093465'
     >>> instance.natural_key
     "DteNaturalKey(" \
-    "emisor_rut=Rut('60910000-1'), tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>, folio=2093465)"
+    "emisor_rut=Rut('60910000-1'), tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>, folio=2093465)"
 
     """
 
@@ -224,12 +224,12 @@ class DteDataL1(DteDataL0):
     The class instances are immutable.
 
     >>> instance = DteDataL1(
-    ...     Rut('60910000-1'), TipoDteEnum.FACTURA_ELECTRONICA, 2093465, date(2018, 5, 7),
+    ...     Rut('60910000-1'), TipoDte.FACTURA_ELECTRONICA, 2093465, date(2018, 5, 7),
     ...     Rut('60910000-1'), 10403)
 
     >>> str(instance)
     "DteDataL1(" \
-    "emisor_rut=Rut('60910000-1'), tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>, " \
+    "emisor_rut=Rut('60910000-1'), tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>, " \
     "folio=2093465, fecha_emision_date=datetime.date(2018, 5, 7), " \
     "receptor_rut=Rut('60910000-1'), monto_total=10403)"
     >>> str(instance) == repr(instance)
@@ -312,7 +312,7 @@ class DteDataL1(DteDataL0):
     def validate_monto_total(cls, v: object, values: Mapping[str, object]) -> object:
         tipo_dte = values.get('tipo_dte')
 
-        if isinstance(v, int) and isinstance(tipo_dte, TipoDteEnum):
+        if isinstance(v, int) and isinstance(tipo_dte, TipoDte):
             validate_dte_monto_total(v, tipo_dte=tipo_dte)
 
         return v

--- a/cl_sii/dte/parse.py
+++ b/cl_sii/dte/parse.py
@@ -428,7 +428,7 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
     # values parsing
     ###########################################################################
 
-    tipo_dte_value = constants.TipoDteEnum(int(_text_strip_or_raise(tipo_dte_em)))
+    tipo_dte_value = constants.TipoDte(int(_text_strip_or_raise(tipo_dte_em)))
     folio_value = int(_text_strip_or_raise(folio_em))
     fecha_emision_value = date.fromisoformat(_text_strip_or_raise(fecha_emision_em))
     fecha_vencimiento_value = None

--- a/cl_sii/extras/mm_fields.py
+++ b/cl_sii/extras/mm_fields.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 import marshmallow.fields
 
-from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.constants import TipoDte
 from cl_sii.rcv.constants import RcvTipoDocto
 from cl_sii.rcv.data_models import PeriodoTributario as RcvPeriodoTributario
 from cl_sii.rut import Rut
@@ -74,13 +74,13 @@ class TipoDteField(marshmallow.fields.Field):
     Marshmallow field for a DTE's "tipo DTE".
 
     Data types:
-    * native/primitive/internal/deserialized: :class:`TipoDteEnum`
+    * native/primitive/internal/deserialized: :class:`TipoDte`
     * representation/serialized: int, same as for Marshmallow field
       :class:`marshmallow.fields.Integer`
 
     The field performs some input value cleaning when it is an str;
     for example ``'  33 \t '`` is allowed and the resulting value
-    is ``TipoDteEnum(33)``.
+    is ``TipoDte(33)``.
 
     Implementation almost identical to
     :class:`cl_sii.extras.mm_fields.RutField`.
@@ -92,14 +92,14 @@ class TipoDteField(marshmallow.fields.Field):
     }
 
     def _serialize(self, value: Optional[object], attr: str, obj: object) -> Optional[int]:
-        validated: Optional[TipoDteEnum] = self._validated(value)
+        validated: Optional[TipoDte] = self._validated(value)
         return validated.value if validated is not None else None
 
-    def _deserialize(self, value: object, attr: str, data: dict) -> Optional[TipoDteEnum]:
+    def _deserialize(self, value: object, attr: str, data: dict) -> Optional[TipoDte]:
         return self._validated(value)
 
-    def _validated(self, value: Optional[object]) -> Optional[TipoDteEnum]:
-        if value is None or isinstance(value, TipoDteEnum):
+    def _validated(self, value: Optional[object]) -> Optional[TipoDte]:
+        if value is None or isinstance(value, TipoDte):
             validated = value
         else:
             if isinstance(value, bool):
@@ -115,9 +115,9 @@ class TipoDteField(marshmallow.fields.Field):
                 self.fail('type')
 
             try:
-                validated = TipoDteEnum(value)  # type: ignore
+                validated = TipoDte(value)  # type: ignore
             except ValueError:
-                # TipoDteEnum('x') raises 'ValueError', not 'TypeError'
+                # TipoDte('x') raises 'ValueError', not 'TypeError'
                 self.fail('invalid')
         return validated
 

--- a/cl_sii/rcv/constants.py
+++ b/cl_sii/rcv/constants.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 from typing import Optional
 
-from ..dte.constants import TipoDteEnum
+from ..dte.constants import TipoDte
 
 
 @enum.unique
@@ -103,10 +103,10 @@ class RcvTipoDocto(enum.IntEnum):
     """
     Enum of "Tipo de Documento" for the RCV domain.
 
-    Unlike :class:`cl_sii.dte.constants.TipoDteEnum` this collection is not
+    Unlike :class:`cl_sii.dte.constants.TipoDte` this collection is not
     restricted to "documentos electrónicos". However, this is not a superset
     of the latter (e.g. "Guía electrónica de despacho" (52) is in
-    ``TipoDteEnum`` but not in ``RcvTipoDocto``).
+    ``TipoDte`` but not in ``RcvTipoDocto``).
 
     Sources:
 
@@ -197,7 +197,7 @@ class RcvTipoDocto(enum.IntEnum):
     ###########################################################################
 
     # For more info about a "liquidación-factura" see
-    #   'cl_sii.dte.constants.TipoDteEnum'.
+    #   'cl_sii.dte.constants.TipoDte'.
 
     LIQUIDACION_FACTURA = 40
     """Liquidación-Factura."""
@@ -291,7 +291,7 @@ class RcvTipoDocto(enum.IntEnum):
     TIPO_924 = 924
     """Resumen Vtas. Pasajes Inter. sin Fact."""
 
-    def as_tipo_dte(self) -> TipoDteEnum:
+    def as_tipo_dte(self) -> TipoDte:
         """
         Return equivalent "Tipo DTE".
 
@@ -299,9 +299,9 @@ class RcvTipoDocto(enum.IntEnum):
 
         """
         try:
-            value = TipoDteEnum(self.value)
+            value = TipoDte(self.value)
         except ValueError as exc:
             raise ValueError(
-                f"There is no equivalent 'TipoDteEnum' for 'RcvTipoDocto.{self.name}'.") from exc
+                f"There is no equivalent 'TipoDte' for 'RcvTipoDocto.{self.name}'.") from exc
 
         return value

--- a/cl_sii/rtc/constants.py
+++ b/cl_sii/rtc/constants.py
@@ -1,7 +1,7 @@
 import enum
 from typing import FrozenSet
 
-from cl_sii.dte.constants import DTE_MONTO_TOTAL_FIELD_MAX_VALUE, TipoDteEnum
+from cl_sii.dte.constants import DTE_MONTO_TOTAL_FIELD_MAX_VALUE, TipoDte
 
 
 # The collection of "tipo DTE" for which it is possible to "ceder" a "DTE".
@@ -17,11 +17,11 @@ from cl_sii.dte.constants import DTE_MONTO_TOTAL_FIELD_MAX_VALUE, TipoDteEnum
 #   - XML type 'SiiDte:DTEFacturasType' in official schema 'SiiTypes_v10.xsd'
 #     - source:
 #       https://github.com/fyntex/lib-cl-sii-python/blob/7e1c4b52/cl_sii/data/ref/factura_electronica/schemas-xml/SiiTypes_v10.xsd#L100-L126
-TIPO_DTE_CEDIBLES: FrozenSet[TipoDteEnum] = frozenset({
-    TipoDteEnum.FACTURA_ELECTRONICA,
-    TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA,
-    TipoDteEnum.FACTURA_COMPRA_ELECTRONICA,
-    TipoDteEnum.LIQUIDACION_FACTURA_ELECTRONICA,
+TIPO_DTE_CEDIBLES: FrozenSet[TipoDte] = frozenset({
+    TipoDte.FACTURA_ELECTRONICA,
+    TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA,
+    TipoDte.FACTURA_COMPRA_ELECTRONICA,
+    TipoDte.LIQUIDACION_FACTURA_ELECTRONICA,
 })
 
 

--- a/cl_sii/rtc/data_models.py
+++ b/cl_sii/rtc/data_models.py
@@ -27,7 +27,7 @@ import pydantic
 
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.dte import data_models as dte_data_models
-from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.constants import TipoDte
 from cl_sii.libs import tz_utils
 from cl_sii.rut import Rut
 
@@ -60,7 +60,7 @@ def validate_cesion_monto(value: int) -> None:
         raise ValueError("Value is out of the valid range.", value)
 
 
-def validate_cesion_dte_tipo_dte(value: TipoDteEnum) -> None:
+def validate_cesion_dte_tipo_dte(value: TipoDte) -> None:
     """
     Validate "tipo DTE" of the "cesión".
 
@@ -98,7 +98,7 @@ class CesionNaturalKey:
 
     >>> instance = CesionNaturalKey(
     ...     dte_data_models.DteNaturalKey(
-    ...         Rut('60910000-1'), TipoDteEnum.FACTURA_ELECTRONICA, 2093465,
+    ...         Rut('60910000-1'), TipoDte.FACTURA_ELECTRONICA, 2093465,
     ...     ),
     ...     1,
     ... )
@@ -172,7 +172,7 @@ class CesionAltNaturalKey:
 
     >>> instance = CesionAltNaturalKey(
     ...     dte_data_models.DteNaturalKey(
-    ...         Rut('60910000-1'), TipoDteEnum.FACTURA_ELECTRONICA, 2093465,
+    ...         Rut('60910000-1'), TipoDte.FACTURA_ELECTRONICA, 2093465,
     ...     ),
     ...     Rut('76389992-6'),
     ...     Rut('76598556-0'),
@@ -361,7 +361,7 @@ class CesionL0:
         return self.dte_key.emisor_rut
 
     @property
-    def dte_tipo_dte(self) -> TipoDteEnum:
+    def dte_tipo_dte(self) -> TipoDte:
         return self.dte_key.tipo_dte
 
     @property

--- a/cl_sii/rtc/data_models_cesiones_periodo.py
+++ b/cl_sii/rtc/data_models_cesiones_periodo.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import cl_sii.dte.data_models
 from cl_sii.base.constants import SII_OFFICIAL_TZ
-from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.constants import TipoDte
 from cl_sii.libs import tz_utils
 from cl_sii.rut import Rut
 
@@ -44,7 +44,7 @@ class CesionesPeriodoEntry:
     RUT of the DTE's "deudor".
     """
 
-    dte_tipo_dte: TipoDteEnum
+    dte_tipo_dte: TipoDte
     """
     The DTE's "tipo DTE" (sighs).
     """
@@ -163,7 +163,7 @@ class CesionesPeriodoEntry:
         if not isinstance(self.dte_deudor_rut, Rut):
             raise TypeError("Inappropriate type of 'dte_deudor_rut'.")
 
-        if not isinstance(self.dte_tipo_dte, TipoDteEnum):
+        if not isinstance(self.dte_tipo_dte, TipoDte):
             raise TypeError("Inappropriate type of 'dte_tipo_dte'.")
         if self.dte_tipo_dte not in TIPO_DTE_CEDIBLES:
             raise ValueError(

--- a/cl_sii/rtc/parse_aec.py
+++ b/cl_sii/rtc/parse_aec.py
@@ -25,7 +25,7 @@ import pydantic
 
 import cl_sii.dte.data_models
 import cl_sii.dte.parse
-from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.constants import TipoDte
 from cl_sii.dte.data_models import DteXmlData
 from cl_sii.dte.parse import DTE_XMLNS_MAP
 from cl_sii.libs import encoding_utils, tz_utils, xml_utils
@@ -361,7 +361,7 @@ class _IdDte(pydantic.BaseModel):
     ###########################################################################
 
     rut_emisor: Rut
-    tipo_dte: TipoDteEnum
+    tipo_dte: TipoDte
     folio: int
     fch_emis: date
     rut_receptor: Rut
@@ -411,7 +411,7 @@ class _IdDte(pydantic.BaseModel):
     @pydantic.validator('tipo_dte', pre=True)
     def validate_tipo_dte(cls, v: object) -> object:
         if isinstance(v, int):
-            v = TipoDteEnum(v)  # Raises ValueError if invalid.
+            v = TipoDte(v)  # Raises ValueError if invalid.
         return v
 
 

--- a/cl_sii/rtc/parse_aec.py
+++ b/cl_sii/rtc/parse_aec.py
@@ -28,7 +28,7 @@ import cl_sii.dte.parse
 from cl_sii.dte.constants import TipoDteEnum
 from cl_sii.dte.data_models import DteXmlData
 from cl_sii.dte.parse import DTE_XMLNS_MAP
-from cl_sii.libs import crypto_utils, encoding_utils, tz_utils, xml_utils
+from cl_sii.libs import encoding_utils, tz_utils, xml_utils
 from cl_sii.libs.xml_utils import XmlElement
 from cl_sii.rut import Rut
 
@@ -167,11 +167,14 @@ class _XmlSignature(pydantic.BaseModel):
             v = encoding_utils.decode_base64_strict(v)  # Raises ValueError.
         return v
 
-    @pydantic.validator('key_info_x509_data_x509_cert')
-    def validate_certificate_is_loadable(cls, v: object) -> object:
-        if isinstance(v, bytes):
-            _ = crypto_utils.load_der_x509_cert(v)  # Raises ValueError.
-        return v
+    # Note: Even though this validation seems to make perfect sense, there are some
+    # real cases of SII-approved AEC where this is not fulfilled.
+    # We will keep this validation in case we need it in the future.
+    # @pydantic.validator('key_info_x509_data_x509_cert')
+    # def validate_certificate_is_loadable(cls, v: object) -> object:
+    #     if isinstance(v, bytes):
+    #         _ = crypto_utils.load_der_x509_cert(v)  # Raises ValueError.
+    #     return v
 
 
 class _Cesionario(pydantic.BaseModel):

--- a/tests/test_dte_constants.py
+++ b/tests/test_dte_constants.py
@@ -1,27 +1,27 @@
 import unittest
 
 from cl_sii.dte import constants  # noqa: F401
-from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.constants import TipoDte
 
 
-class TipoDteEnumTest(unittest.TestCase):
+class TipoDteTest(unittest.TestCase):
 
     def test_members(self):
         self.assertSetEqual(
-            {x for x in TipoDteEnum},
+            {x for x in TipoDte},
             {
-                TipoDteEnum.FACTURA_ELECTRONICA,
-                TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA,
-                TipoDteEnum.LIQUIDACION_FACTURA_ELECTRONICA,
-                TipoDteEnum.FACTURA_COMPRA_ELECTRONICA,
-                TipoDteEnum.GUIA_DESPACHO_ELECTRONICA,
-                TipoDteEnum.NOTA_DEBITO_ELECTRONICA,
-                TipoDteEnum.NOTA_CREDITO_ELECTRONICA,
+                TipoDte.FACTURA_ELECTRONICA,
+                TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA,
+                TipoDte.LIQUIDACION_FACTURA_ELECTRONICA,
+                TipoDte.FACTURA_COMPRA_ELECTRONICA,
+                TipoDte.GUIA_DESPACHO_ELECTRONICA,
+                TipoDte.NOTA_DEBITO_ELECTRONICA,
+                TipoDte.NOTA_CREDITO_ELECTRONICA,
             }
         )
 
     def test_FACTURA_ELECTRONICA(self):
-        value = TipoDteEnum.FACTURA_ELECTRONICA
+        value = TipoDte.FACTURA_ELECTRONICA
 
         self.assertEqual(value.name, 'FACTURA_ELECTRONICA')
         self.assertEqual(value.value, 33)
@@ -39,7 +39,7 @@ class TipoDteEnumTest(unittest.TestCase):
             self.assertEqual(result, expected)
 
     def test_FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA(self):
-        value = TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA
+        value = TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA
 
         self.assertEqual(value.name, 'FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA')
         self.assertEqual(value.value, 34)
@@ -57,7 +57,7 @@ class TipoDteEnumTest(unittest.TestCase):
             self.assertTrue(result is expected)
 
     def test_LIQUIDACION_FACTURA_ELECTRONICA(self):
-        value = TipoDteEnum.LIQUIDACION_FACTURA_ELECTRONICA
+        value = TipoDte.LIQUIDACION_FACTURA_ELECTRONICA
 
         self.assertEqual(value.name, 'LIQUIDACION_FACTURA_ELECTRONICA')
         self.assertEqual(value.value, 43)
@@ -75,7 +75,7 @@ class TipoDteEnumTest(unittest.TestCase):
             self.assertEqual(result, expected)
 
     def test_FACTURA_COMPRA_ELECTRONICA(self):
-        value = TipoDteEnum.FACTURA_COMPRA_ELECTRONICA
+        value = TipoDte.FACTURA_COMPRA_ELECTRONICA
 
         self.assertEqual(value.name, 'FACTURA_COMPRA_ELECTRONICA')
         self.assertEqual(value.value, 46)
@@ -93,7 +93,7 @@ class TipoDteEnumTest(unittest.TestCase):
             self.assertTrue(result is expected)
 
     def test_GUIA_DESPACHO_ELECTRONICA(self):
-        value = TipoDteEnum.GUIA_DESPACHO_ELECTRONICA
+        value = TipoDte.GUIA_DESPACHO_ELECTRONICA
 
         self.assertEqual(value.name, 'GUIA_DESPACHO_ELECTRONICA')
         self.assertEqual(value.value, 52)
@@ -111,7 +111,7 @@ class TipoDteEnumTest(unittest.TestCase):
             self.assertTrue(result is expected)
 
     def test_NOTA_DEBITO_ELECTRONICA(self):
-        value = TipoDteEnum.NOTA_DEBITO_ELECTRONICA
+        value = TipoDte.NOTA_DEBITO_ELECTRONICA
 
         self.assertEqual(value.name, 'NOTA_DEBITO_ELECTRONICA')
         self.assertEqual(value.value, 56)
@@ -129,7 +129,7 @@ class TipoDteEnumTest(unittest.TestCase):
             self.assertTrue(result is expected)
 
     def test_NOTA_CREDITO_ELECTRONICA(self):
-        value = TipoDteEnum.NOTA_CREDITO_ELECTRONICA
+        value = TipoDte.NOTA_CREDITO_ELECTRONICA
 
         self.assertEqual(value.name, 'NOTA_CREDITO_ELECTRONICA')
         self.assertEqual(value.value, 61)

--- a/tests/test_dte_data_models.py
+++ b/tests/test_dte_data_models.py
@@ -14,7 +14,7 @@ from cl_sii.dte.constants import (  # noqa: F401
     DTE_FOLIO_FIELD_MIN_VALUE,
     DTE_MONTO_TOTAL_FIELD_MAX_VALUE,
     DTE_MONTO_TOTAL_FIELD_MIN_VALUE,
-    TipoDteEnum,
+    TipoDte,
 )
 from cl_sii.dte.data_models import (  # noqa: F401
     DteDataL0, DteDataL1, DteDataL2, DteNaturalKey, DteXmlData,
@@ -31,7 +31,7 @@ class DteNaturalKeyTest(unittest.TestCase):
 
         self.dte_nk_1 = DteNaturalKey(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
         )
 
@@ -73,7 +73,7 @@ class DteNaturalKeyTest(unittest.TestCase):
             self.dte_nk_1.as_dict(),
             dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             )
         )
@@ -89,7 +89,7 @@ class DteDataL0Test(unittest.TestCase):
 
         self.dte_l0_1 = DteDataL0(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
         )
 
@@ -98,7 +98,7 @@ class DteDataL0Test(unittest.TestCase):
             self.dte_l0_1.as_dict(),
             dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ))
 
@@ -107,7 +107,7 @@ class DteDataL0Test(unittest.TestCase):
             self.dte_l0_1.natural_key,
             DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ))
 
@@ -119,7 +119,7 @@ class DteDataL1Test(unittest.TestCase):
 
         self.dte_l1_1 = DteDataL1(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
             fecha_emision_date=date(2019, 4, 1),
             receptor_rut=Rut('96790240-3'),
@@ -130,7 +130,7 @@ class DteDataL1Test(unittest.TestCase):
         try:
             _ = dataclasses.replace(
                 self.dte_l1_1,
-                tipo_dte=TipoDteEnum.LIQUIDACION_FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.LIQUIDACION_FACTURA_ELECTRONICA,
                 monto_total=-1,
             )
         except pydantic.ValidationError as exc:
@@ -187,7 +187,7 @@ class DteDataL1Test(unittest.TestCase):
             self.dte_l1_1.as_dict(),
             dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -198,13 +198,13 @@ class DteDataL1Test(unittest.TestCase):
         emisor_rut = self.dte_l1_1.emisor_rut
         receptor_rut = self.dte_l1_1.receptor_rut
         dte_factura_venta = dataclasses.replace(
-            self.dte_l1_1, tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA)
+            self.dte_l1_1, tipo_dte=TipoDte.FACTURA_ELECTRONICA)
         dte_factura_venta_exenta = dataclasses.replace(
-            self.dte_l1_1, tipo_dte=TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA)
+            self.dte_l1_1, tipo_dte=TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA)
         dte_factura_compra = dataclasses.replace(
-            self.dte_l1_1, tipo_dte=TipoDteEnum.FACTURA_COMPRA_ELECTRONICA)
+            self.dte_l1_1, tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA)
         dte_nota_credito = dataclasses.replace(
-            self.dte_l1_1, tipo_dte=TipoDteEnum.NOTA_CREDITO_ELECTRONICA)
+            self.dte_l1_1, tipo_dte=TipoDte.NOTA_CREDITO_ELECTRONICA)
 
         # 'vendedor_rut'
         self.assertEqual(dte_factura_venta.vendedor_rut, emisor_rut)
@@ -259,7 +259,7 @@ class DteDataL2Test(unittest.TestCase):
 
         self.dte_l2_1 = DteDataL2(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
             fecha_emision_date=date(2019, 4, 1),
             receptor_rut=Rut('96790240-3'),
@@ -278,7 +278,7 @@ class DteDataL2Test(unittest.TestCase):
         )
         self.dte_l2_2 = DteDataL2(
             emisor_rut=Rut('60910000-1'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=2336600,
             fecha_emision_date=date(2019, 8, 8),
             receptor_rut=Rut('76555835-2'),
@@ -615,7 +615,7 @@ class DteDataL2Test(unittest.TestCase):
             self.dte_l2_1.as_dict(),
             dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -636,7 +636,7 @@ class DteDataL2Test(unittest.TestCase):
             self.dte_l2_2.as_dict(),
             dict(
                 emisor_rut=Rut('60910000-1'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=2336600,
                 fecha_emision_date=date(2019, 8, 8),
                 receptor_rut=Rut('76555835-2'),
@@ -659,7 +659,7 @@ class DteDataL2Test(unittest.TestCase):
             self.dte_l2_1.as_dte_data_l1(),
             DteDataL1(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -670,7 +670,7 @@ class DteDataL2Test(unittest.TestCase):
             self.dte_l2_2.as_dte_data_l1(),
             DteDataL1(
                 emisor_rut=Rut('60910000-1'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=2336600,
                 fecha_emision_date=date(2019, 8, 8),
                 receptor_rut=Rut('76555835-2'),
@@ -699,7 +699,7 @@ class DteXmlDataTest(unittest.TestCase):
 
         self.dte_xml_data_1 = DteXmlData(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
             fecha_emision_date=date(2019, 4, 1),
             receptor_rut=Rut('96790240-3'),
@@ -718,7 +718,7 @@ class DteXmlDataTest(unittest.TestCase):
         )
         self.dte_xml_data_2 = DteXmlData(
             emisor_rut=Rut('60910000-1'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=2336600,
             fecha_emision_date=date(2019, 8, 8),
             receptor_rut=Rut('76555835-2'),
@@ -1085,7 +1085,7 @@ class DteXmlDataTest(unittest.TestCase):
             self.dte_xml_data_1.as_dict(),
             dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -1106,7 +1106,7 @@ class DteXmlDataTest(unittest.TestCase):
             self.dte_xml_data_2.as_dict(),
             dict(
                 emisor_rut=Rut('60910000-1'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=2336600,
                 fecha_emision_date=date(2019, 8, 8),
                 receptor_rut=Rut('76555835-2'),
@@ -1129,7 +1129,7 @@ class DteXmlDataTest(unittest.TestCase):
             self.dte_xml_data_1.as_dte_data_l1(),
             DteDataL1(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -1140,7 +1140,7 @@ class DteXmlDataTest(unittest.TestCase):
             self.dte_xml_data_2.as_dte_data_l1(),
             DteDataL1(
                 emisor_rut=Rut('60910000-1'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=2336600,
                 fecha_emision_date=date(2019, 8, 8),
                 receptor_rut=Rut('76555835-2'),
@@ -1153,7 +1153,7 @@ class DteXmlDataTest(unittest.TestCase):
             self.dte_xml_data_1.as_dte_data_l2(),
             DteDataL2(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -1175,7 +1175,7 @@ class DteXmlDataTest(unittest.TestCase):
             self.dte_xml_data_2.as_dte_data_l2(),
             DteDataL2(
                 emisor_rut=Rut('60910000-1'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=2336600,
                 fecha_emision_date=date(2019, 8, 8),
                 receptor_rut=Rut('76555835-2'),
@@ -1207,37 +1207,37 @@ class FunctionsTest(unittest.TestCase):
 
     def test_validate_dte_monto_total_with_valid_values(self) -> None:
         # Test value '0':
-        for tipo_dte in TipoDteEnum:
+        for tipo_dte in TipoDte:
             try:
                 validate_dte_monto_total(0, tipo_dte)
             except ValueError as e:
                 self.fail('{exc_name} raised'.format(exc_name=type(e).__name__))
 
         # Test value '1':
-        for tipo_dte in TipoDteEnum:
+        for tipo_dte in TipoDte:
             try:
                 validate_dte_monto_total(1, tipo_dte)
             except ValueError as e:
                 self.fail('{exc_name} raised'.format(exc_name=type(e).__name__))
 
         # Test value '-1':
-        for tipo_dte in TipoDteEnum:
-            if tipo_dte == TipoDteEnum.LIQUIDACION_FACTURA_ELECTRONICA:
+        for tipo_dte in TipoDte:
+            if tipo_dte == TipoDte.LIQUIDACION_FACTURA_ELECTRONICA:
                 try:
                     validate_dte_monto_total(-1, tipo_dte)
                 except ValueError as e:
                     self.fail('{exc_name} raised'.format(exc_name=type(e).__name__))
 
         # Test maximum value:
-        for tipo_dte in TipoDteEnum:
+        for tipo_dte in TipoDte:
             try:
                 validate_dte_monto_total(DTE_MONTO_TOTAL_FIELD_MAX_VALUE, tipo_dte)
             except ValueError as e:
                 self.fail('{exc_name} raised'.format(exc_name=type(e).__name__))
 
         # Test minimum value:
-        for tipo_dte in TipoDteEnum:
-            if tipo_dte == TipoDteEnum.LIQUIDACION_FACTURA_ELECTRONICA:
+        for tipo_dte in TipoDte:
+            if tipo_dte == TipoDte.LIQUIDACION_FACTURA_ELECTRONICA:
                 dte_monto_total_field_min_value = DTE_MONTO_TOTAL_FIELD_MIN_VALUE
             else:
                 dte_monto_total_field_min_value = 0
@@ -1251,20 +1251,20 @@ class FunctionsTest(unittest.TestCase):
         expected_exc_msg = "Value is out of the valid range for 'monto_total'."
 
         # Test value that is too large:
-        for tipo_dte in TipoDteEnum:
+        for tipo_dte in TipoDte:
             with self.assertRaises(ValueError) as assert_raises_cm:
                 validate_dte_monto_total(DTE_MONTO_TOTAL_FIELD_MAX_VALUE + 1, tipo_dte)
             self.assertEqual(str(assert_raises_cm.exception), expected_exc_msg)
 
         # Test value that is too small:
-        for tipo_dte in TipoDteEnum:
+        for tipo_dte in TipoDte:
             with self.assertRaises(ValueError) as assert_raises_cm:
                 validate_dte_monto_total(DTE_MONTO_TOTAL_FIELD_MIN_VALUE - 1, tipo_dte)
             self.assertEqual(str(assert_raises_cm.exception), expected_exc_msg)
 
         # Test value that is negative:
-        for tipo_dte in TipoDteEnum:
-            if tipo_dte != TipoDteEnum.LIQUIDACION_FACTURA_ELECTRONICA:
+        for tipo_dte in TipoDte:
+            if tipo_dte != TipoDte.LIQUIDACION_FACTURA_ELECTRONICA:
                 with self.assertRaises(ValueError) as assert_raises_cm:
                     validate_dte_monto_total(-1, tipo_dte)
                 self.assertEqual(str(assert_raises_cm.exception), expected_exc_msg)

--- a/tests/test_dte_parse.py
+++ b/tests/test_dte_parse.py
@@ -461,7 +461,7 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             dict(dte_xml_data.as_dict()),
             dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=cl_sii.dte.constants.TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=cl_sii.dte.constants.TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -487,7 +487,7 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             dict(dte_xml_data.as_dict()),
             dict(
                 emisor_rut=Rut('60910000-1'),
-                tipo_dte=cl_sii.dte.constants.TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=cl_sii.dte.constants.TipoDte.FACTURA_ELECTRONICA,
                 folio=2336600,
                 fecha_emision_date=date(2019, 8, 8),
                 receptor_rut=Rut('76555835-2'),
@@ -513,7 +513,7 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             dict(dte_xml_data.as_dict()),
             dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=cl_sii.dte.constants.TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=cl_sii.dte.constants.TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -539,7 +539,7 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             dict(dte_xml_data.as_dict()),
             dict(
                 emisor_rut=Rut('76399752-9'),
-                tipo_dte=cl_sii.dte.constants.TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=cl_sii.dte.constants.TipoDte.FACTURA_ELECTRONICA,
                 folio=25568,
                 fecha_emision_date=date(2019, 3, 29),
                 receptor_rut=Rut('96874030-K'),

--- a/tests/test_extras_mm_fields.py
+++ b/tests/test_extras_mm_fields.py
@@ -7,7 +7,7 @@ from cl_sii.extras.mm_fields import (
     RcvPeriodoTributario, RcvPeriodoTributarioField,
     RcvTipoDocto, RcvTipoDoctoField,
     Rut, RutField,
-    TipoDteEnum, TipoDteField,
+    TipoDte, TipoDteField,
 )
 
 
@@ -157,7 +157,7 @@ class TipoDteFieldTest(unittest.TestCase):
     def setUp(self) -> None:
 
         class MyObj:
-            def __init__(self, tipo_dte: TipoDteEnum, other_field: int = None) -> None:
+            def __init__(self, tipo_dte: TipoDte, other_field: int = None) -> None:
                 self.tipo_dte = tipo_dte
                 self.other_field = other_field
 
@@ -200,25 +200,25 @@ class TipoDteFieldTest(unittest.TestCase):
         schema = self.MyMmSchema()
 
         data_valid_1 = {'source field name': 33}
-        data_valid_2 = {'source field name': TipoDteEnum(33)}
+        data_valid_2 = {'source field name': TipoDte(33)}
         data_valid_3 = {'source field name': '  33 \t '}
 
         result = schema.load(data_valid_1)
-        self.assertDictEqual(dict(result.data), {'tipo_dte': TipoDteEnum(33)})
+        self.assertDictEqual(dict(result.data), {'tipo_dte': TipoDte(33)})
         self.assertDictEqual(dict(result.errors), {})
 
         result = schema.load(data_valid_2)
-        self.assertDictEqual(dict(result.data), {'tipo_dte': TipoDteEnum(33)})
+        self.assertDictEqual(dict(result.data), {'tipo_dte': TipoDte(33)})
         self.assertDictEqual(dict(result.errors), {})
 
         result = schema.load(data_valid_3)
-        self.assertDictEqual(dict(result.data), {'tipo_dte': TipoDteEnum(33)})
+        self.assertDictEqual(dict(result.data), {'tipo_dte': TipoDte(33)})
         self.assertDictEqual(dict(result.errors), {})
 
     def test_dump_ok_valid(self) -> None:
         schema = self.MyMmSchema()
 
-        obj_valid_1 = self.MyObj(tipo_dte=TipoDteEnum(33))
+        obj_valid_1 = self.MyObj(tipo_dte=TipoDte(33))
         obj_valid_2 = self.MyObj(tipo_dte=None)
 
         data, errors = schema.dump(obj_valid_1)

--- a/tests/test_rcv_constants.py
+++ b/tests/test_rcv_constants.py
@@ -1,6 +1,6 @@
 import unittest
 
-from cl_sii.dte.constants import TipoDteEnum  # noqa: F401
+from cl_sii.dte.constants import TipoDte  # noqa: F401
 from cl_sii.rcv import constants  # noqa: F401
 from cl_sii.rcv.constants import RcEstadoContable, RcvKind, RcvTipoDocto  # noqa: F401
 
@@ -129,10 +129,10 @@ class RcvTipoDoctoTest(unittest.TestCase):
     def test_as_tipo_dte(self):
         self.assertEqual(
             RcvTipoDocto.FACTURA_ELECTRONICA.as_tipo_dte(),
-            TipoDteEnum.FACTURA_ELECTRONICA)
+            TipoDte.FACTURA_ELECTRONICA)
 
         with self.assertRaises(ValueError) as cm:
             RcvTipoDocto.FACTURA.as_tipo_dte()
         self.assertEqual(
             cm.exception.args,
-            ("There is no equivalent 'TipoDteEnum' for 'RcvTipoDocto.FACTURA'.", ))
+            ("There is no equivalent 'TipoDte' for 'RcvTipoDocto.FACTURA'.", ))

--- a/tests/test_rtc_data_models.py
+++ b/tests/test_rtc_data_models.py
@@ -7,7 +7,7 @@ from datetime import date, datetime
 import pydantic
 
 from cl_sii.dte.data_models import DteNaturalKey, DteDataL1, DteDataL2
-from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.constants import TipoDte
 from cl_sii.libs import tz_utils
 from cl_sii.rtc.data_models import (
     CesionNaturalKey,
@@ -27,7 +27,7 @@ class CesionNaturalKeyTest(unittest.TestCase):
     def _set_obj_1(self) -> None:
         obj_dte_natural_key = DteNaturalKey(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
         )
 
@@ -51,7 +51,7 @@ class CesionNaturalKeyTest(unittest.TestCase):
             "CesionNaturalKey("
             "dte_key=DteNaturalKey("
             "emisor_rut=Rut('76354771-K'),"
-            " tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>,"
+            " tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>,"
             " folio=170"
             "),"
             " seq=32"
@@ -67,7 +67,7 @@ class CesionNaturalKeyTest(unittest.TestCase):
         expected_output = dict(
             dte_key=dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=32,
@@ -87,7 +87,7 @@ class CesionNaturalKeyTest(unittest.TestCase):
         obj = self.obj_1
         expected_validation_error = {
             'loc': ('dte_key',),
-            'msg': """('Value is not "cedible".', <TipoDteEnum.NOTA_CREDITO_ELECTRONICA: 61>)""",
+            'msg': """('Value is not "cedible".', <TipoDte.NOTA_CREDITO_ELECTRONICA: 61>)""",
             'type': 'value_error',
         }
 
@@ -96,7 +96,7 @@ class CesionNaturalKeyTest(unittest.TestCase):
                 obj,
                 dte_key=dataclasses.replace(
                     obj.dte_key,
-                    tipo_dte=TipoDteEnum.NOTA_CREDITO_ELECTRONICA,
+                    tipo_dte=TipoDte.NOTA_CREDITO_ELECTRONICA,
                 ),
             )
 
@@ -134,7 +134,7 @@ class CesionAltNaturalKeyTest(unittest.TestCase):
     def _set_obj_1(self) -> None:
         obj_dte_natural_key = DteNaturalKey(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
         )
 
@@ -164,7 +164,7 @@ class CesionAltNaturalKeyTest(unittest.TestCase):
             "CesionAltNaturalKey("
             "dte_key=DteNaturalKey("
             "emisor_rut=Rut('76354771-K'),"
-            " tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>,"
+            " tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>,"
             " folio=170"
             "),"
             " cedente_rut=Rut('76389992-6'),"
@@ -185,7 +185,7 @@ class CesionAltNaturalKeyTest(unittest.TestCase):
         expected_output = dict(
             dte_key=dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             cedente_rut=Rut('76389992-6'),
@@ -207,7 +207,7 @@ class CesionAltNaturalKeyTest(unittest.TestCase):
         obj = self.obj_1
         expected_validation_error = {
             'loc': ('dte_key',),
-            'msg': """('Value is not "cedible".', <TipoDteEnum.NOTA_CREDITO_ELECTRONICA: 61>)""",
+            'msg': """('Value is not "cedible".', <TipoDte.NOTA_CREDITO_ELECTRONICA: 61>)""",
             'type': 'value_error',
         }
 
@@ -216,7 +216,7 @@ class CesionAltNaturalKeyTest(unittest.TestCase):
                 obj,
                 dte_key=dataclasses.replace(
                     obj.dte_key,
-                    tipo_dte=TipoDteEnum.NOTA_CREDITO_ELECTRONICA,
+                    tipo_dte=TipoDte.NOTA_CREDITO_ELECTRONICA,
                 ),
             )
 
@@ -304,7 +304,7 @@ class CesionL0Test(unittest.TestCase):
     def _set_obj_1(self) -> None:
         obj_dte_natural_key = DteNaturalKey(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
         )
 
@@ -335,7 +335,7 @@ class CesionL0Test(unittest.TestCase):
             "CesionL0("
             "dte_key=DteNaturalKey("
             "emisor_rut=Rut('76354771-K'),"
-            " tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>,"
+            " tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>,"
             " folio=170"
             "),"
             " seq=32,"
@@ -357,7 +357,7 @@ class CesionL0Test(unittest.TestCase):
         expected_output = dict(
             dte_key=dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=32,
@@ -381,7 +381,7 @@ class CesionL0Test(unittest.TestCase):
         expected_output = CesionNaturalKey(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=32,
@@ -401,7 +401,7 @@ class CesionL0Test(unittest.TestCase):
         expected_output = CesionAltNaturalKey(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             cedente_rut=Rut('76389992-6'),
@@ -427,7 +427,7 @@ class CesionL0Test(unittest.TestCase):
             {
                 'loc': ('dte_key',),
                 'msg':
-                    """('Value is not "cedible".', <TipoDteEnum.NOTA_CREDITO_ELECTRONICA: 61>)""",
+                    """('Value is not "cedible".', <TipoDte.NOTA_CREDITO_ELECTRONICA: 61>)""",
                 'type': 'value_error',
             },
         ]
@@ -437,7 +437,7 @@ class CesionL0Test(unittest.TestCase):
                 obj,
                 dte_key=dataclasses.replace(
                     obj.dte_key,
-                    tipo_dte=TipoDteEnum.NOTA_CREDITO_ELECTRONICA,
+                    tipo_dte=TipoDte.NOTA_CREDITO_ELECTRONICA,
                 ),
             )
 
@@ -535,7 +535,7 @@ class CesionL1Test(CesionL0Test):
     def _set_obj_1(self) -> None:
         obj_dte_natural_key = DteNaturalKey(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
         )
 
@@ -571,7 +571,7 @@ class CesionL1Test(CesionL0Test):
             "CesionL1("
             "dte_key=DteNaturalKey("
             "emisor_rut=Rut('76354771-K'),"
-            " tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>,"
+            " tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>,"
             " folio=170"
             "),"
             " seq=32,"
@@ -598,7 +598,7 @@ class CesionL1Test(CesionL0Test):
         expected_output = dict(
             dte_key=dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=32,
@@ -620,7 +620,7 @@ class CesionL1Test(CesionL0Test):
         expected_output = CesionL0(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=32,
@@ -639,7 +639,7 @@ class CesionL1Test(CesionL0Test):
         obj = self.obj_1
         expected_output = DteDataL1(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
             fecha_emision_date=date(2019, 4, 1),
             receptor_rut=Rut('96790240-3'),
@@ -707,7 +707,7 @@ class CesionL2Test(CesionL1Test):
     def _set_obj_1(self) -> None:
         obj_dte_natural_key = DteNaturalKey(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
         )
 
@@ -764,7 +764,7 @@ class CesionL2Test(CesionL1Test):
             "CesionL2("
             "dte_key=DteNaturalKey("
             "emisor_rut=Rut('76354771-K'),"
-            " tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>,"
+            " tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>,"
             " folio=170"
             "),"
             " seq=32,"
@@ -797,7 +797,7 @@ class CesionL2Test(CesionL1Test):
         expected_output = dict(
             dte_key=dict(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=32,
@@ -840,7 +840,7 @@ class CesionL2Test(CesionL1Test):
         expected_output = CesionL1(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=32,
@@ -864,7 +864,7 @@ class CesionL2Test(CesionL1Test):
         obj = self.obj_1
         expected_output = DteDataL2(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
             fecha_emision_date=date(2019, 4, 1),
             receptor_rut=Rut('96790240-3'),

--- a/tests/test_rtc_data_models_aec.py
+++ b/tests/test_rtc_data_models_aec.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 
 import pydantic
 
-from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.constants import TipoDte
 from cl_sii.dte.data_models import DteDataL1, DteNaturalKey, DteXmlData
 from cl_sii.libs import encoding_utils
 from cl_sii.libs import tz_utils
@@ -26,7 +26,7 @@ class CesionAecXmlTest(unittest.TestCase):
         obj = CesionAecXml(
             dte=DteDataL1(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -67,7 +67,7 @@ class CesionAecXmlTest(unittest.TestCase):
         obj = CesionAecXml(
             dte=DteDataL1(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -114,7 +114,7 @@ class CesionAecXmlTest(unittest.TestCase):
         expected_output = CesionNaturalKey(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=1,
@@ -125,7 +125,7 @@ class CesionAecXmlTest(unittest.TestCase):
         expected_output = CesionNaturalKey(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=2,
@@ -140,7 +140,7 @@ class CesionAecXmlTest(unittest.TestCase):
         expected_output = CesionAltNaturalKey(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             cedente_rut=Rut('76354771-K'),
@@ -156,7 +156,7 @@ class CesionAecXmlTest(unittest.TestCase):
         expected_output = CesionAltNaturalKey(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             cedente_rut=Rut('76389992-6'),
@@ -175,7 +175,7 @@ class CesionAecXmlTest(unittest.TestCase):
         expected_output = CesionL2(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=1,
@@ -227,7 +227,7 @@ class AecXmlTest(unittest.TestCase):
         )
         obj_dte = DteXmlData(
             emisor_rut=Rut('76354771-K'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=170,
             fecha_emision_date=date(2019, 4, 1),
             receptor_rut=Rut('96790240-3'),
@@ -249,7 +249,7 @@ class AecXmlTest(unittest.TestCase):
         obj_cesion_1 = CesionAecXml(
             dte=DteDataL1(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -286,7 +286,7 @@ class AecXmlTest(unittest.TestCase):
         obj_cesion_2 = CesionAecXml(
             dte=DteDataL1(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -363,7 +363,7 @@ class AecXmlTest(unittest.TestCase):
         expected_output = CesionNaturalKey(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=2,
@@ -377,7 +377,7 @@ class AecXmlTest(unittest.TestCase):
         expected_output = CesionAltNaturalKey(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             cedente_rut=Rut('76389992-6'),
@@ -411,7 +411,7 @@ class AecXmlTest(unittest.TestCase):
         expected_output = CesionL2(
             dte_key=DteNaturalKey(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
             ),
             seq=2,
@@ -462,7 +462,7 @@ class AecXmlTest(unittest.TestCase):
             {
                 'loc': ('dte',),
                 'msg':
-                    """('Value is not "cedible".', <TipoDteEnum.NOTA_CREDITO_ELECTRONICA: 61>)""",
+                    """('Value is not "cedible".', <TipoDte.NOTA_CREDITO_ELECTRONICA: 61>)""",
                 'type': 'value_error',
             },
         ]
@@ -472,7 +472,7 @@ class AecXmlTest(unittest.TestCase):
                 obj,
                 dte=dataclasses.replace(
                     obj.dte,
-                    tipo_dte=TipoDteEnum.NOTA_CREDITO_ELECTRONICA,
+                    tipo_dte=TipoDte.NOTA_CREDITO_ELECTRONICA,
                 ),
             )
 
@@ -627,13 +627,13 @@ class AecXmlTest(unittest.TestCase):
                     "'dte' of CesionAecXml with CesionNaturalKey("
                     "dte_key=DteNaturalKey("
                     "emisor_rut=Rut('76354771-K'),"
-                    " tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>,"
+                    " tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>,"
                     " folio=171),"
                     " seq=1"
                     ")"
                     " must match DteDataL1 with DteNaturalKey("
                     "emisor_rut=Rut('76354771-K'),"
-                    " tipo_dte=<TipoDteEnum.FACTURA_ELECTRONICA: 33>,"
+                    " tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>,"
                     " folio=170"
                     ").",
                 'type': 'value_error',

--- a/tests/test_rtc_data_models_cesiones_periodo.py
+++ b/tests/test_rtc_data_models_cesiones_periodo.py
@@ -5,7 +5,7 @@ from datetime import date, datetime
 
 import cl_sii.dte.data_models
 from cl_sii.base.constants import SII_OFFICIAL_TZ
-from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.constants import TipoDte
 from cl_sii.libs import tz_utils
 from cl_sii.libs.tz_utils import convert_naive_dt_to_tz_aware
 from cl_sii.rtc.data_models import CesionL2
@@ -20,7 +20,7 @@ class CesionesPeriodoEntryTest(unittest.TestCase):
         self.valid_kwargs = dict(
             dte_vendedor_rut=Rut('51532520-4'),
             dte_deudor_rut=Rut('75320502-0'),
-            dte_tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            dte_tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             dte_folio=3608460,
             dte_fecha_emision=date(2019, 2, 11),
             dte_monto_total=256357,
@@ -72,20 +72,20 @@ class CesionesPeriodoEntryTest(unittest.TestCase):
 
     def test_init_error_dte_tipo_dte_1(self) -> None:
         self.valid_kwargs.update(dict(
-            dte_tipo_dte=TipoDteEnum.NOTA_CREDITO_ELECTRONICA,
+            dte_tipo_dte=TipoDte.NOTA_CREDITO_ELECTRONICA,
         ))
         with self.assertRaises(ValueError) as cm:
             CesionesPeriodoEntry(**self.valid_kwargs)
         self.assertEqual(
             cm.exception.args,
             ("The \"tipo DTE\" in 'dte_tipo_dte' is not \"cedible\".",
-             TipoDteEnum.NOTA_CREDITO_ELECTRONICA))
+             TipoDte.NOTA_CREDITO_ELECTRONICA))
 
     def test_as_dte_data_l1_ok_1(self) -> None:
         obj = CesionesPeriodoEntry(**self.valid_kwargs)
         dte_obj = cl_sii.dte.data_models.DteDataL1(
             emisor_rut=Rut('51532520-4'),
-            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_ELECTRONICA,
             folio=3608460,
             receptor_rut=Rut('75320502-0'),
             fecha_emision_date=date(2019, 2, 11),
@@ -100,12 +100,12 @@ class CesionesPeriodoEntryTest(unittest.TestCase):
 
     def test_as_dte_data_l1_ok_2(self) -> None:
         self.valid_kwargs.update(dict(
-            dte_tipo_dte=TipoDteEnum.FACTURA_COMPRA_ELECTRONICA,
+            dte_tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA,
         ))
         obj = CesionesPeriodoEntry(**self.valid_kwargs)
         dte_obj = cl_sii.dte.data_models.DteDataL1(
             emisor_rut=Rut('75320502-0'),
-            tipo_dte=TipoDteEnum.FACTURA_COMPRA_ELECTRONICA,
+            tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA,
             folio=3608460,
             receptor_rut=Rut('51532520-4'),
             fecha_emision_date=date(2019, 2, 11),
@@ -123,7 +123,7 @@ class CesionesPeriodoEntryTest(unittest.TestCase):
         expected_output = CesionL2(
             dte_key=cl_sii.dte.data_models.DteNaturalKey(
                 emisor_rut=Rut('51532520-4'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=3608460,
             ),
             seq=None,
@@ -156,13 +156,13 @@ class CesionesPeriodoEntryTest(unittest.TestCase):
 
     def test_as_cesion_l2_ok_2(self) -> None:
         self.valid_kwargs.update(dict(
-            dte_tipo_dte=TipoDteEnum.FACTURA_COMPRA_ELECTRONICA,
+            dte_tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA,
         ))
         obj = CesionesPeriodoEntry(**self.valid_kwargs)
         expected_output = CesionL2(
             dte_key=cl_sii.dte.data_models.DteNaturalKey(
                 emisor_rut=Rut('75320502-0'),
-                tipo_dte=TipoDteEnum.FACTURA_COMPRA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA,
                 folio=3608460,
             ),
             seq=None,

--- a/tests/test_rtc_parse_aec.py
+++ b/tests/test_rtc_parse_aec.py
@@ -4,7 +4,7 @@ import unittest
 from datetime import date, datetime
 
 from cl_sii.dte.data_models import DteDataL1, DteXmlData
-from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.dte.constants import TipoDte
 from cl_sii.dte.parse import DTE_XMLNS
 from cl_sii.libs import encoding_utils
 from cl_sii.libs import tz_utils
@@ -155,7 +155,7 @@ class AecXmlParserTest(unittest.TestCase):
         expected_output = AecXml(
             dte=DteXmlData(
                 emisor_rut=Rut('76354771-K'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
@@ -185,7 +185,7 @@ class AecXmlParserTest(unittest.TestCase):
                 CesionAecXml(
                     dte=DteDataL1(
                         emisor_rut=Rut('76354771-K'),
-                        tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                        tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                         folio=170,
                         fecha_emision_date=date(2019, 4, 1),
                         receptor_rut=Rut('96790240-3'),
@@ -221,7 +221,7 @@ class AecXmlParserTest(unittest.TestCase):
                 CesionAecXml(
                     dte=DteDataL1(
                         emisor_rut=Rut('76354771-K'),
-                        tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                        tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                         folio=170,
                         fecha_emision_date=date(2019, 4, 1),
                         receptor_rut=Rut('96790240-3'),
@@ -273,7 +273,7 @@ class AecXmlParserTest(unittest.TestCase):
         expected_output = AecXml(
             dte=DteXmlData(
                 emisor_rut=Rut('76399752-9'),
-                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=25568,
                 fecha_emision_date=date(2019, 3, 29),
                 receptor_rut=Rut('96874030-K'),
@@ -303,7 +303,7 @@ class AecXmlParserTest(unittest.TestCase):
                 CesionAecXml(
                     dte=DteDataL1(
                         emisor_rut=Rut('76399752-9'),
-                        tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                        tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                         folio=25568,
                         fecha_emision_date=date(2019, 3, 29),
                         receptor_rut=Rut('96874030-K'),


### PR DESCRIPTION
- (PR #261, 2021-12-24) chore(rtc.parse): Disable validation that AEC signature cert is loadable
- (PR #253, 2021-12-24) Rename of the enum class for `TipoDte` object