### PR TITLE
chore: Add tool to automatically sort Python imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,24 @@
+# Isort Configuration
+#
+# Isort is a Python import sorter.
+#
+# - Web site: https://github.com/PyCQA/isort/
+# - Configuration options: https://pycqa.github.io/isort/docs/configuration/options/
+
+[settings]
+combine_as_imports=false
+ensure_newline_before_comments=true
+extra_standard_library=
+force_grid_wrap=0
+force_single_line=false
+include_trailing_comma=true
+known_first_party=
+known_local_folder=
+known_third_party=
+line_length=100
+lines_after_imports=2
+multi_line_output=3
+no_lines_before=LOCALFOLDER
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+skip_gitignore=true
+use_parentheses=true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL = /usr/bin/env bash
 .DEFAULT_GOAL := help
 .PHONY: help
 .PHONY: clean clean-build clean-pyc clean-test
-.PHONY: lint test test-all test-coverage test-coverage-report-console test-coverage-report-html
+.PHONY: lint lint-fix test test-all test-coverage test-coverage-report-console test-coverage-report-html
 .PHONY: dist upload-release
 
 help:
@@ -35,6 +35,10 @@ clean-test: ## remove test, lint and coverage artifacts
 lint: ## run tools for code style analysis, static type check, etc
 	flake8 --config=setup.cfg  cl_sii  scripts  tests
 	mypy --config-file setup.cfg  cl_sii  scripts
+	isort --check-only .
+
+lint-fix: ## Fix lint errors
+	isort .
 
 test: ## run tests quickly with the default Python
 	python setup.py test

--- a/cl_sii/cte/f29/data_models.py
+++ b/cl_sii/cte/f29/data_models.py
@@ -13,15 +13,17 @@ from typing import (
     Any,
     ClassVar,
     Iterator,
-    Mapping, MutableMapping,
+    Mapping,
+    MutableMapping,
     Optional,
     Set,
-    Type, Tuple,
+    Tuple,
+    Type,
     Union,
 )
 
-from cl_sii.rut import Rut
 from cl_sii.rcv.data_models import PeriodoTributario
+from cl_sii.rut import Rut
 
 
 logger = logging.getLogger(__name__)

--- a/cl_sii/cte/f29/parse_datos_obj.py
+++ b/cl_sii/cte/f29/parse_datos_obj.py
@@ -8,9 +8,8 @@ from typing import Callable, Mapping, MutableMapping, Optional
 import jsonschema
 
 from cl_sii.libs.json_utils import JsonSchemaValidationError, read_json_schema
-from cl_sii.rut import Rut
 from cl_sii.rcv.data_models import PeriodoTributario
-
+from cl_sii.rut import Rut
 from .data_models import CteForm29
 
 

--- a/cl_sii/dte/data_models.py
+++ b/cl_sii/dte/data_models.py
@@ -26,7 +26,6 @@ import cl_sii.rut.constants
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.libs import tz_utils
 from cl_sii.rut import Rut
-
 from . import constants
 from .constants import TipoDte
 

--- a/cl_sii/dte/parse.py
+++ b/cl_sii/dte/parse.py
@@ -23,13 +23,10 @@ import os
 from datetime import date, datetime
 from typing import Optional, Tuple
 
-from cl_sii.libs import encoding_utils
-from cl_sii.libs import tz_utils
-from cl_sii.libs import xml_utils
+from cl_sii.libs import encoding_utils, tz_utils, xml_utils
 from cl_sii.libs.xml_utils import XmlElement, XmlElementTree
 from cl_sii.rut import Rut
-from . import constants
-from . import data_models
+from . import constants, data_models
 
 
 logger = logging.getLogger(__name__)

--- a/cl_sii/libs/rows_processing.py
+++ b/cl_sii/libs/rows_processing.py
@@ -1,6 +1,5 @@
 import csv
 import logging
-
 from typing import Dict, Iterable, Sequence, Tuple
 
 import marshmallow

--- a/cl_sii/libs/xml_utils.py
+++ b/cl_sii/libs/xml_utils.py
@@ -22,6 +22,8 @@ It is used by various Web technologies such as SOAP, SAML, and others.
 import io
 import logging
 import os
+import xml.parsers.expat
+import xml.parsers.expat.errors
 from typing import IO, Optional, Tuple, Union
 
 import defusedxml
@@ -29,12 +31,11 @@ import defusedxml.lxml
 import lxml.etree
 import signxml
 import signxml.exceptions
-import xml.parsers.expat
-import xml.parsers.expat.errors
-from lxml.etree import ElementBase as XmlElement  # noqa: F401
-# note: 'lxml.etree.ElementTree' is a **function**, not a class.
-from lxml.etree import _ElementTree as XmlElementTree  # noqa: F401
-from lxml.etree import XMLSchema as XmlSchema  # noqa: F401
+from lxml.etree import ElementBase as XmlElement
+from lxml.etree import XMLSchema as XmlSchema
+from lxml.etree import (  # note: 'lxml.etree.ElementTree' is a **function**, not a class.  # noqa: E501
+    _ElementTree as XmlElementTree,
+)
 
 from . import crypto_utils
 

--- a/cl_sii/rcv/data_models.py
+++ b/cl_sii/rcv/data_models.py
@@ -16,7 +16,6 @@ import cl_sii.dte.data_models
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.libs import tz_utils
 from cl_sii.rut import Rut
-
 from .constants import RcEstadoContable, RcvKind, RcvTipoDocto
 
 

--- a/cl_sii/rcv/parse_csv.py
+++ b/cl_sii/rcv/parse_csv.py
@@ -13,17 +13,16 @@ import marshmallow
 
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.extras import mm_fields
-from cl_sii.libs import csv_utils
-from cl_sii.libs import mm_utils
-from cl_sii.libs import rows_processing
-from cl_sii.libs import tz_utils
+from cl_sii.libs import csv_utils, mm_utils, rows_processing, tz_utils
 from cl_sii.rut import Rut
-
 from .constants import RcEstadoContable, RcvKind
 from .data_models import (
-    RcvDetalleEntry, RcNoIncluirDetalleEntry,
-    RcPendienteDetalleEntry, RcReclamadoDetalleEntry,
-    RcRegistroDetalleEntry, RvDetalleEntry,
+    RcNoIncluirDetalleEntry,
+    RcPendienteDetalleEntry,
+    RcReclamadoDetalleEntry,
+    RcRegistroDetalleEntry,
+    RcvDetalleEntry,
+    RvDetalleEntry,
 )
 
 

--- a/cl_sii/rtc/data_models.py
+++ b/cl_sii/rtc/data_models.py
@@ -30,7 +30,6 @@ from cl_sii.dte import data_models as dte_data_models
 from cl_sii.dte.constants import TipoDte
 from cl_sii.libs import tz_utils
 from cl_sii.rut import Rut
-
 from . import constants
 
 

--- a/cl_sii/rtc/data_models_aec.py
+++ b/cl_sii/rtc/data_models_aec.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import dataclasses
 from datetime import date, datetime
-from typing import ClassVar, Mapping, Tuple, Optional, Sequence
+from typing import ClassVar, Mapping, Optional, Sequence, Tuple
 
 import pydantic
 
@@ -15,7 +15,6 @@ from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.dte import data_models as dte_data_models
 from cl_sii.libs import tz_utils
 from cl_sii.rut import Rut
-
 from . import data_models
 
 

--- a/cl_sii/rtc/data_models_cesiones_periodo.py
+++ b/cl_sii/rtc/data_models_cesiones_periodo.py
@@ -10,7 +10,6 @@ from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.dte.constants import TipoDte
 from cl_sii.libs import tz_utils
 from cl_sii.rut import Rut
-
 from . import data_models
 from .constants import CESION_MONTO_CEDIDO_FIELD_MIN_VALUE, TIPO_DTE_CEDIBLES
 

--- a/cl_sii/rtc/parse_aec.py
+++ b/cl_sii/rtc/parse_aec.py
@@ -31,7 +31,6 @@ from cl_sii.dte.parse import DTE_XMLNS_MAP
 from cl_sii.libs import encoding_utils, tz_utils, xml_utils
 from cl_sii.libs.xml_utils import XmlElement
 from cl_sii.rut import Rut
-
 from . import data_models_aec
 
 

--- a/cl_sii/rtc/xml_utils.py
+++ b/cl_sii/rtc/xml_utils.py
@@ -7,7 +7,6 @@ import signxml
 
 from cl_sii.dte.parse import DTE_XMLNS_MAP
 from cl_sii.libs import crypto_utils, xml_utils
-
 from .data_models_aec import AecXml
 
 

--- a/cl_sii/rut/crypto_utils.py
+++ b/cl_sii/rut/crypto_utils.py
@@ -5,8 +5,7 @@ import cryptography
 import cryptography.x509
 from cryptography.hazmat.backends.openssl import backend as crypto_x509_backend
 
-from . import constants
-from . import Rut
+from . import Rut, constants
 
 
 def get_subject_rut_from_certificate_pfx(pfx_file_bytes: bytes, password: Optional[str]) -> Rut:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,6 +6,7 @@
 codecov==2.1.11
 coverage==5.3
 flake8==3.8.4
+isort==5.10.1
 mypy==0.790
 tox==3.20.1
 

--- a/scripts/canonicalize_xml_file.py
+++ b/scripts/canonicalize_xml_file.py
@@ -27,6 +27,7 @@ import sys
 import xml.etree.ElementTree
 from typing import BinaryIO, Iterable, TextIO, Union
 
+
 try:
     import cl_sii  # noqa: F401
 except ImportError:

--- a/scripts/clean_dte_xml_file.py
+++ b/scripts/clean_dte_xml_file.py
@@ -22,6 +22,7 @@ import pathlib
 import sys
 from typing import Iterable
 
+
 try:
     import cl_sii  # noqa: F401
 except ImportError:

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -19,6 +19,7 @@ import sys
 from datetime import datetime
 from typing import Sequence
 
+
 try:
     import cl_sii  # noqa: F401
 except ImportError:

--- a/tests/test_cte_f29_parse_datos_obj.py
+++ b/tests/test_cte_f29_parse_datos_obj.py
@@ -5,11 +5,9 @@ from decimal import Decimal
 from typing import Any, Mapping
 from unittest import TestCase
 
-from cl_sii.cte.f29 import data_models
-from cl_sii.cte.f29 import parse_datos_obj
+from cl_sii.cte.f29 import data_models, parse_datos_obj
 from cl_sii.rcv.data_models import PeriodoTributario
 from cl_sii.rut import Rut
-
 from .utils import read_test_file_json_dict
 
 

--- a/tests/test_dte_data_models.py
+++ b/tests/test_dte_data_models.py
@@ -5,11 +5,7 @@ from datetime import date, datetime
 
 import pydantic
 
-from cl_sii.libs import encoding_utils
-from cl_sii.libs import tz_utils
-from cl_sii.rut import Rut  # noqa: F401
-
-from cl_sii.dte.constants import (  # noqa: F401
+from cl_sii.dte.constants import (
     DTE_FOLIO_FIELD_MAX_VALUE,
     DTE_FOLIO_FIELD_MIN_VALUE,
     DTE_MONTO_TOTAL_FIELD_MAX_VALUE,
@@ -17,10 +13,17 @@ from cl_sii.dte.constants import (  # noqa: F401
     TipoDte,
 )
 from cl_sii.dte.data_models import (  # noqa: F401
-    DteDataL0, DteDataL1, DteDataL2, DteNaturalKey, DteXmlData,
-    validate_contribuyente_razon_social, validate_dte_folio, validate_dte_monto_total,
+    DteDataL0,
+    DteDataL1,
+    DteDataL2,
+    DteNaturalKey,
+    DteXmlData,
+    validate_contribuyente_razon_social,
+    validate_dte_folio,
+    validate_dte_monto_total,
 )
-
+from cl_sii.libs import encoding_utils, tz_utils
+from cl_sii.rut import Rut
 from .utils import read_test_file_bytes
 
 

--- a/tests/test_dte_parse.py
+++ b/tests/test_dte_parse.py
@@ -5,18 +5,18 @@ from datetime import date, datetime
 
 import cl_sii.dte.constants
 from cl_sii.dte.data_models import DteDataL2
-from cl_sii.libs import crypto_utils
-from cl_sii.libs import encoding_utils
-from cl_sii.libs import tz_utils
-from cl_sii.libs import xml_utils
-from cl_sii.rut import Rut
-
 from cl_sii.dte.parse import (  # noqa: F401
-    clean_dte_xml, parse_dte_xml, validate_dte_xml,
-    _remove_dte_xml_doc_personalizado, _set_dte_xml_missing_xmlns,
-    DTE_XML_SCHEMA_OBJ, DTE_XMLNS, DTE_XMLNS_MAP
+    DTE_XML_SCHEMA_OBJ,
+    DTE_XMLNS,
+    DTE_XMLNS_MAP,
+    _remove_dte_xml_doc_personalizado,
+    _set_dte_xml_missing_xmlns,
+    clean_dte_xml,
+    parse_dte_xml,
+    validate_dte_xml,
 )
-
+from cl_sii.libs import crypto_utils, encoding_utils, tz_utils, xml_utils
+from cl_sii.rut import Rut
 from .utils import read_test_file_bytes
 
 

--- a/tests/test_extras_drf_fields.py
+++ b/tests/test_extras_drf_fields.py
@@ -2,6 +2,7 @@ import unittest
 
 import rest_framework  # noqa: F401
 
+
 # TODO: create a test setup that at least makes it possible to run the following imports
 #   (underlying `import rest_framework.fields` raises Django's 'ImproperlyConfigured'):
 # from cl_sii.extras.drf_fields import Rut, RutField

--- a/tests/test_extras_mm_fields.py
+++ b/tests/test_extras_mm_fields.py
@@ -1,13 +1,17 @@
-from datetime import date, datetime
 import unittest
+from datetime import date, datetime
 
 import marshmallow
 
 from cl_sii.extras.mm_fields import (
-    RcvPeriodoTributario, RcvPeriodoTributarioField,
-    RcvTipoDocto, RcvTipoDoctoField,
-    Rut, RutField,
-    TipoDte, TipoDteField,
+    RcvPeriodoTributario,
+    RcvPeriodoTributarioField,
+    RcvTipoDocto,
+    RcvTipoDoctoField,
+    Rut,
+    RutField,
+    TipoDte,
+    TipoDteField,
 )
 
 

--- a/tests/test_libs_crypto_utils.py
+++ b/tests/test_libs_crypto_utils.py
@@ -7,13 +7,17 @@ import cryptography.x509
 from cryptography.x509 import oid
 
 from cl_sii.libs.crypto_utils import (  # noqa: F401
-    X509Cert, add_pem_cert_header_footer, load_der_x509_cert, load_pem_x509_cert,
+    X509Cert,
+    add_pem_cert_header_footer,
+    load_der_x509_cert,
+    load_pem_x509_cert,
     remove_pem_cert_header_footer,
-    x509_cert_der_to_pem, x509_cert_pem_to_der,
+    x509_cert_der_to_pem,
+    x509_cert_pem_to_der,
 )
 from cl_sii.rut.constants import SII_CERT_TITULAR_RUT_OID
-
 from . import utils
+
 
 # TODO: get fake certificates, keys, and all the variations from
 #   https://github.com/urllib3/urllib3/tree/1.24.2/dummyserver/certs

--- a/tests/test_libs_dataclass_utils.py
+++ b/tests/test_libs_dataclass_utils.py
@@ -3,7 +3,10 @@ import unittest
 from typing import Dict
 
 from cl_sii.libs.dataclass_utils import (
-    DcDeepCompareMixin, DcDeepComparison, dc_deep_compare, _dc_deep_compare_to,
+    DcDeepCompareMixin,
+    DcDeepComparison,
+    _dc_deep_compare_to,
+    dc_deep_compare,
 )
 
 

--- a/tests/test_libs_encoding_utils.py
+++ b/tests/test_libs_encoding_utils.py
@@ -1,6 +1,10 @@
 import unittest
 
-from cl_sii.libs.encoding_utils import clean_base64, decode_base64_strict, validate_base64  # noqa: F401,E501
+from cl_sii.libs.encoding_utils import (  # noqa: F401
+    clean_base64,
+    decode_base64_strict,
+    validate_base64,
+)
 
 
 class FunctionsTest(unittest.TestCase):

--- a/tests/test_libs_json_utils.py
+++ b/tests/test_libs_json_utils.py
@@ -1,7 +1,6 @@
 import unittest
 
 from cl_sii.libs.json_utils import read_json_schema  # noqa: F401
-
 from .utils import read_test_file_json_dict  # noqa: F401
 
 

--- a/tests/test_libs_mm_utils.py
+++ b/tests/test_libs_mm_utils.py
@@ -1,7 +1,8 @@
 import unittest
 
 from cl_sii.libs.mm_utils import (  # noqa: F401
-    CustomMarshmallowDateField, validate_no_unexpected_input_fields,
+    CustomMarshmallowDateField,
+    validate_no_unexpected_input_fields,
 )
 
 

--- a/tests/test_libs_rows_processing.py
+++ b/tests/test_libs_rows_processing.py
@@ -1,7 +1,8 @@
 import unittest
 
 from cl_sii.libs.rows_processing import (  # noqa: F401
-    csv_rows_mm_deserialization_iterator, rows_mm_deserialization_iterator,
+    csv_rows_mm_deserialization_iterator,
+    rows_mm_deserialization_iterator,
 )
 
 

--- a/tests/test_libs_tz_utils.py
+++ b/tests/test_libs_tz_utils.py
@@ -3,9 +3,15 @@ import re
 import unittest
 
 from cl_sii.libs.tz_utils import (  # noqa: F401
-    convert_naive_dt_to_tz_aware, convert_tz_aware_dt_to_naive,
-    dt_is_aware, dt_is_naive, get_now_tz_aware, validate_dt_tz,
-    PytzTimezone, _TZ_CL_SANTIAGO, TZ_UTC,
+    _TZ_CL_SANTIAGO,
+    TZ_UTC,
+    PytzTimezone,
+    convert_naive_dt_to_tz_aware,
+    convert_tz_aware_dt_to_naive,
+    dt_is_aware,
+    dt_is_naive,
+    get_now_tz_aware,
+    validate_dt_tz,
 )
 
 

--- a/tests/test_libs_xml_utils.py
+++ b/tests/test_libs_xml_utils.py
@@ -4,14 +4,20 @@ import unittest
 import lxml.etree
 
 from cl_sii.libs.crypto_utils import load_pem_x509_cert
-
-from cl_sii.libs.xml_utils import XmlElement
 from cl_sii.libs.xml_utils import (  # noqa: F401
-    XmlSyntaxError, XmlFeatureForbidden, XmlSchemaDocValidationError,
-    XmlSignatureInvalid, XmlSignatureInvalidCertificate, XmlSignatureUnverified,
-    parse_untrusted_xml, read_xml_schema, validate_xml_doc, verify_xml_signature, write_xml_doc,
+    XmlElement,
+    XmlFeatureForbidden,
+    XmlSchemaDocValidationError,
+    XmlSignatureInvalid,
+    XmlSignatureInvalidCertificate,
+    XmlSignatureUnverified,
+    XmlSyntaxError,
+    parse_untrusted_xml,
+    read_xml_schema,
+    validate_xml_doc,
+    verify_xml_signature,
+    write_xml_doc,
 )
-
 from .utils import read_test_file_bytes
 
 

--- a/tests/test_rcv_data_models.py
+++ b/tests/test_rcv_data_models.py
@@ -15,7 +15,7 @@ from cl_sii.rcv.data_models import (
     RcReclamadoDetalleEntry,
     RcRegistroDetalleEntry,
     RcvDetalleEntry,
-    RvDetalleEntry
+    RvDetalleEntry,
 )
 from cl_sii.rut import Rut
 

--- a/tests/test_rcv_parse_csv.py
+++ b/tests/test_rcv_parse_csv.py
@@ -2,16 +2,19 @@ import unittest
 from typing import Callable
 
 from cl_sii.rcv.parse_csv import (  # noqa: F401
-    RcvCompraNoIncluirCsvRowSchema, RcvCompraPendienteCsvRowSchema,
-    RcvCompraReclamadoCsvRowSchema, RcvCompraRegistroCsvRowSchema,
+    RcvCompraNoIncluirCsvRowSchema,
+    RcvCompraPendienteCsvRowSchema,
+    RcvCompraReclamadoCsvRowSchema,
+    RcvCompraRegistroCsvRowSchema,
     RcvVentaCsvRowSchema,
-    parse_rcv_compra_no_incluir_csv_file, parse_rcv_compra_pendiente_csv_file,
-    parse_rcv_compra_reclamado_csv_file, parse_rcv_compra_registro_csv_file,
-    parse_rcv_venta_csv_file,
     _parse_rcv_csv_file,
+    parse_rcv_compra_no_incluir_csv_file,
+    parse_rcv_compra_pendiente_csv_file,
+    parse_rcv_compra_reclamado_csv_file,
+    parse_rcv_compra_registro_csv_file,
+    parse_rcv_venta_csv_file,
 )
 from cl_sii.rut import Rut
-
 from .utils import get_test_file_path
 
 

--- a/tests/test_rtc_data_models.py
+++ b/tests/test_rtc_data_models.py
@@ -6,15 +6,15 @@ from datetime import date, datetime
 
 import pydantic
 
-from cl_sii.dte.data_models import DteNaturalKey, DteDataL1, DteDataL2
 from cl_sii.dte.constants import TipoDte
+from cl_sii.dte.data_models import DteDataL1, DteDataL2, DteNaturalKey
 from cl_sii.libs import tz_utils
 from cl_sii.rtc.data_models import (
-    CesionNaturalKey,
     CesionAltNaturalKey,
     CesionL0,
     CesionL1,
     CesionL2,
+    CesionNaturalKey,
 )
 from cl_sii.rut import Rut
 

--- a/tests/test_rtc_data_models_aec.py
+++ b/tests/test_rtc_data_models_aec.py
@@ -8,12 +8,10 @@ import pydantic
 
 from cl_sii.dte.constants import TipoDte
 from cl_sii.dte.data_models import DteDataL1, DteNaturalKey, DteXmlData
-from cl_sii.libs import encoding_utils
-from cl_sii.libs import tz_utils
-from cl_sii.rtc.data_models import CesionL2, CesionNaturalKey, CesionAltNaturalKey
-from cl_sii.rtc.data_models_aec import CesionAecXml, AecXml
+from cl_sii.libs import encoding_utils, tz_utils
+from cl_sii.rtc.data_models import CesionAltNaturalKey, CesionL2, CesionNaturalKey
+from cl_sii.rtc.data_models_aec import AecXml, CesionAecXml
 from cl_sii.rut import Rut
-
 from .utils import read_test_file_bytes
 
 

--- a/tests/test_rtc_parse_aec.py
+++ b/tests/test_rtc_parse_aec.py
@@ -3,17 +3,13 @@ from __future__ import annotations
 import unittest
 from datetime import date, datetime
 
-from cl_sii.dte.data_models import DteDataL1, DteXmlData
 from cl_sii.dte.constants import TipoDte
+from cl_sii.dte.data_models import DteDataL1, DteXmlData
 from cl_sii.dte.parse import DTE_XMLNS
-from cl_sii.libs import encoding_utils
-from cl_sii.libs import tz_utils
-from cl_sii.libs import xml_utils
-from cl_sii.rut import Rut
-
-from cl_sii.rtc.data_models_aec import CesionAecXml, AecXml
+from cl_sii.libs import encoding_utils, tz_utils, xml_utils
+from cl_sii.rtc.data_models_aec import AecXml, CesionAecXml
 from cl_sii.rtc.parse_aec import AEC_XML_SCHEMA_OBJ, parse_aec_xml, validate_aec_xml
-
+from cl_sii.rut import Rut
 from .utils import read_test_file_bytes
 
 

--- a/tests/test_rtc_xml_utils.py
+++ b/tests/test_rtc_xml_utils.py
@@ -8,7 +8,6 @@ from cl_sii.libs.crypto_utils import load_pem_x509_cert
 from cl_sii.libs.xml_utils import parse_untrusted_xml, verify_xml_signature, write_xml_doc
 from cl_sii.rtc.parse_aec import parse_aec_xml
 from cl_sii.rtc.xml_utils import AecXMLVerifier, verify_aec_signature
-
 from .utils import read_test_file_bytes
 
 

--- a/tests/test_rut_crypto_utils.py
+++ b/tests/test_rut_crypto_utils.py
@@ -6,7 +6,6 @@ from cryptography.hazmat.backends.openssl import backend as crypto_x509_backend
 from cl_sii import rut
 from cl_sii.libs.crypto_utils import load_der_x509_cert
 from cl_sii.rut.crypto_utils import get_subject_rut_from_certificate_pfx
-
 from . import utils
 
 


### PR DESCRIPTION
- Add `isort` to Python dependencies.
- Add Isort configuration.
- Add Isort to `lint` and `lint-fix`(new) Make tasks
- Sort Python imports with Isort in `cl_sii`, `scripts`, and `tests`


## About Isort

> isort is a Python utility / library to sort imports alphabetically, and automatically separated into sections and by type. It provides a command line utility, Python library and plugins for various editors to quickly sort all your imports.

- VCS: https://github.com/PyCQA/isort/
- Documentation: https://pycqa.github.io/isort/
- Python Package Index: https://pypi.org/project/isort/

-----


Internal Ref: https://cordada.aha.io/features/COMPCLDATA-29