### PR TITLE
cl_sii.rut: Add method to get the RUT of the certificate holder

### DIFF
--- a/cl_sii/rut/constants.py
+++ b/cl_sii/rut/constants.py
@@ -7,6 +7,8 @@ https://github.com/fyntex/lib-cl-sii-python/blob/f57a326/cl_sii/data/ref/factura
 """
 import re
 
+import cryptography.x509
+
 
 RUT_CANONICAL_STRICT_REGEX = re.compile(r'^(?P<digits>\d{1,8})-(?P<dv>[\dK])$')
 """RUT (strict) regex for canonical format."""
@@ -18,3 +20,22 @@ RUT_DIGITS_MAX_VALUE = 99999999
 """RUT digits max value."""
 RUT_DIGITS_MIN_VALUE = 50000000
 """RUT digits min value."""
+
+SII_CERT_TITULAR_RUT_OID = cryptography.x509.oid.ObjectIdentifier("1.3.6.1.4.1.8321.1")
+"""OID of the RUT of the certificate holder"""
+# - Organismo: MINISTERIO DE ECONOMÍA / SUBSECRETARIA DE ECONOMIA
+# - Decreto 181 (Julio-Agosto 2002)
+#   "APRUEBA REGLAMENTO DE LA LEY 19.799 SOBRE DOCUMENTOS ELECTRONICOS, FIRMA ELECTRONICA
+#   Y LA CERTIFICACION DE DICHA FIRMA"
+# - ref: https://www.leychile.cl/Consulta/m/norma_plana?org=&idNorma=201668
+# dice:
+# > RUT del titular del certificado : 1.3.6.1.4.1.8321.1
+# > RUT de la certificadora emisora : 1.3.6.1.4.1.8321.2
+#
+# - ref: http://acepta.newtenberg.com/1919/articles-82538_recurso_3.pdf
+# dice:
+# > OtherName: Para certificados de identidad de individuos, aquí se registra el RUT, en
+# > la siguiente estructura:
+#   Type-id = 1.3.6.1.4.1.8321.1
+#   Value ='xx.xxx.xx-v'
+# > El campo Value es un IA5String con el RUT del individuo titular del certificado.

--- a/cl_sii/rut/crypto_utils.py
+++ b/cl_sii/rut/crypto_utils.py
@@ -1,0 +1,49 @@
+import re
+from typing import Optional
+
+import cryptography
+import cryptography.x509
+from cryptography.hazmat.backends.openssl import backend as crypto_x509_backend
+
+from . import constants
+from . import Rut
+
+
+def get_subject_rut_from_certificate_pfx(pfx_file_bytes: bytes, password: Optional[str]) -> Rut:
+    """
+    Return the Chilean RUT stored in a digital certificate.
+
+    Original source URL: https://github.com/fyntex/fd-cl-data/blob/cfd5a716fb9b2cbd8a03fca1bacfd1b844b1337f/fd_cl_data/apps/sii_auth/models/sii_auth_credential.py#L701-L745  # noqa: E501
+
+    :param pfx_file_bytes: Digital certificate in PKCS12 format
+    :param password: (Optional) The password to use to decrypt the PKCS12 file
+    """
+    private_key, x509_cert, additional_certs = crypto_x509_backend.load_key_and_certificates_from_pkcs12(  # noqa: E501
+        data=pfx_file_bytes,
+        password=password.encode() if password is not None else None,
+    )
+    # https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/#cryptography.hazmat.primitives.serialization.pkcs12.load_key_and_certificates  # noqa: E501
+
+    subject_alt_name_ext = x509_cert.extensions.get_extension_for_class(
+        cryptography.x509.extensions.SubjectAlternativeName,
+    )
+
+    # Search for the RUT in the certificate.
+    try:
+        results = [
+            x.value
+            for x in subject_alt_name_ext.value._general_names
+            if x.type_id == constants.SII_CERT_TITULAR_RUT_OID
+        ]
+    except AttributeError:
+        raise Exception('Certificate has no RUT information')
+
+    if not results:
+        raise Exception('Certificate has no RUT information')
+    elif len(results) > 1:
+        raise Exception(f'len(results) == {len(results)}')
+
+    subject_rut_raw: bytes = results[0]
+    subject_rut = re.sub(r'[^0-9-]', '', subject_rut_raw.decode('utf-8'))
+
+    return Rut(subject_rut)

--- a/tests/test_libs_crypto_utils.py
+++ b/tests/test_libs_crypto_utils.py
@@ -11,6 +11,7 @@ from cl_sii.libs.crypto_utils import (  # noqa: F401
     remove_pem_cert_header_footer,
     x509_cert_der_to_pem, x509_cert_pem_to_der,
 )
+from cl_sii.rut.constants import SII_CERT_TITULAR_RUT_OID
 
 from . import utils
 
@@ -24,10 +25,8 @@ from . import utils
 #   Y LA CERTIFICACION DE DICHA FIRMA"
 # - ref: https://www.leychile.cl/Consulta/m/norma_plana?org=&idNorma=201668
 # dice:
-# > RUT del titular del certificado : 1.3.6.1.4.1.8321.1
 # > RUT de la certificadora emisora : 1.3.6.1.4.1.8321.2
 _SII_CERT_CERTIFICADORA_EMISORA_RUT_OID = oid.ObjectIdentifier("1.3.6.1.4.1.8321.2")
-_SII_CERT_TITULAR_RUT_OID = oid.ObjectIdentifier("1.3.6.1.4.1.8321.1")
 
 
 class FunctionsTest(unittest.TestCase):
@@ -332,7 +331,7 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(len(subject_alt_name_ext.value._general_names._general_names), 1)
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].type_id,
-            _SII_CERT_TITULAR_RUT_OID)
+            SII_CERT_TITULAR_RUT_OID)
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].value,
             b'\x16\n13185095-6')
@@ -527,7 +526,7 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(len(subject_alt_name_ext.value._general_names._general_names), 1)
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].type_id,
-            _SII_CERT_TITULAR_RUT_OID)
+            SII_CERT_TITULAR_RUT_OID)
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].value,
             b'\x16\t8480437-1')
@@ -721,7 +720,7 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(subject_alt_name_ext.critical, False)
         self.assertEqual(len(subject_alt_name_ext.value._general_names._general_names), 1)
         # TODO: find out where did OID '1.3.6.1.4.1.8658.1' come from.
-        #   Shouldn't it have been equal to '_SII_CERT_TITULAR_RUT_OID'?
+        #   Shouldn't it have been equal to 'cl_sii.rut.constants.SII_CERT_TITULAR_RUT_OID'?
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].type_id,
             oid.ObjectIdentifier("1.3.6.1.4.1.8658.1"))

--- a/tests/test_rut_crypto_utils.py
+++ b/tests/test_rut_crypto_utils.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from cryptography.hazmat.backends.openssl import backend as crypto_x509_backend
+
+from cl_sii import rut
+from cl_sii.libs.crypto_utils import load_der_x509_cert
+from cl_sii.rut.crypto_utils import get_subject_rut_from_certificate_pfx
+
+from . import utils
+
+
+class FunctionsTest(unittest.TestCase):
+    def test_get_subject_rut_from_certificate_pfx_ok(self) -> None:
+        cert_der_bytes = utils.read_test_file_bytes(
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der'
+        )
+
+        x509_cert = load_der_x509_cert(cert_der_bytes)
+
+        with patch.object(
+            crypto_x509_backend,
+            'load_key_and_certificates_from_pkcs12',
+            Mock(return_value=(None, x509_cert, None)),
+        ):
+            pfx_file_bytes = b'hello'
+            password = 'fake_password'
+            subject_rut = get_subject_rut_from_certificate_pfx(
+                pfx_file_bytes=pfx_file_bytes,
+                password=password,
+            )
+            self.assertIsInstance(subject_rut, rut.Rut)
+            self.assertEqual(subject_rut, rut.Rut('13185095-6'))
+
+    def test_get_subject_rut_from_certificate_pfx_fails_if_rut_info_is_missing(self) -> None:
+        cert_der_bytes = utils.read_test_file_bytes(
+            'test_data/crypto/wildcard-google-com-cert.der'
+        )
+
+        x509_cert = load_der_x509_cert(cert_der_bytes)
+
+        with patch.object(
+            crypto_x509_backend,
+            'load_key_and_certificates_from_pkcs12',
+            Mock(return_value=(None, x509_cert, None)),
+        ):
+            pfx_file_bytes = b'hello'
+            password = 'fake_password'
+            with self.assertRaises(Exception) as cm:
+                get_subject_rut_from_certificate_pfx(
+                    pfx_file_bytes=pfx_file_bytes,
+                    password=password,
+                )
+            self.assertEqual(cm.exception.args, ('Certificate has no RUT information',))


### PR DESCRIPTION
 Get the Chilean RUT stored in a digital certificate.

- Add constant `SII_CERT_TITULAR_RUT_OID`
- Add module `cl_sii.rut.crypto_utils` including the method  `get_subject_rut_from_certificate_pfx`
- Add test