### PR TITLE
Add 'Black' Python code formatter

### DIFF
--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -11,5 +11,5 @@ line-length = 100
 skip-string-normalization = true
 target-version = ['py38', 'py39']
 extend-exclude = '''
-^/cl_sii/(extras|libs|rcv|rtc|rut)/|tests/
+^/cl_sii/(libs|rcv|rtc|rut)/|tests/
 '''

--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -11,5 +11,5 @@ line-length = 100
 skip-string-normalization = true
 target-version = ['py38', 'py39']
 extend-exclude = '''
-^/cl_sii/(libs|rcv|rtc|rut)/|tests/
+^/cl_sii/(rcv|rtc|rut)/|tests/
 '''

--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -11,5 +11,5 @@ line-length = 100
 skip-string-normalization = true
 target-version = ['py38', 'py39']
 extend-exclude = '''
-^/cl_sii/(dte|extras|libs|rcv|rtc|rut)/|tests/
+^/cl_sii/(extras|libs|rcv|rtc|rut)/|tests/
 '''

--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -1,0 +1,15 @@
+# Black Configuration
+#
+# Black is a Python source code formatter.
+#
+# - Web site: https://github.com/psf/black/
+# - Documentation: https://black.readthedocs.io/
+
+[tool.black]
+include = '\.pyi?$'
+line-length = 100
+skip-string-normalization = true
+target-version = ['py38', 'py39']
+extend-exclude = '''
+^/cl_sii/(cte|dte|extras|libs|rcv|rtc|rut)/|tests/|setup\.py
+'''

--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -11,5 +11,5 @@ line-length = 100
 skip-string-normalization = true
 target-version = ['py38', 'py39']
 extend-exclude = '''
-^/cl_sii/(cte|dte|extras|libs|rcv|rtc|rut)/|tests/|setup\.py
+^/cl_sii/(cte|dte|extras|libs|rcv|rtc|rut)/|tests/
 '''

--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -11,5 +11,5 @@ line-length = 100
 skip-string-normalization = true
 target-version = ['py38', 'py39']
 extend-exclude = '''
-^/cl_sii/(rcv|rtc|rut)/|tests/
+^/cl_sii/(rtc|rut)/|tests/
 '''

--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -11,5 +11,5 @@ line-length = 100
 skip-string-normalization = true
 target-version = ['py38', 'py39']
 extend-exclude = '''
-^/cl_sii/(cte|dte|extras|libs|rcv|rtc|rut)/|tests/
+^/cl_sii/(dte|extras|libs|rcv|rtc|rut)/|tests/
 '''

--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -10,6 +10,3 @@ include = '\.pyi?$'
 line-length = 100
 skip-string-normalization = true
 target-version = ['py38', 'py39']
-extend-exclude = '''
-tests/
-'''

--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -11,5 +11,5 @@ line-length = 100
 skip-string-normalization = true
 target-version = ['py38', 'py39']
 extend-exclude = '''
-^/cl_sii/rut/|tests/
+tests/
 '''

--- a/.black.cfg.toml
+++ b/.black.cfg.toml
@@ -11,5 +11,5 @@ line-length = 100
 skip-string-normalization = true
 target-version = ['py38', 'py39']
 extend-exclude = '''
-^/cl_sii/(rtc|rut)/|tests/
+^/cl_sii/rut/|tests/
 '''

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SHELL = /usr/bin/env bash
 
+# Black
+BLACK = black --config .black.cfg.toml
+
 .DEFAULT_GOAL := help
 .PHONY: help
 .PHONY: clean clean-build clean-pyc clean-test
@@ -36,8 +39,10 @@ lint: ## run tools for code style analysis, static type check, etc
 	flake8 --config=setup.cfg  cl_sii  scripts  tests
 	mypy --config-file setup.cfg  cl_sii  scripts
 	isort --check-only .
+	$(BLACK) --check .
 
 lint-fix: ## Fix lint errors
+	$(BLACK) .
 	isort .
 
 test: ## run tests quickly with the default Python

--- a/cl_sii/cte/f29/data_models.py
+++ b/cl_sii/cte/f29/data_models.py
@@ -224,7 +224,9 @@ class CteForm29:
                     "%s(contribuyente_rut=%r, periodo_tributario=%r, folio=%r)"
                     " contains invalid or unknown SII Form 29 codes: %s.",
                     self.__class__.__name__,
-                    self.contribuyente_rut, self.periodo_tributario, self.folio,
+                    self.contribuyente_rut,
+                    self.periodo_tributario,
+                    self.folio,
                     ', '.join(str(code) for code in sorted(unknown_codes)),
                 )
 

--- a/cl_sii/cte/f29/parse_datos_obj.py
+++ b/cl_sii/cte/f29/parse_datos_obj.py
@@ -16,7 +16,10 @@ from .data_models import CteForm29
 SiiCteF29DatosObjType = Mapping[str, Mapping[str, object]]
 _CTE_F29_DATOS_OBJ_SCHEMA_PATH = (
     Path(__file__).parent.parent.parent
-    / 'data' / 'cte' / 'schemas-json' / 'f29_datos_obj.schema.json'
+    / 'data'
+    / 'cte'
+    / 'schemas-json'
+    / 'f29_datos_obj.schema.json'
 )
 CTE_F29_DATOS_OBJ_SCHEMA = read_json_schema(_CTE_F29_DATOS_OBJ_SCHEMA_PATH)
 
@@ -94,11 +97,11 @@ def _parse_sii_cte_f29_datos_obj_to_dict(
         folio=obj_extra[7],
         contribuyente_rut=obj_extra[3],
         periodo_tributario=periodo_tributario,
-
+        #
         tipo_declaracion=datos_obj_extras.get('CLASE'),
         banco=datos_obj_extras.get('BANCO'),
         medio_pago=datos_obj_extras.get('MEDIO_PAGO'),
-
+        #
         extra=obj_extra,
     )
     return obj_dict

--- a/cl_sii/dte/constants.py
+++ b/cl_sii/dte/constants.py
@@ -25,7 +25,7 @@ DTE_FOLIO_FIELD_TYPE = int
 """DTE field 'Folio' type."""
 DTE_FOLIO_FIELD_MIN_VALUE = 1
 """DTE field 'Folio' min value."""
-DTE_FOLIO_FIELD_MAX_VALUE = 10 ** 10
+DTE_FOLIO_FIELD_MAX_VALUE = 10**10
 """DTE field 'Folio' max value."""
 
 
@@ -59,9 +59,9 @@ DTE_FOLIO_FIELD_MAX_VALUE = 10 ** 10
 
 DTE_MONTO_TOTAL_FIELD_TYPE = int
 """DTE field 'Monto Total' type."""
-DTE_MONTO_TOTAL_FIELD_MIN_VALUE = -10 ** 18
+DTE_MONTO_TOTAL_FIELD_MIN_VALUE = -(10**18)
 """DTE field 'Monto Total' min value."""
-DTE_MONTO_TOTAL_FIELD_MAX_VALUE = 10 ** 18
+DTE_MONTO_TOTAL_FIELD_MAX_VALUE = 10**18
 """DTE field 'Monto Total' max value."""
 
 

--- a/cl_sii/dte/data_models.py
+++ b/cl_sii/dte/data_models.py
@@ -38,9 +38,7 @@ def validate_dte_folio(value: int) -> None:
     :raises TypeError:
 
     """
-    # note: mypy gets confused and complains about "Unsupported operand types for >/<".
-    if (value < constants.DTE_FOLIO_FIELD_MIN_VALUE  # type: ignore
-            or value > constants.DTE_FOLIO_FIELD_MAX_VALUE):  # type: ignore
+    if value < constants.DTE_FOLIO_FIELD_MIN_VALUE or value > constants.DTE_FOLIO_FIELD_MAX_VALUE:
         raise ValueError("Value is out of the valid range for 'folio'.")
 
 
@@ -52,9 +50,10 @@ def validate_dte_monto_total(value: int, tipo_dte: TipoDte) -> None:
     :raises TypeError:
 
     """
-    # note: mypy gets confused and complains about "Unsupported operand types for >/<".
-    if (value < constants.DTE_MONTO_TOTAL_FIELD_MIN_VALUE  # type: ignore
-            or value > constants.DTE_MONTO_TOTAL_FIELD_MAX_VALUE):  # type: ignore
+    if (
+        value < constants.DTE_MONTO_TOTAL_FIELD_MIN_VALUE
+        or value > constants.DTE_MONTO_TOTAL_FIELD_MAX_VALUE
+    ):
         raise ValueError("Value is out of the valid range for 'monto_total'.")
 
     if value < 0 and tipo_dte != TipoDte.LIQUIDACION_FACTURA_ELECTRONICA:
@@ -99,9 +98,13 @@ def validate_non_empty_bytes(value: bytes) -> None:
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class DteNaturalKey:
 
@@ -169,9 +172,13 @@ class DteNaturalKey:
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class DteDataL0(DteNaturalKey):
 
@@ -207,9 +214,13 @@ class DteDataL0(DteNaturalKey):
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class DteDataL1(DteDataL0):
 
@@ -272,7 +283,8 @@ class DteDataL1(DteDataL0):
             result = self.receptor_rut
         else:
             raise ValueError(
-                "Concept \"vendedor\" does not apply for this 'tipo_dte'.", self.tipo_dte)
+                "Concept \"vendedor\" does not apply for this 'tipo_dte'.", self.tipo_dte
+            )
 
         return result
 
@@ -290,7 +302,8 @@ class DteDataL1(DteDataL0):
         else:
             raise ValueError(
                 "Concepts \"comprador\" and \"deudor\" do not apply for this 'tipo_dte'.",
-                self.tipo_dte)
+                self.tipo_dte,
+            )
 
         return result
 
@@ -319,9 +332,13 @@ class DteDataL1(DteDataL0):
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class DteDataL2(DteDataL1):
 
@@ -407,7 +424,8 @@ class DteDataL2(DteDataL1):
             folio=self.folio,
             fecha_emision_date=self.fecha_emision_date,
             receptor_rut=self.receptor_rut,
-            monto_total=self.monto_total)
+            monto_total=self.monto_total,
+        )
 
     ###########################################################################
     # Validators
@@ -446,9 +464,13 @@ class DteDataL2(DteDataL1):
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class DteXmlData(DteDataL1):
 
@@ -534,7 +556,8 @@ class DteXmlData(DteDataL1):
             folio=self.folio,
             fecha_emision_date=self.fecha_emision_date,
             receptor_rut=self.receptor_rut,
-            monto_total=self.monto_total)
+            monto_total=self.monto_total,
+        )
 
     def as_dte_data_l2(self) -> DteDataL2:
         return DteDataL2(

--- a/cl_sii/dte/parse.py
+++ b/cl_sii/dte/parse.py
@@ -68,6 +68,7 @@ It is read from a file at import time to avoid unnecessary reads afterwards.
 # main functions
 ###############################################################################
 
+
 def clean_dte_xml(
     xml_doc: XmlElement,
     set_missing_xmlns: bool = False,
@@ -143,16 +144,20 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
     # c) 'Exportaciones'
     documento_em = xml_em.find(
         'sii-dte:Documento',  # "Informacion Tributaria del DTE"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     liquidacion_em = xml_em.find(
         'sii-dte:Liquidacion',  # "Informacion Tributaria de Liquidaciones"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     exportaciones_em = xml_em.find(
         'sii-dte:Exportaciones',  # "Informacion Tributaria de exportaciones"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     signature_em = xml_em.find(
         'ds:Signature',  # "Firma Digital sobre Documento"
-        namespaces=xml_utils.XML_DSIG_NS_MAP)
+        namespaces=xml_utils.XML_DSIG_NS_MAP,
+    )
 
     if liquidacion_em is not None or exportaciones_em is not None:
         raise NotImplementedError("XML element 'Documento' is the only one supported.")
@@ -179,14 +184,16 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
     #     "Comisiones y otros cargos es obligatoria para Liquidaciones Factura"
     encabezado_em = documento_em.find(
         'sii-dte:Encabezado',  # "Identificacion y Totales del Documento"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     # note: excluded because currently it is not useful.
     # ted_em = documento_em.find(
     #     'sii-dte:TED',  # "Timbre Electronico de DTE"
     #     namespaces=DTE_XMLNS_MAP)
     tmst_firma_em = documento_em.find(
         'sii-dte:TmstFirma',  # "Fecha y Hora en que se Firmo Digitalmente el Documento"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
 
     # 'Documento.Encabezado'
     # Excluded elements (optional according to the XML schema but the SII may require some of these
@@ -201,16 +208,20 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
     #     "Otra Moneda"
     id_doc_em = encabezado_em.find(
         'sii-dte:IdDoc',  # "Identificacion del DTE"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     emisor_em = encabezado_em.find(
         'sii-dte:Emisor',  # "Datos del Emisor"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     receptor_em = encabezado_em.find(
         'sii-dte:Receptor',  # "Datos del Receptor"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     totales_em = encabezado_em.find(
         'sii-dte:Totales',  # "Montos Totales del DTE"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
 
     # 'Documento.Encabezado.IdDoc'
     # Excluded elements (optional according to the XML schema but the SII may require some of these
@@ -264,17 +275,21 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
     # (required):
     tipo_dte_em = id_doc_em.find(
         'sii-dte:TipoDTE',  # "Tipo de DTE"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     folio_em = id_doc_em.find(
         'sii-dte:Folio',  # "Folio del Documento Electronico"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     fecha_emision_em = id_doc_em.find(
         'sii-dte:FchEmis',  # "Fecha Emision Contable del DTE"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     # (optional):
     fecha_vencimiento_em = id_doc_em.find(
         'sii-dte:FchVenc',  # "Fecha de Vencimiento del Pago"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
 
     # 'Documento.Encabezado.Emisor'
     # Excluded elements (optional according to the XML schema but the SII may require some of these
@@ -302,17 +317,21 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
     # (required):
     emisor_rut_em = emisor_em.find(
         'sii-dte:RUTEmisor',  # "RUT del Emisor del DTE"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     emisor_razon_social_em = emisor_em.find(
         'sii-dte:RznSoc',  # "Nombre o Razon Social del Emisor"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     emisor_giro_em = emisor_em.find(
         'sii-dte:GiroEmis',  # "Giro Comercial del Emisor Relevante para el DTE"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     # (optional):
     emisor_email_em = emisor_em.find(
         'sii-dte:CorreoEmisor',  # "Correo Elect. de contacto en empresa del receptor" (wrong!)
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
 
     # 'Documento.Encabezado.Receptor'
     # Excluded elements (optional according to the XML schema but the SII may require some of these
@@ -342,14 +361,17 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
     # (required):
     receptor_rut_em = receptor_em.find(
         'sii-dte:RUTRecep',  # "RUT del Receptor del DTE"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     receptor_razon_social_em = receptor_em.find(
         'sii-dte:RznSocRecep',  # "Nombre o Razon Social del Receptor"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
     # (optional):
     receptor_email_em = emisor_em.find(
         'sii-dte:CorreoRecep',  # "Correo Elect. de contacto en empresa del receptor"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
 
     # 'Documento.Encabezado.Totales'
     # Excluded elements (optional according to the XML schema but the SII may require some of these
@@ -390,7 +412,8 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
     #   "Valor a Pagar Total del documento"
     monto_total_em = totales_em.find(
         'sii-dte:MntTotal',  # "Monto Total del DTE"
-        namespaces=DTE_XMLNS_MAP)
+        namespaces=DTE_XMLNS_MAP,
+    )
 
     # 'Signature'
     # signature_signed_info_em = signature_em.find(
@@ -407,19 +430,23 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
     #     namespaces=xml_utils.XML_DSIG_NS_MAP)
     signature_signature_value_em = signature_em.find(
         'ds:SignatureValue',  # "Valor de la Firma Digital"
-        namespaces=xml_utils.XML_DSIG_NS_MAP)
+        namespaces=xml_utils.XML_DSIG_NS_MAP,
+    )
     signature_key_info_em = signature_em.find(
         'ds:KeyInfo',  # "Informacion de Claves Publicas y Certificado"
-        namespaces=xml_utils.XML_DSIG_NS_MAP)
+        namespaces=xml_utils.XML_DSIG_NS_MAP,
+    )
     # signature_key_info_key_value_em = signature_key_info_em.find(
     #     'ds:KeyValue',
     #     namespaces=xml_utils.XML_DSIG_NS_MAP)
     signature_key_info_x509_data_em = signature_key_info_em.find(
         'ds:X509Data',  # "Informacion del Certificado Publico"
-        namespaces=xml_utils.XML_DSIG_NS_MAP)
+        namespaces=xml_utils.XML_DSIG_NS_MAP,
+    )
     signature_key_info_x509_cert_em = signature_key_info_x509_data_em.find(
         'ds:X509Certificate',  # "Certificado Publico"
-        namespaces=xml_utils.XML_DSIG_NS_MAP)
+        namespaces=xml_utils.XML_DSIG_NS_MAP,
+    )
 
     ###########################################################################
     # values parsing
@@ -430,8 +457,7 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
     fecha_emision_value = date.fromisoformat(_text_strip_or_raise(fecha_emision_em))
     fecha_vencimiento_value = None
     if fecha_vencimiento_em is not None:
-        fecha_vencimiento_value = date.fromisoformat(
-            _text_strip_or_raise(fecha_vencimiento_em))
+        fecha_vencimiento_value = date.fromisoformat(_text_strip_or_raise(fecha_vencimiento_em))
 
     emisor_rut_value = Rut(_text_strip_or_raise(emisor_rut_em))
     emisor_razon_social_value = _text_strip_or_raise(emisor_razon_social_em)
@@ -450,12 +476,15 @@ def parse_dte_xml(xml_doc: XmlElement) -> data_models.DteXmlData:
 
     tmst_firma_value = tz_utils.convert_naive_dt_to_tz_aware(
         dt=datetime.fromisoformat(_text_strip_or_raise(tmst_firma_em)),
-        tz=data_models.DteXmlData.DATETIME_FIELDS_TZ)
+        tz=data_models.DteXmlData.DATETIME_FIELDS_TZ,
+    )
 
     signature_signature_value = encoding_utils.decode_base64_strict(
-        _text_strip_or_raise(signature_signature_value_em))
+        _text_strip_or_raise(signature_signature_value_em)
+    )
     signature_key_info_x509_cert_der = encoding_utils.decode_base64_strict(
-        _text_strip_or_raise(signature_key_info_x509_cert_em))
+        _text_strip_or_raise(signature_key_info_x509_cert_em)
+    )
 
     return data_models.DteXmlData(
         emisor_rut=emisor_rut_value,
@@ -512,6 +541,7 @@ def _text_strip_or_raise(xml_em: XmlElement) -> str:
 ###############################################################################
 # helpers
 ###############################################################################
+
 
 def _set_dte_xml_missing_xmlns(xml_doc: XmlElement) -> Tuple[XmlElement, bool]:
 

--- a/cl_sii/extras/dj_form_fields.py
+++ b/cl_sii/extras/dj_form_fields.py
@@ -63,8 +63,11 @@ class RutField(django.forms.CharField):
                     code='invalid',
                 )
 
-        if (converted_value is not None and self.validate_dv
-                and Rut.calc_dv(converted_value.digits) != converted_value.dv):
+        if (
+            converted_value is not None
+            and self.validate_dv
+            and Rut.calc_dv(converted_value.digits) != converted_value.dv
+        ):
             raise django.core.exceptions.ValidationError(
                 self.error_messages['invalid_dv'],
                 code='invalid_dv',

--- a/cl_sii/extras/mm_fields.py
+++ b/cl_sii/extras/mm_fields.py
@@ -45,7 +45,7 @@ class RutField(marshmallow.fields.Field):
     """
 
     default_error_messages = {
-        'invalid': 'Not a syntactically valid RUT.'
+        'invalid': 'Not a syntactically valid RUT.',
     }
 
     def _serialize(self, value: Optional[object], attr: str, obj: object) -> Optional[str]:
@@ -88,7 +88,7 @@ class TipoDteField(marshmallow.fields.Field):
     """
 
     default_error_messages = {
-        'invalid': 'Not a valid Tipo DTE.'
+        'invalid': 'Not a valid Tipo DTE.',
     }
 
     def _serialize(self, value: Optional[object], attr: str, obj: object) -> Optional[int]:
@@ -141,7 +141,7 @@ class RcvTipoDoctoField(marshmallow.fields.Field):
     """
 
     default_error_messages = {
-        'invalid': "Not a valid RCV's Tipo de Documento."
+        'invalid': "Not a valid RCV's Tipo de Documento.",
     }
 
     def _serialize(self, value: Optional[object], attr: str, obj: object) -> Optional[int]:

--- a/cl_sii/libs/crypto_utils.py
+++ b/cl_sii/libs/crypto_utils.py
@@ -63,7 +63,8 @@ def load_der_x509_cert(der_value: bytes) -> X509Cert:
     try:
         x509_cert = cryptography.x509.load_der_x509_certificate(
             data=der_value,
-            backend=_crypto_x509_backend)
+            backend=_crypto_x509_backend,
+        )
     except ValueError:
         # e.g.
         #   "Unable to load certificate"
@@ -94,7 +95,8 @@ def load_pem_x509_cert(pem_value: Union[str, bytes]) -> X509Cert:
     try:
         x509_cert = cryptography.x509.load_pem_x509_certificate(
             data=mod_pem_value_bytes,
-            backend=_crypto_x509_backend)
+            backend=_crypto_x509_backend,
+        )
     except ValueError:
         # e.g.
         #   "Unable to load certificate. See

--- a/cl_sii/libs/csv_utils.py
+++ b/cl_sii/libs/csv_utils.py
@@ -34,13 +34,16 @@ def create_csv_dict_reader(
             if csv_reader.fieldnames is None:
                 raise Exception(
                     "Programming error: when a 'csv.DictReader' instance is created with"
-                    "'fieldnames=None', the attribute will be set to the values of the first row.")
+                    "'fieldnames=None', the attribute will be set to the values of the first row."
+                )
             if tuple(csv_reader.fieldnames) != expected_field_names:
                 raise ValueError(
                     "CSV file field names do not match those expected, or their order.",
-                    csv_reader.fieldnames)
+                    csv_reader.fieldnames,
+                )
         else:
             raise ValueError(
-                "Param 'expected_field_names' is required if 'expected_fields_strict' is True.")
+                "Param 'expected_field_names' is required if 'expected_fields_strict' is True."
+            )
 
     return csv_reader

--- a/cl_sii/libs/dataclass_utils.py
+++ b/cl_sii/libs/dataclass_utils.py
@@ -63,7 +63,8 @@ class DcDeepCompareMixin:
         if not dataclasses.is_dataclass(self):
             # TODO: would it be possible to run this check when the **class** is created?
             raise Exception(
-                "Programming error. Only dataclasses may subclass 'DcDeepCompareMixin'.")
+                "Programming error. Only dataclasses may subclass 'DcDeepCompareMixin'."
+            )
         # note: 'is_dataclass' returns True if obj is a dataclass or an instance of a dataclass.
         if not dataclasses.is_dataclass(value):
             raise TypeError("Value must be a dataclass instance.")

--- a/cl_sii/libs/encoding_utils.py
+++ b/cl_sii/libs/encoding_utils.py
@@ -26,11 +26,12 @@ def clean_base64(value: Union[str, bytes]) -> bytes:
     # remove line breaks and spaces
     # warning: we may only remove characters that are not part of the standard base-64 alphabet
     #   (or any of its popular alternatives).
-    value_base64_bytes_cleaned = value_base64_bytes \
-        .replace(b'\n', b'') \
-        .replace(b'\r', b'') \
-        .replace(b'\t', b'') \
+    value_base64_bytes_cleaned = (
+        value_base64_bytes.replace(b'\n', b'')
+        .replace(b'\r', b'')
+        .replace(b'\t', b'')
         .replace(b' ', b'')
+    )
 
     return value_base64_bytes_cleaned
 

--- a/cl_sii/libs/json_utils.py
+++ b/cl_sii/libs/json_utils.py
@@ -7,6 +7,7 @@ from typing import Mapping
 # exceptions
 ###############################################################################
 
+
 class JsonSchemaValidationError(Exception):
     """
     JSON data failed validation against a schema.
@@ -20,6 +21,7 @@ class JsonSchemaValidationError(Exception):
 ###############################################################################
 # functions
 ###############################################################################
+
 
 def read_json_schema(file_path: Path) -> Mapping[str, object]:
     """

--- a/cl_sii/libs/mm_utils.py
+++ b/cl_sii/libs/mm_utils.py
@@ -10,6 +10,7 @@ import marshmallow.utils
 # validators
 ###############################################################################
 
+
 def validate_no_unexpected_input_fields(
     schema: marshmallow.Schema,
     data: dict,
@@ -41,12 +42,14 @@ def validate_no_unexpected_input_fields(
     unexpected_input_fields = set(original_data) - fields_name_or_load_from
     if unexpected_input_fields:
         raise marshmallow.ValidationError(
-            "Unexpected input field.", field_names=list(unexpected_input_fields))
+            "Unexpected input field.", field_names=list(unexpected_input_fields)
+        )
 
 
 ###############################################################################
 # fields
 ###############################################################################
+
 
 class CustomMarshmallowDateField(marshmallow.fields.Field):
     """

--- a/cl_sii/libs/rows_processing.py
+++ b/cl_sii/libs/rows_processing.py
@@ -19,6 +19,7 @@ class MaxRowsExceeded(RuntimeError):
 # iterators
 ###############################################################################
 
+
 def csv_rows_mm_deserialization_iterator(
     csv_reader: csv.DictReader,
     row_schema: marshmallow.Schema,
@@ -61,7 +62,8 @@ def csv_rows_mm_deserialization_iterator(
     #   > "Iterable[Dict[str, object]]")
     rows_iterator: Iterable[Dict[str, object]] = csv_reader  # type: ignore
     iterator = rows_mm_deserialization_iterator(
-        rows_iterator, row_schema, n_rows_offset, max_n_rows, fields_to_remove_names)
+        rows_iterator, row_schema, n_rows_offset, max_n_rows, fields_to_remove_names
+    )
 
     try:
         # note: we chose not to use 'yield from' to be explicit about what we are yielding.
@@ -139,13 +141,16 @@ def rows_mm_deserialization_iterator(
                     "Marshmallow schema is 'strict' but validation errors were returned by "
                     "method 'load' ('UnmarshalResult.errors') instead of being raised. "
                     "Errors: %s",
-                    repr(returned_validation_errors))
+                    repr(returned_validation_errors),
+                )
             if raised_validation_errors:
                 logger.fatal(
                     "Programming error: either returned or raised validation errors "
                     "(depending on 'strict') but never both. "
                     "Returned errors: %s. Raised errors: %s",
-                    repr(returned_validation_errors), repr(raised_validation_errors))
+                    repr(returned_validation_errors),
+                    repr(raised_validation_errors),
+                )
 
             validation_errors.update(returned_validation_errors)
 

--- a/cl_sii/libs/xml_utils.py
+++ b/cl_sii/libs/xml_utils.py
@@ -65,6 +65,7 @@ https://github.com/XML-Security/signxml/blob/16503242/signxml/__init__.py#L23-L3
 # exceptions
 ###############################################################################
 
+
 class BaseXmlParsingError(Exception):
 
     """
@@ -144,6 +145,7 @@ class XmlSignatureInvalidCertificate(XmlSignatureInvalid):
 # functions
 ###############################################################################
 
+
 def parse_untrusted_xml(value: bytes) -> XmlElement:
     """
     Parse XML-encoded content in value.
@@ -183,15 +185,17 @@ def parse_untrusted_xml(value: bytes) -> XmlElement:
 
         xml_root_em = defusedxml.lxml.fromstring(
             text=value,
-            parser=None,           # default: None (a custom one will be created)
-            base_url=None,         # default: None
-            forbid_dtd=False,      # default: False (allow Document Type Definition)
+            parser=None,  # default: None (a custom one will be created)
+            base_url=None,  # default: None
+            forbid_dtd=False,  # default: False (allow Document Type Definition)
             forbid_entities=True,  # default: True (forbid Entity definitions/declarations)
         )  # type: XmlElement
 
-    except (defusedxml.DTDForbidden,
-            defusedxml.EntitiesForbidden,
-            defusedxml.ExternalReferenceForbidden) as exc:
+    except (
+        defusedxml.DTDForbidden,
+        defusedxml.EntitiesForbidden,
+        defusedxml.ExternalReferenceForbidden,
+    ) as exc:
         # note: we'd rather use 'defusedxml.DefusedXmlException' but that would catch
         #   'defusedxml.NotSupportedError' as well
 
@@ -230,11 +234,13 @@ def parse_untrusted_xml(value: bytes) -> XmlElement:
 
         # For sanity crop the XML-encoded content to max 1 KiB (arbitrary value).
         log_msg = "Unexpected XML 'ExpatError' at line {} offset {}: {}. Content: %s".format(
-            exc.lineno, exc.offset, xml.parsers.expat.errors.messages[exc.code])
+            exc.lineno, exc.offset, xml.parsers.expat.errors.messages[exc.code]
+        )
         logger.exception(log_msg, str(value[:1024]))
 
         exc_msg = "Unexpected error while parsing value as XML. Line {}, offset {}.".format(
-            exc.lineno, exc.offset)
+            exc.lineno, exc.offset
+        )
         raise UnknownXmlParsingError(exc_msg) from exc
 
     except lxml.etree.LxmlError as exc:
@@ -415,7 +421,8 @@ def verify_xml_signature(
     n_signatures = (
         len(xml_doc.findall('.//ds:Signature', namespaces=XML_DSIG_NS_MAP))
         + len(xml_doc.findall('.//dsig11:Signature', namespaces=XML_DSIG_NS_MAP))
-        + len(xml_doc.findall('.//dsig2:Signature', namespaces=XML_DSIG_NS_MAP)))
+        + len(xml_doc.findall('.//dsig2:Signature', namespaces=XML_DSIG_NS_MAP))
+    )
 
     if n_signatures > 1 and not xml_verifier_supports_multiple_signatures:
         raise NotImplementedError("XML document with more than one signature is not supported.")
@@ -432,7 +439,8 @@ def verify_xml_signature(
         trusted_x509_cert_open_ssl = trusted_x509_cert
     elif isinstance(trusted_x509_cert, crypto_utils.X509Cert):
         trusted_x509_cert_open_ssl = crypto_utils._X509CertOpenSsl.from_cryptography(
-            trusted_x509_cert)
+            trusted_x509_cert
+        )
     elif trusted_x509_cert is None:
         trusted_x509_cert_open_ssl = None
     else:
@@ -468,7 +476,9 @@ def verify_xml_signature(
         #   Source:
         #   https://github.com/XML-Security/signxml/commit/ef15da8dbb904f1dedfdd210ae3e0df5da535612
         result: signxml.VerifyResult = xml_verifier.verify(
-            data=tmp_bytes, require_x509=True, x509_cert=trusted_x509_cert_open_ssl,
+            data=tmp_bytes,
+            require_x509=True,
+            x509_cert=trusted_x509_cert_open_ssl,
             ignore_ambiguous_key_info=True,
         )
 

--- a/cl_sii/rcv/constants.py
+++ b/cl_sii/rcv/constants.py
@@ -302,6 +302,7 @@ class RcvTipoDocto(enum.IntEnum):
             value = TipoDte(self.value)
         except ValueError as exc:
             raise ValueError(
-                f"There is no equivalent 'TipoDte' for 'RcvTipoDocto.{self.name}'.") from exc
+                f"There is no equivalent 'TipoDte' for 'RcvTipoDocto.{self.name}'."
+            ) from exc
 
         return value

--- a/cl_sii/rcv/data_models.py
+++ b/cl_sii/rcv/data_models.py
@@ -94,14 +94,19 @@ class PeriodoTributario:
         # note: timezone-aware
         return tz_utils.convert_naive_dt_to_tz_aware(
             datetime(self.year, self.month, day=1, hour=0, minute=0, second=0),
-            self.DATETIME_FIELDS_TZ)
+            self.DATETIME_FIELDS_TZ,
+        )
 
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class RcvDetalleEntry:
 
@@ -171,7 +176,8 @@ class RcvDetalleEntry:
 
     @pydantic.root_validator(skip_on_failure=True)
     def validate_rcv_kind_is_consistent_with_rc_estado_contable(
-        cls, values: Mapping[str, object],
+        cls,
+        values: Mapping[str, object],
     ) -> Mapping[str, object]:
         rcv_kind = values.get('RCV_KIND')
         rc_estado_contable = values.get('RC_ESTADO_CONTABLE')
@@ -180,11 +186,13 @@ class RcvDetalleEntry:
             if rcv_kind == RcvKind.COMPRAS:
                 if rc_estado_contable is None:
                     raise ValueError(
-                        "'RC_ESTADO_CONTABLE' must not be None when 'RCV_KIND' is 'COMPRAS'.")
+                        "'RC_ESTADO_CONTABLE' must not be None when 'RCV_KIND' is 'COMPRAS'."
+                    )
             elif rcv_kind == RcvKind.VENTAS:
                 if rc_estado_contable is not None:
                     raise ValueError(
-                        "'RC_ESTADO_CONTABLE' must be None when 'RCV_KIND' is 'VENTAS'.")
+                        "'RC_ESTADO_CONTABLE' must be None when 'RCV_KIND' is 'VENTAS'."
+                    )
 
         return values
 
@@ -228,9 +236,13 @@ class RcvDetalleEntry:
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class RvDetalleEntry(RcvDetalleEntry):
 
@@ -278,9 +290,13 @@ class RvDetalleEntry(RcvDetalleEntry):
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class RcRegistroDetalleEntry(RcvDetalleEntry):
 
@@ -325,9 +341,13 @@ class RcRegistroDetalleEntry(RcvDetalleEntry):
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class RcNoIncluirDetalleEntry(RcRegistroDetalleEntry):
 
@@ -341,9 +361,13 @@ class RcNoIncluirDetalleEntry(RcRegistroDetalleEntry):
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class RcReclamadoDetalleEntry(RcvDetalleEntry):
 
@@ -392,9 +416,13 @@ class RcReclamadoDetalleEntry(RcvDetalleEntry):
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class RcPendienteDetalleEntry(RcvDetalleEntry):
 

--- a/cl_sii/rcv/parse_csv.py
+++ b/cl_sii/rcv/parse_csv.py
@@ -504,8 +504,8 @@ def parse_rcv_compra_pendiente_csv_file(
 # schemas
 ###############################################################################
 
-class _RcvCsvRowSchemaBase(marshmallow.Schema):
 
+class _RcvCsvRowSchemaBase(marshmallow.Schema):
     @marshmallow.validates_schema(pass_original=True)
     def validate_schema(self, data: dict, original_data: dict) -> None:
         mm_utils.validate_no_unexpected_input_fields(self, data, original_data)
@@ -610,7 +610,8 @@ class RcvVentaCsvRowSchema(_RcvCsvRowSchemaBase):
         # >>> data['fecha_recepcion_dt'].isoformat()
         # '2018-10-23T01:54:13'
         data['fecha_recepcion_dt'] = tz_utils.convert_naive_dt_to_tz_aware(
-            dt=data['fecha_recepcion_dt'], tz=self.FIELD_FECHA_RECEPCION_DT_TZ)
+            dt=data['fecha_recepcion_dt'], tz=self.FIELD_FECHA_RECEPCION_DT_TZ
+        )
         # >>> data['fecha_recepcion_dt'].isoformat()
         # '2018-10-23T01:54:13-03:00'
         # >>> data['fecha_recepcion_dt'].astimezone(pytz.UTC).isoformat()
@@ -621,10 +622,12 @@ class RcvVentaCsvRowSchema(_RcvCsvRowSchemaBase):
 
         if 'fecha_acuse_dt' in data and data['fecha_acuse_dt']:
             data['fecha_acuse_dt'] = tz_utils.convert_naive_dt_to_tz_aware(
-                dt=data['fecha_acuse_dt'], tz=self.FIELD_FECHA_ACUSE_DT_TZ)
+                dt=data['fecha_acuse_dt'], tz=self.FIELD_FECHA_ACUSE_DT_TZ
+            )
         if 'fecha_reclamo_dt' in data and data['fecha_reclamo_dt']:
             data['fecha_reclamo_dt'] = tz_utils.convert_naive_dt_to_tz_aware(
-                dt=data['fecha_reclamo_dt'], tz=self.FIELD_FECHA_RECLAMO_DT_TZ)
+                dt=data['fecha_reclamo_dt'], tz=self.FIELD_FECHA_RECLAMO_DT_TZ
+            )
 
         # Remove leading and trailing whitespace.
         data['receptor_razon_social'] = data['receptor_razon_social'].strip()
@@ -747,7 +750,8 @@ class RcvCompraRegistroCsvRowSchema(_RcvCsvRowSchemaBase):
         # >>> data['fecha_recepcion_dt'].isoformat()
         # '2018-10-23T01:54:13'
         data['fecha_recepcion_dt'] = tz_utils.convert_naive_dt_to_tz_aware(
-            dt=data['fecha_recepcion_dt'], tz=self.FIELD_FECHA_RECEPCION_DT_TZ)
+            dt=data['fecha_recepcion_dt'], tz=self.FIELD_FECHA_RECEPCION_DT_TZ
+        )
         # >>> data['fecha_recepcion_dt'].isoformat()
         # '2018-10-23T01:54:13-03:00'
         # >>> data['fecha_recepcion_dt'].astimezone(pytz.UTC).isoformat()
@@ -755,7 +759,8 @@ class RcvCompraRegistroCsvRowSchema(_RcvCsvRowSchemaBase):
 
         if data['fecha_acuse_dt']:
             data['fecha_acuse_dt'] = tz_utils.convert_naive_dt_to_tz_aware(
-                dt=data['fecha_acuse_dt'], tz=self.FIELD_FECHA_ACUSE_DT_TZ)
+                dt=data['fecha_acuse_dt'], tz=self.FIELD_FECHA_ACUSE_DT_TZ
+            )
 
         # note: to express this value in another timezone (but the value does not change), do
         #   `dt_obj.astimezone(pytz.timezone('some timezone'))`
@@ -798,7 +803,6 @@ class RcvCompraRegistroCsvRowSchema(_RcvCsvRowSchemaBase):
 
 
 class RcvCompraNoIncluirCsvRowSchema(RcvCompraRegistroCsvRowSchema):
-
     def to_detalle_entry(self, data: dict) -> RcNoIncluirDetalleEntry:
         try:
             emisor_rut: Rut = data['emisor_rut']  # type: ignore
@@ -919,7 +923,8 @@ class RcvCompraReclamadoCsvRowSchema(_RcvCsvRowSchemaBase):
         # >>> data['fecha_recepcion_dt'].isoformat()
         # '2018-10-23T01:54:13'
         data['fecha_recepcion_dt'] = tz_utils.convert_naive_dt_to_tz_aware(
-            dt=data['fecha_recepcion_dt'], tz=self.FIELD_FECHA_RECEPCION_DT_TZ)
+            dt=data['fecha_recepcion_dt'], tz=self.FIELD_FECHA_RECEPCION_DT_TZ
+        )
         # >>> data['fecha_recepcion_dt'].isoformat()
         # '2018-10-23T01:54:13-03:00'
         # >>> data['fecha_recepcion_dt'].astimezone(pytz.UTC).isoformat()
@@ -927,7 +932,8 @@ class RcvCompraReclamadoCsvRowSchema(_RcvCsvRowSchemaBase):
 
         if data['fecha_reclamo_dt']:
             data['fecha_reclamo_dt'] = tz_utils.convert_naive_dt_to_tz_aware(
-                dt=data['fecha_reclamo_dt'], tz=self.FIELD_FECHA_RECLAMO_DT_TZ)
+                dt=data['fecha_reclamo_dt'], tz=self.FIELD_FECHA_RECLAMO_DT_TZ
+            )
 
         # note: to express this value in another timezone (but the value does not change), do
         #   `dt_obj.astimezone(pytz.timezone('some timezone'))`
@@ -1045,7 +1051,8 @@ class RcvCompraPendienteCsvRowSchema(_RcvCsvRowSchemaBase):
         # >>> data['fecha_recepcion_dt'].isoformat()
         # '2018-10-23T01:54:13'
         data['fecha_recepcion_dt'] = tz_utils.convert_naive_dt_to_tz_aware(
-            dt=data['fecha_recepcion_dt'], tz=self.FIELD_FECHA_RECEPCION_DT_TZ)
+            dt=data['fecha_recepcion_dt'], tz=self.FIELD_FECHA_RECEPCION_DT_TZ
+        )
         # >>> data['fecha_recepcion_dt'].isoformat()
         # '2018-10-23T01:54:13-03:00'
         # >>> data['fecha_recepcion_dt'].astimezone(pytz.UTC).isoformat()
@@ -1093,6 +1100,7 @@ class RcvCompraPendienteCsvRowSchema(_RcvCsvRowSchemaBase):
 # helpers
 ###############################################################################
 
+
 class _RcvCsvDialect(csv.Dialect):
 
     """
@@ -1136,11 +1144,12 @@ def _parse_rcv_csv_file(
         if field_to_remove_name not in expected_input_field_names:
             raise Exception(
                 "Programming error: field to remove is not one of the expected ones.",
-                field_to_remove_name)
+                field_to_remove_name,
+            )
 
     _CSV_ROW_DICT_EXTRA_FIELDS_KEY = '_extra_csv_fields_data'
 
-    fields_to_remove_names += (_CSV_ROW_DICT_EXTRA_FIELDS_KEY, )  # type: ignore
+    fields_to_remove_names += (_CSV_ROW_DICT_EXTRA_FIELDS_KEY,)  # type: ignore
 
     input_data_enc = 'utf-8'
     # note:
@@ -1176,7 +1185,8 @@ def _parse_rcv_csv_file(
                     conversion_error = str(exc)
                     logger.exception(
                         "Deserialized data to data model instance conversion failed "
-                        "(probably a programming error).")
+                        "(probably a programming error)."
+                    )
 
             # Instead of empty dicts, lists, str, etc, we want to have None.
             if validation_errors:

--- a/cl_sii/rtc/constants.py
+++ b/cl_sii/rtc/constants.py
@@ -17,12 +17,14 @@ from cl_sii.dte.constants import DTE_MONTO_TOTAL_FIELD_MAX_VALUE, TipoDte
 #   - XML type 'SiiDte:DTEFacturasType' in official schema 'SiiTypes_v10.xsd'
 #     - source:
 #       https://github.com/fyntex/lib-cl-sii-python/blob/7e1c4b52/cl_sii/data/ref/factura_electronica/schemas-xml/SiiTypes_v10.xsd#L100-L126
-TIPO_DTE_CEDIBLES: FrozenSet[TipoDte] = frozenset({
-    TipoDte.FACTURA_ELECTRONICA,
-    TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA,
-    TipoDte.FACTURA_COMPRA_ELECTRONICA,
-    TipoDte.LIQUIDACION_FACTURA_ELECTRONICA,
-})
+TIPO_DTE_CEDIBLES: FrozenSet[TipoDte] = frozenset(
+    {
+        TipoDte.FACTURA_ELECTRONICA,
+        TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA,
+        TipoDte.FACTURA_COMPRA_ELECTRONICA,
+        TipoDte.LIQUIDACION_FACTURA_ELECTRONICA,
+    }
+)
 
 
 ###############################################################################
@@ -60,6 +62,7 @@ CESION_SEQUENCE_NUMBER_MAX_VALUE: int = 40
 ###############################################################################
 # Other
 ###############################################################################
+
 
 @enum.unique
 class RolContribuyenteEnCesion(enum.Enum):

--- a/cl_sii/rtc/data_models.py
+++ b/cl_sii/rtc/data_models.py
@@ -81,9 +81,13 @@ def validate_cesion_and_dte_montos(cesion_value: int, dte_value: int) -> None:
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class CesionNaturalKey:
     """
@@ -151,9 +155,13 @@ class CesionNaturalKey:
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class CesionAltNaturalKey:
     """
@@ -261,9 +269,13 @@ class CesionAltNaturalKey:
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class CesionL0:
     """
@@ -399,9 +411,13 @@ class CesionL0:
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        arbitrary_types_allowed=True,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            arbitrary_types_allowed=True,
+        ),
+    ),
 )
 class CesionL1(CesionL0):
     """
@@ -500,7 +516,8 @@ class CesionL1(CesionL0):
 
     @pydantic.root_validator(skip_on_failure=True)
     def validate_monto_cedido_does_not_exceed_dte_monto_total(
-        cls, values: Mapping[str, object],
+        cls,
+        values: Mapping[str, object],
     ) -> Mapping[str, object]:
         monto_cedido = values['monto_cedido']
         dte_monto_total = values['dte_monto_total']
@@ -513,11 +530,15 @@ class CesionL1(CesionL0):
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        anystr_strip_whitespace=True,
-        arbitrary_types_allowed=True,
-        min_anystr_length=1,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            anystr_strip_whitespace=True,
+            arbitrary_types_allowed=True,
+            min_anystr_length=1,
+        ),
+    ),
 )
 class CesionL2(CesionL1):
     """

--- a/cl_sii/rtc/data_models_aec.py
+++ b/cl_sii/rtc/data_models_aec.py
@@ -20,11 +20,15 @@ from . import data_models
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        anystr_strip_whitespace=True,
-        arbitrary_types_allowed=True,
-        min_anystr_length=1,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            anystr_strip_whitespace=True,
+            arbitrary_types_allowed=True,
+            min_anystr_length=1,
+        ),
+    ),
 )
 class CesionAecXml:
     """
@@ -338,7 +342,8 @@ class CesionAecXml:
 
     @pydantic.root_validator(skip_on_failure=True)
     def validate_fecha_cesion_dt_is_consistent_with_dte(
-        cls, values: Mapping[str, object],
+        cls,
+        values: Mapping[str, object],
     ) -> Mapping[str, object]:
         fecha_cesion_dt = values['fecha_cesion_dt']
         dte = values['dte']
@@ -350,7 +355,8 @@ class CesionAecXml:
 
     @pydantic.root_validator(skip_on_failure=True)
     def validate_monto_cesion_does_not_exceed_dte_monto_total(
-        cls, values: Mapping[str, object],
+        cls,
+        values: Mapping[str, object],
     ) -> Mapping[str, object]:
         monto_cesion = values['monto_cesion']
         dte = values['dte']
@@ -365,14 +371,14 @@ class CesionAecXml:
 
     @pydantic.root_validator(skip_on_failure=True)
     def validate_fecha_ultimo_vencimiento_is_consistent_with_dte(
-        cls, values: Mapping[str, object],
+        cls,
+        values: Mapping[str, object],
     ) -> Mapping[str, object]:
         fecha_ultimo_vencimiento = values['fecha_ultimo_vencimiento']
         dte = values['dte']
 
-        if (
-            isinstance(fecha_ultimo_vencimiento, date)
-            and isinstance(dte, dte_data_models.DteDataL1)
+        if isinstance(fecha_ultimo_vencimiento, date) and isinstance(
+            dte, dte_data_models.DteDataL1
         ):
             pass  # TODO: Validate value of 'fecha_ultimo_vencimiento' in relation to the DTE data.
 
@@ -381,11 +387,15 @@ class CesionAecXml:
 
 @pydantic.dataclasses.dataclass(
     frozen=True,
-    config=type('Config', (), dict(
-        anystr_strip_whitespace=True,
-        arbitrary_types_allowed=True,
-        min_anystr_length=1,
-    ))
+    config=type(
+        'Config',
+        (),
+        dict(
+            anystr_strip_whitespace=True,
+            arbitrary_types_allowed=True,
+            min_anystr_length=1,
+        ),
+    ),
 )
 class AecXml:
     """
@@ -731,7 +741,8 @@ class AecXml:
 
     @pydantic.root_validator(skip_on_failure=True)
     def validate_dte_matches_cesiones_dtes(
-        cls, values: Mapping[str, object],
+        cls,
+        values: Mapping[str, object],
     ) -> Mapping[str, object]:
         dte = values['dte']
         cesiones = values['cesiones']
@@ -752,7 +763,8 @@ class AecXml:
 
     @pydantic.root_validator(skip_on_failure=True)
     def validate_last_cesion_matches_some_fields(
-        cls, values: Mapping[str, object],
+        cls,
+        values: Mapping[str, object],
     ) -> Mapping[str, object]:
         field_validations: Sequence[Tuple[str, str]] = [
             # (AecXml field, CesionAecXml field):
@@ -785,7 +797,8 @@ class AecXml:
 
     @pydantic.root_validator
     def validate_signature_value_and_signature_x509_cert_der_may_only_be_none_together(
-        cls, values: Mapping[str, object],
+        cls,
+        values: Mapping[str, object],
     ) -> Mapping[str, object]:
         signature_value = values.get('signature_value')
         signature_x509_cert_der = values.get('signature_x509_cert_der')

--- a/cl_sii/rtc/data_models_cesiones_periodo.py
+++ b/cl_sii/rtc/data_models_cesiones_periodo.py
@@ -167,7 +167,8 @@ class CesionesPeriodoEntry:
         if self.dte_tipo_dte not in TIPO_DTE_CEDIBLES:
             raise ValueError(
                 "The \"tipo DTE\" in 'dte_tipo_dte' is not \"cedible\".",
-                self.dte_tipo_dte)
+                self.dte_tipo_dte,
+            )
 
         if not isinstance(self.dte_folio, int):
             raise TypeError("Inappropriate type of 'dte_folio'.")
@@ -226,14 +227,17 @@ class CesionesPeriodoEntry:
         if self.fecha_cesion_dt.date() != self.fecha_cesion:
             raise ValueError(
                 "Date of 'fecha_cesion_dt' (considering timezone) does not match 'fecha_cesion'.",
-                self.fecha_cesion_dt, self.fecha_cesion)
+                self.fecha_cesion_dt,
+                self.fecha_cesion,
+            )
 
         if not isinstance(self.monto_cedido, int):
             raise TypeError("Inappropriate type of 'monto_cedido'.")
         if not self.monto_cedido >= CESION_MONTO_CEDIDO_FIELD_MIN_VALUE:
             raise ValueError(
                 f"Amount 'monto_cedido' must be >= {CESION_MONTO_CEDIDO_FIELD_MIN_VALUE}.",
-                self.monto_cedido)
+                self.monto_cedido,
+            )
         data_models.validate_cesion_and_dte_montos(
             cesion_value=self.monto_cedido,
             dte_value=self.dte_monto_total,
@@ -261,7 +265,8 @@ class CesionesPeriodoEntry:
         else:
             raise ValueError(
                 'Programming error: the "vendedor" is neither the "emisor" nor the "vendedor".',
-                self)
+                self,
+            )
 
         try:
             dte_data = cl_sii.dte.data_models.DteDataL1(

--- a/cl_sii/rtc/parse_aec.py
+++ b/cl_sii/rtc/parse_aec.py
@@ -58,6 +58,7 @@ It is read from a file at import time to avoid unnecessary reads afterwards.
 # Main Functions
 ###############################################################################
 
+
 def validate_aec_xml(xml_doc: XmlElement) -> None:
     """
     Validate ``xml_doc`` against AEC's XML schema.
@@ -82,6 +83,7 @@ def parse_aec_xml(xml_doc: XmlElement) -> data_models_aec.AecXml:
 ###############################################################################
 # Parser Functions and Models
 ###############################################################################
+
 
 def _empty_str_to_none(v: object) -> object:
     """
@@ -133,8 +135,8 @@ class _XmlSignature(pydantic.BaseModel):
         key_info_em = xml_em.find('ds:KeyInfo', namespaces=xml_utils.XML_DSIG_NS_MAP)
 
         # XPath: //Signature/KeyInfo/X509Data
-        key_info_x509_data_em = (
-            key_info_em.find('ds:X509Data', namespaces=xml_utils.XML_DSIG_NS_MAP)
+        key_info_x509_data_em = key_info_em.find(
+            'ds:X509Data', namespaces=xml_utils.XML_DSIG_NS_MAP
         )
 
         # XPath: //Signature
@@ -144,7 +146,7 @@ class _XmlSignature(pydantic.BaseModel):
                 'ds:SignatureValue',
                 namespaces=xml_utils.XML_DSIG_NS_MAP,
             ),
-
+            #
             # XPath: //Signature/KeyInfo/X509Data/X509Certificate
             key_info_x509_data_x509_cert=key_info_x509_data_em.findtext(
                 'ds:X509Certificate',
@@ -219,7 +221,9 @@ class _Cesionario(pydantic.BaseModel):
     ###########################################################################
 
     _validate_rut = pydantic.validator(  # type: ignore[pydantic-field]
-        'rut', pre=True, allow_reuse=True,
+        'rut',
+        pre=True,
+        allow_reuse=True,
     )(_validate_rut)
 
 
@@ -262,11 +266,15 @@ class _RutAutorizado(pydantic.BaseModel):
     ###########################################################################
 
     _empty_str_to_none = pydantic.validator(  # type: ignore[pydantic-field]
-        'nombre', pre=True, allow_reuse=True,
+        'nombre',
+        pre=True,
+        allow_reuse=True,
     )(_empty_str_to_none)
 
     _validate_rut = pydantic.validator(  # type: ignore[pydantic-field]
-        'rut', pre=True, allow_reuse=True,
+        'rut',
+        pre=True,
+        allow_reuse=True,
     )(_validate_rut)
 
 
@@ -321,7 +329,8 @@ class _Cedente(pydantic.BaseModel):
             declaracion_jurada=xml_em.findtext(
                 'sii-dte:DeclaracionJurada',
                 namespaces=DTE_XMLNS_MAP,
-            ) or None,
+            )
+            or None,
             ruts_autorizados=cedente_persona_autorizada_dict_list,
         )
 
@@ -400,11 +409,15 @@ class _IdDte(pydantic.BaseModel):
     ###########################################################################
 
     _validate_rut_emisor = pydantic.validator(  # type: ignore[pydantic-field]
-        'rut_emisor', pre=True, allow_reuse=True,
+        'rut_emisor',
+        pre=True,
+        allow_reuse=True,
     )(_validate_rut)
 
     _validate_rut_receptor = pydantic.validator(  # type: ignore[pydantic-field]
-        'rut_receptor', pre=True, allow_reuse=True,
+        'rut_receptor',
+        pre=True,
+        allow_reuse=True,
     )(_validate_rut)
 
     @pydantic.validator('tipo_dte', pre=True)
@@ -736,15 +749,23 @@ class _Caratula(pydantic.BaseModel):
     ###########################################################################
 
     _empty_str_to_none = pydantic.validator(  # type: ignore[pydantic-field]
-        'nmb_contacto', 'fono_contacto', 'mail_contacto', pre=True, allow_reuse=True,
+        'nmb_contacto',
+        'fono_contacto',
+        'mail_contacto',
+        pre=True,
+        allow_reuse=True,
     )(_empty_str_to_none)
 
     _validate_rut_cedente = pydantic.validator(  # type: ignore[pydantic-field]
-        'rut_cedente', pre=True, allow_reuse=True,
+        'rut_cedente',
+        pre=True,
+        allow_reuse=True,
     )(_validate_rut)
 
     _validate_rut_cesionario = pydantic.validator(  # type: ignore[pydantic-field]
-        'rut_cesionario', pre=True, allow_reuse=True,
+        'rut_cesionario',
+        pre=True,
+        allow_reuse=True,
     )(_validate_rut)
 
     @pydantic.validator('tmst_firmaenvio')
@@ -809,10 +830,7 @@ class _DocumentoAec(pydantic.BaseModel):
             namespaces=DTE_XMLNS_MAP,
         )
         cesion_dict_list: Sequence[Mapping[str, object]]
-        cesion_dict_list = [
-            _Cesion.parse_xml_to_dict(cesion_em)
-            for cesion_em in cesion_em_list
-        ]
+        cesion_dict_list = [_Cesion.parse_xml_to_dict(cesion_em) for cesion_em in cesion_em_list]
 
         # XPath: /AEC/DocumentoAEC
         return dict(
@@ -869,8 +887,7 @@ class _Aec(pydantic.BaseModel):
 
         aec_xml_cesion_list: Sequence[data_models_aec.CesionAecXml]
         aec_xml_cesion_list = [
-            cesion_struct.as_cesion_aec_xml()
-            for cesion_struct in cesion_struct_list
+            cesion_struct.as_cesion_aec_xml() for cesion_struct in cesion_struct_list
         ]
 
         return data_models_aec.AecXml(

--- a/cl_sii/rtc/xml_utils.py
+++ b/cl_sii/rtc/xml_utils.py
@@ -39,9 +39,10 @@ class AecXMLVerifier(signxml.XMLVerifier):
 # functions
 ###############################################################################
 
+
 def verify_aec_signature(
     aec_xml_doc: xml_utils.XmlElement,
-    aec_xml: AecXml
+    aec_xml: AecXml,
 ) -> Optional[bool]:
     """
     Verify signature of AEC XML document ``aec_xml_doc``.

--- a/cl_sii/rut/__init__.py
+++ b/cl_sii/rut/__init__.py
@@ -174,11 +174,7 @@ class Rut:
 
         # Based on:
         #   https://gist.github.com/rbonvall/464824/4b07668b83ee45121345e4634ebce10dc6412ba3
-        s = sum(
-            d * f
-            for d, f
-            in zip(map(int, reversed(rut_digits)), itertools.cycle(range(2, 8)))
-        )
+        s = sum(d * f for d, f in zip(map(int, reversed(rut_digits)), itertools.cycle(range(2, 8))))
         result_alg = 11 - (s % 11)
         return {10: 'K', 11: '0'}.get(result_alg, str(result_alg))
 
@@ -191,8 +187,11 @@ class Rut:
         will be calculated appropriately i.e. it is not random.
 
         """
-        rut_digits = str(random.randint(
-            constants.RUT_DIGITS_MIN_VALUE,
-            constants.RUT_DIGITS_MAX_VALUE))
+        rut_digits = str(
+            random.randint(
+                constants.RUT_DIGITS_MIN_VALUE,
+                constants.RUT_DIGITS_MAX_VALUE,
+            )
+        )
         rut_dv = Rut.calc_dv(rut_digits)
         return Rut(f'{rut_digits}-{rut_dv}')

--- a/cl_sii/rut/crypto_utils.py
+++ b/cl_sii/rut/crypto_utils.py
@@ -17,7 +17,11 @@ def get_subject_rut_from_certificate_pfx(pfx_file_bytes: bytes, password: Option
     :param pfx_file_bytes: Digital certificate in PKCS12 format
     :param password: (Optional) The password to use to decrypt the PKCS12 file
     """
-    private_key, x509_cert, additional_certs = crypto_x509_backend.load_key_and_certificates_from_pkcs12(  # noqa: E501
+    (
+        private_key,
+        x509_cert,
+        additional_certs,
+    ) = crypto_x509_backend.load_key_and_certificates_from_pkcs12(
         data=pfx_file_bytes,
         password=password.encode() if password is not None else None,
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@
 # note: it is mandatory to register all dependencies of the required packages.
 
 # Required packages:
+black==22.1.0
 bumpversion==0.5.3
 codecov==2.1.11
 coverage==5.3
@@ -19,6 +20,13 @@ twine==3.1.1
 wheel==0.35.1
 
 # Packages dependencies:
+#   - black:
+#       - click
+#       - mypy-extensions
+#       - pathspec
+#       - platformdirs
+#       - tomli
+#       - typing-extensions
 #   - codecov:
 #       - coverage
 #       - requests:
@@ -82,6 +90,7 @@ wheel==0.35.1
 # cryptography
 # distlib
 # docutils
+click==8.0.3
 filelock==3.0.12
 # idna
 importlib-metadata==1.6.0
@@ -90,7 +99,9 @@ keyring==21.4.0
 mccabe==0.6.1
 mypy-extensions==0.4.3
 packaging==20.4
+pathspec==0.9.0
 pkginfo==1.7.0
+platformdirs==2.4.1
 pluggy==0.13.1
 py==1.10.0
 pycodestyle==2.8.0
@@ -103,9 +114,10 @@ requests==2.25.1
 # SecretStorage
 # six
 toml==0.10.2
+tomli==2.0.0
 tqdm==4.45.0
 typed-ast==1.4.2
-typing-extensions==3.7.4.3
+typing-extensions==4.0.1
 # urllib3
 virtualenv==20.4.3
 # webencodings

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ from setuptools import find_packages, setup
 def get_version(*file_paths: Sequence[str]) -> str:
     filename = os.path.join(os.path.dirname(__file__), *file_paths)
     version_file = open(filename).read()
-    version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError('Unable to find version string.')
@@ -39,8 +38,7 @@ extras_requirements = {
     'djangorestframework': ['djangorestframework>=3.10.3,<3.14'],
 }
 
-setup_requirements = [
-]
+setup_requirements = []
 
 test_requirements = [
     # note: include here only packages **imported** in test code (e.g. 'requests-mock'), NOT those

--- a/tests/test_cte_f29_data_models.py
+++ b/tests/test_cte_f29_data_models.py
@@ -61,9 +61,7 @@ class CteForm29Test(TestCase):
         obj = cte_f29_factories.create_CteForm29()
 
         code_field_names: Sequence[str] = [
-            field_name
-            for field_name in obj.CODE_FIELD_MAPPING.values()
-            if field_name is not None
+            field_name for field_name in obj.CODE_FIELD_MAPPING.values() if field_name is not None
         ]
         unique_code_field_names = set(code_field_names)
 

--- a/tests/test_cte_f29_parse_datos_obj.py
+++ b/tests/test_cte_f29_parse_datos_obj.py
@@ -59,7 +59,7 @@ class FunctionsTest(TestCase):
             762: 12443,
             795: 157080,
             915: datetime.date(2017, 10, 31),
-            922: "013-2015"
+            922: "013-2015",
         }
         self.assertEqual(obj.as_codes_dict(include_none=False), expected_codes_dict)
 
@@ -100,7 +100,7 @@ class FunctionsTest(TestCase):
                 595: 1536269,
                 761: 1,
                 762: 12443,
-                795: 157080
+                795: 157080,
             },
             "total_a_pagar_en_plazo_legal": 1536269,
             "total_a_pagar_con_recargo": 1603589,

--- a/tests/test_dte_constants.py
+++ b/tests/test_dte_constants.py
@@ -5,7 +5,6 @@ from cl_sii.dte.constants import TipoDte
 
 
 class TipoDteTest(unittest.TestCase):
-
     def test_members(self):
         self.assertSetEqual(
             {x for x in TipoDte},
@@ -17,7 +16,7 @@ class TipoDteTest(unittest.TestCase):
                 TipoDte.GUIA_DESPACHO_ELECTRONICA,
                 TipoDte.NOTA_DEBITO_ELECTRONICA,
                 TipoDte.NOTA_CREDITO_ELECTRONICA,
-            }
+            },
         )
 
     def test_FACTURA_ELECTRONICA(self):

--- a/tests/test_dte_data_models.py
+++ b/tests/test_dte_data_models.py
@@ -28,7 +28,6 @@ from .utils import read_test_file_bytes
 
 
 class DteNaturalKeyTest(unittest.TestCase):
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -78,7 +77,7 @@ class DteNaturalKeyTest(unittest.TestCase):
                 emisor_rut=Rut('76354771-K'),
                 tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
-            )
+            ),
         )
 
     def test_slug(self) -> None:
@@ -86,7 +85,6 @@ class DteNaturalKeyTest(unittest.TestCase):
 
 
 class DteDataL0Test(unittest.TestCase):
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -103,7 +101,8 @@ class DteDataL0Test(unittest.TestCase):
                 emisor_rut=Rut('76354771-K'),
                 tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
-            ))
+            ),
+        )
 
     def test_natural_key(self) -> None:
         self.assertEqual(
@@ -112,11 +111,11 @@ class DteDataL0Test(unittest.TestCase):
                 emisor_rut=Rut('76354771-K'),
                 tipo_dte=TipoDte.FACTURA_ELECTRONICA,
                 folio=170,
-            ))
+            ),
+        )
 
 
 class DteDataL1Test(unittest.TestCase):
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -195,19 +194,22 @@ class DteDataL1Test(unittest.TestCase):
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
                 monto_total=2996301,
-            ))
+            ),
+        )
 
     def test_vendedor_rut_comprador_rut(self) -> None:
         emisor_rut = self.dte_l1_1.emisor_rut
         receptor_rut = self.dte_l1_1.receptor_rut
-        dte_factura_venta = dataclasses.replace(
-            self.dte_l1_1, tipo_dte=TipoDte.FACTURA_ELECTRONICA)
+        dte_factura_venta = dataclasses.replace(self.dte_l1_1, tipo_dte=TipoDte.FACTURA_ELECTRONICA)
         dte_factura_venta_exenta = dataclasses.replace(
-            self.dte_l1_1, tipo_dte=TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA)
+            self.dte_l1_1, tipo_dte=TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA
+        )
         dte_factura_compra = dataclasses.replace(
-            self.dte_l1_1, tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA)
+            self.dte_l1_1, tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA
+        )
         dte_nota_credito = dataclasses.replace(
-            self.dte_l1_1, tipo_dte=TipoDte.NOTA_CREDITO_ELECTRONICA)
+            self.dte_l1_1, tipo_dte=TipoDte.NOTA_CREDITO_ELECTRONICA
+        )
 
         # 'vendedor_rut'
         self.assertEqual(dte_factura_venta.vendedor_rut, emisor_rut)
@@ -217,7 +219,8 @@ class DteDataL1Test(unittest.TestCase):
             self.assertIsNone(dte_nota_credito.vendedor_rut)
         self.assertEqual(
             cm.exception.args,
-            ("Concept \"vendedor\" does not apply for this 'tipo_dte'.", dte_nota_credito.tipo_dte))
+            ("Concept \"vendedor\" does not apply for this 'tipo_dte'.", dte_nota_credito.tipo_dte),
+        )
 
         # 'comprador_rut'
         self.assertEqual(dte_factura_venta.comprador_rut, receptor_rut)
@@ -227,8 +230,11 @@ class DteDataL1Test(unittest.TestCase):
             self.assertIsNone(dte_nota_credito.comprador_rut)
         self.assertEqual(
             cm.exception.args,
-            ("Concepts \"comprador\" and \"deudor\" do not apply for this 'tipo_dte'.",
-             dte_nota_credito.tipo_dte))
+            (
+                "Concepts \"comprador\" and \"deudor\" do not apply for this 'tipo_dte'.",
+                dte_nota_credito.tipo_dte,
+            ),
+        )
 
         # 'deudor_rut'
         self.assertEqual(dte_factura_venta.deudor_rut, receptor_rut)
@@ -238,24 +244,34 @@ class DteDataL1Test(unittest.TestCase):
             self.assertIsNone(dte_nota_credito.deudor_rut)
         self.assertEqual(
             cm.exception.args,
-            ("Concepts \"comprador\" and \"deudor\" do not apply for this 'tipo_dte'.",
-             dte_nota_credito.tipo_dte))
+            (
+                "Concepts \"comprador\" and \"deudor\" do not apply for this 'tipo_dte'.",
+                dte_nota_credito.tipo_dte,
+            ),
+        )
 
 
 class DteDataL2Test(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
 
-        cls.dte_1_xml_signature_value = encoding_utils.decode_base64_strict(read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-signature-value-base64.txt'))
+        cls.dte_1_xml_signature_value = encoding_utils.decode_base64_strict(
+            read_test_file_bytes(
+                'test_data/sii-crypto/DTE--76354771-K--33--170-signature-value-base64.txt'
+            )
+        )
         cls.dte_1_xml_cert_der = read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der')
-        cls.dte_2_xml_signature_value = encoding_utils.decode_base64_strict(read_test_file_bytes(
-            'test_data/sii-crypto/DTE--60910000-1--33--2336600-signature-value-base64.txt'))
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der'
+        )
+        cls.dte_2_xml_signature_value = encoding_utils.decode_base64_strict(
+            read_test_file_bytes(
+                'test_data/sii-crypto/DTE--60910000-1--33--2336600-signature-value-base64.txt'
+            )
+        )
         cls.dte_2_xml_cert_der = read_test_file_bytes(
-            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der')
+            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der'
+        )
 
     def setUp(self) -> None:
         super().setUp()
@@ -272,7 +288,8 @@ class DteDataL2Test(unittest.TestCase):
             fecha_vencimiento_date=None,
             firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 1, 1, 36, 40),
-                tz=DteDataL2.DATETIME_FIELDS_TZ),
+                tz=DteDataL2.DATETIME_FIELDS_TZ,
+            ),
             signature_value=self.dte_1_xml_signature_value,
             signature_x509_cert_der=self.dte_1_xml_cert_der,
             emisor_giro='Ingenieria y Construccion',
@@ -291,7 +308,8 @@ class DteDataL2Test(unittest.TestCase):
             fecha_vencimiento_date=date(2019, 8, 8),
             firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 8, 9, 9, 41, 9),
-                tz=DteDataL2.DATETIME_FIELDS_TZ),
+                tz=DteDataL2.DATETIME_FIELDS_TZ,
+            ),
             signature_value=self.dte_2_xml_signature_value,
             signature_x509_cert_der=self.dte_2_xml_cert_der,
             emisor_giro='Corporación Educacional y Servicios                 Profesionales',
@@ -382,11 +400,12 @@ class DteDataL2Test(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('firma_documento_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
         ]
@@ -412,7 +431,8 @@ class DteDataL2Test(unittest.TestCase):
         self.assertEqual(b'\x20', b' ')
         self.assertEqual(
             bytes_value_with_x20,
-            base64.b64decode(bytes_value_with_x20_as_base64, validate=True))
+            base64.b64decode(bytes_value_with_x20_as_base64, validate=True),
+        )
 
         init_kwars = self.dte_l2_1.as_dict()
         init_kwars.update(dict(signature_value=bytes_value_with_x20))
@@ -452,7 +472,8 @@ class DteDataL2Test(unittest.TestCase):
         self.assertEqual(b'\x20', b' ')
         self.assertEqual(
             bytes_value_with_x20,
-            base64.b64decode(bytes_value_with_x20_as_base64, validate=True))
+            base64.b64decode(bytes_value_with_x20_as_base64, validate=True),
+        )
 
         init_kwars = self.dte_l2_1.as_dict()
         init_kwars.update(dict(signature_x509_cert_der=bytes_value_with_x20))
@@ -509,11 +530,12 @@ class DteDataL2Test(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('emisor_email',),
-                'msg':
+                'msg': (
                     "("
                     "'Value has leading or trailing whitespace characters.', "
                     "' fake_emisor_email@test.cl '"
-                    ")",
+                    ")"
+                ),
                 'type': 'value_error',
             },
         ]
@@ -533,11 +555,12 @@ class DteDataL2Test(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('receptor_email',),
-                'msg':
+                'msg': (
                     "("
                     "'Value has leading or trailing whitespace characters.', "
                     "' fake_receptor_email@test.cl '"
-                    ")",
+                    ")"
+                ),
                 'type': 'value_error',
             },
         ]
@@ -628,13 +651,15 @@ class DteDataL2Test(unittest.TestCase):
                 fecha_vencimiento_date=None,
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                     dt=datetime(2019, 4, 1, 1, 36, 40),
-                    tz=DteDataL2.DATETIME_FIELDS_TZ),
+                    tz=DteDataL2.DATETIME_FIELDS_TZ,
+                ),
                 signature_value=self.dte_1_xml_signature_value,
                 signature_x509_cert_der=self.dte_1_xml_cert_der,
                 emisor_giro='Ingenieria y Construccion',
                 emisor_email='hello@example.com',
                 receptor_email=None,
-            ))
+            ),
+        )
         self.assertDictEqual(
             self.dte_l2_2.as_dict(),
             dict(
@@ -649,13 +674,15 @@ class DteDataL2Test(unittest.TestCase):
                 fecha_vencimiento_date=date(2019, 8, 8),
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                     dt=datetime(2019, 8, 9, 9, 41, 9),
-                    tz=DteDataL2.DATETIME_FIELDS_TZ),
+                    tz=DteDataL2.DATETIME_FIELDS_TZ,
+                ),
                 signature_value=self.dte_2_xml_signature_value,
                 signature_x509_cert_der=self.dte_2_xml_cert_der,
                 emisor_giro='Corporación Educacional y Servicios                 Profesionales',
                 emisor_email=None,
                 receptor_email=None,
-            ))
+            ),
+        )
 
     def test_as_dte_data_l1(self) -> None:
         self.assertEqual(
@@ -667,7 +694,7 @@ class DteDataL2Test(unittest.TestCase):
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
                 monto_total=2996301,
-            )
+            ),
         )
         self.assertEqual(
             self.dte_l2_2.as_dte_data_l1(),
@@ -678,24 +705,31 @@ class DteDataL2Test(unittest.TestCase):
                 fecha_emision_date=date(2019, 8, 8),
                 receptor_rut=Rut('76555835-2'),
                 monto_total=10642,
-            )
+            ),
         )
 
 
 class DteXmlDataTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
 
-        cls.dte_1_xml_signature_value = encoding_utils.decode_base64_strict(read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-signature-value-base64.txt'))
+        cls.dte_1_xml_signature_value = encoding_utils.decode_base64_strict(
+            read_test_file_bytes(
+                'test_data/sii-crypto/DTE--76354771-K--33--170-signature-value-base64.txt'
+            )
+        )
         cls.dte_1_xml_cert_der = read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der')
-        cls.dte_2_xml_signature_value = encoding_utils.decode_base64_strict(read_test_file_bytes(
-            'test_data/sii-crypto/DTE--60910000-1--33--2336600-signature-value-base64.txt'))
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der'
+        )
+        cls.dte_2_xml_signature_value = encoding_utils.decode_base64_strict(
+            read_test_file_bytes(
+                'test_data/sii-crypto/DTE--60910000-1--33--2336600-signature-value-base64.txt'
+            )
+        )
         cls.dte_2_xml_cert_der = read_test_file_bytes(
-            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der')
+            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der'
+        )
 
     def setUp(self) -> None:
         super().setUp()
@@ -712,7 +746,8 @@ class DteXmlDataTest(unittest.TestCase):
             fecha_vencimiento_date=None,
             firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 1, 1, 36, 40),
-                tz=DteXmlData.DATETIME_FIELDS_TZ),
+                tz=DteXmlData.DATETIME_FIELDS_TZ,
+            ),
             signature_value=self.dte_1_xml_signature_value,
             signature_x509_cert_der=self.dte_1_xml_cert_der,
             emisor_giro='Ingenieria y Construccion',
@@ -731,7 +766,8 @@ class DteXmlDataTest(unittest.TestCase):
             fecha_vencimiento_date=date(2019, 8, 8),
             firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 8, 9, 9, 41, 9),
-                tz=DteXmlData.DATETIME_FIELDS_TZ),
+                tz=DteXmlData.DATETIME_FIELDS_TZ,
+            ),
             signature_value=self.dte_2_xml_signature_value,
             signature_x509_cert_der=self.dte_2_xml_cert_der,
             emisor_giro='Corporación Educacional y Servicios                 Profesionales',
@@ -852,11 +888,12 @@ class DteXmlDataTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('firma_documento_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
         ]
@@ -882,7 +919,8 @@ class DteXmlDataTest(unittest.TestCase):
         self.assertEqual(b'\x20', b' ')
         self.assertEqual(
             bytes_value_with_x20,
-            base64.b64decode(bytes_value_with_x20_as_base64, validate=True))
+            base64.b64decode(bytes_value_with_x20_as_base64, validate=True),
+        )
 
         init_kwars = self.dte_xml_data_1.as_dict()
         init_kwars.update(dict(signature_value=bytes_value_with_x20))
@@ -922,7 +960,8 @@ class DteXmlDataTest(unittest.TestCase):
         self.assertEqual(b'\x20', b' ')
         self.assertEqual(
             bytes_value_with_x20,
-            base64.b64decode(bytes_value_with_x20_as_base64, validate=True))
+            base64.b64decode(bytes_value_with_x20_as_base64, validate=True),
+        )
 
         init_kwars = self.dte_xml_data_1.as_dict()
         init_kwars.update(dict(signature_x509_cert_der=bytes_value_with_x20))
@@ -979,11 +1018,12 @@ class DteXmlDataTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('emisor_email',),
-                'msg':
+                'msg': (
                     "("
                     "'Value has leading or trailing whitespace characters.', "
                     "' fake_emisor_email@test.cl '"
-                    ")",
+                    ")"
+                ),
                 'type': 'value_error',
             },
         ]
@@ -1003,11 +1043,12 @@ class DteXmlDataTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('receptor_email',),
-                'msg':
+                'msg': (
                     "("
                     "'Value has leading or trailing whitespace characters.', "
                     "' fake_receptor_email@test.cl '"
-                    ")",
+                    ")"
+                ),
                 'type': 'value_error',
             },
         ]
@@ -1098,13 +1139,15 @@ class DteXmlDataTest(unittest.TestCase):
                 fecha_vencimiento_date=None,
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                     dt=datetime(2019, 4, 1, 1, 36, 40),
-                    tz=DteXmlData.DATETIME_FIELDS_TZ),
+                    tz=DteXmlData.DATETIME_FIELDS_TZ,
+                ),
                 signature_value=self.dte_1_xml_signature_value,
                 signature_x509_cert_der=self.dte_1_xml_cert_der,
                 emisor_giro='Ingenieria y Construccion',
                 emisor_email='hello@example.com',
                 receptor_email=None,
-            ))
+            ),
+        )
         self.assertDictEqual(
             self.dte_xml_data_2.as_dict(),
             dict(
@@ -1119,13 +1162,15 @@ class DteXmlDataTest(unittest.TestCase):
                 fecha_vencimiento_date=date(2019, 8, 8),
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                     dt=datetime(2019, 8, 9, 9, 41, 9),
-                    tz=DteXmlData.DATETIME_FIELDS_TZ),
+                    tz=DteXmlData.DATETIME_FIELDS_TZ,
+                ),
                 signature_value=self.dte_2_xml_signature_value,
                 signature_x509_cert_der=self.dte_2_xml_cert_der,
                 emisor_giro='Corporación Educacional y Servicios                 Profesionales',
                 emisor_email=None,
                 receptor_email=None,
-            ))
+            ),
+        )
 
     def test_as_dte_data_l1(self) -> None:
         self.assertEqual(
@@ -1137,7 +1182,7 @@ class DteXmlDataTest(unittest.TestCase):
                 fecha_emision_date=date(2019, 4, 1),
                 receptor_rut=Rut('96790240-3'),
                 monto_total=2996301,
-            )
+            ),
         )
         self.assertEqual(
             self.dte_xml_data_2.as_dte_data_l1(),
@@ -1148,7 +1193,7 @@ class DteXmlDataTest(unittest.TestCase):
                 fecha_emision_date=date(2019, 8, 8),
                 receptor_rut=Rut('76555835-2'),
                 monto_total=10642,
-            )
+            ),
         )
 
     def test_as_dte_data_l2(self) -> None:
@@ -1166,13 +1211,14 @@ class DteXmlDataTest(unittest.TestCase):
                 fecha_vencimiento_date=None,
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                     dt=datetime(2019, 4, 1, 1, 36, 40),
-                    tz=DteXmlData.DATETIME_FIELDS_TZ),
+                    tz=DteXmlData.DATETIME_FIELDS_TZ,
+                ),
                 signature_value=self.dte_1_xml_signature_value,
                 signature_x509_cert_der=self.dte_1_xml_cert_der,
                 emisor_giro='Ingenieria y Construccion',
                 emisor_email='hello@example.com',
                 receptor_email=None,
-            )
+            ),
         )
         self.assertEqual(
             self.dte_xml_data_2.as_dte_data_l2(),
@@ -1188,18 +1234,18 @@ class DteXmlDataTest(unittest.TestCase):
                 fecha_vencimiento_date=date(2019, 8, 8),
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                     dt=datetime(2019, 8, 9, 9, 41, 9),
-                    tz=DteXmlData.DATETIME_FIELDS_TZ),
+                    tz=DteXmlData.DATETIME_FIELDS_TZ,
+                ),
                 signature_value=self.dte_2_xml_signature_value,
                 signature_x509_cert_der=self.dte_2_xml_cert_der,
                 emisor_giro='Corporación Educacional y Servicios                 Profesionales',
                 emisor_email=None,
                 receptor_email=None,
-            )
+            ),
         )
 
 
 class FunctionsTest(unittest.TestCase):
-
     def test_validate_contribuyente_razon_social(self) -> None:
         # TODO: implement for 'validate_contribuyente_razon_social'
         pass

--- a/tests/test_dte_parse.py
+++ b/tests/test_dte_parse.py
@@ -21,55 +21,53 @@ from .utils import read_test_file_bytes
 
 
 class OthersTest(unittest.TestCase):
-
     def test_DTE_XML_SCHEMA_OBJ(self) -> None:
         # TODO: implement
         pass
 
 
 class FunctionValidateDteXmlTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
 
         cls.dte_bad_xml_1_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170.xml'
+        )
         cls.dte_bad_xml_2_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76399752-9--33--25568.xml')
+            'test_data/sii-dte/DTE--76399752-9--33--25568.xml'
+        )
         cls.dte_bad_xml_3_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--60910000-1--33--2336600.xml')
+            'test_data/sii-dte/DTE--60910000-1--33--2336600.xml'
+        )
 
         cls.dte_clean_xml_1_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned.xml'
+        )
         cls.dte_clean_xml_2_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76399752-9--33--25568--cleaned.xml')
+            'test_data/sii-dte/DTE--76399752-9--33--25568--cleaned.xml'
+        )
         cls.dte_clean_xml_3_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--60910000-1--33--2336600--cleaned.xml')
+            'test_data/sii-dte/DTE--60910000-1--33--2336600--cleaned.xml'
+        )
 
     def test_validate_dte_xml_ok_dte_1(self) -> None:
         xml_doc = xml_utils.parse_untrusted_xml(self.dte_clean_xml_1_xml_bytes)
         validate_dte_xml(xml_doc)
 
-        self.assertEqual(
-            xml_doc.getroottree().getroot().tag,
-            '{%s}DTE' % DTE_XMLNS)
+        self.assertEqual(xml_doc.getroottree().getroot().tag, '{%s}DTE' % DTE_XMLNS)
 
     def test_validate_dte_xml_ok_dte_2(self) -> None:
         xml_doc = xml_utils.parse_untrusted_xml(self.dte_clean_xml_2_xml_bytes)
         validate_dte_xml(xml_doc)
 
-        self.assertEqual(
-            xml_doc.getroottree().getroot().tag,
-            '{%s}DTE' % DTE_XMLNS)
+        self.assertEqual(xml_doc.getroottree().getroot().tag, '{%s}DTE' % DTE_XMLNS)
 
     def test_validate_dte_xml_ok_dte_3(self) -> None:
         xml_doc = xml_utils.parse_untrusted_xml(self.dte_clean_xml_3_xml_bytes)
         validate_dte_xml(xml_doc)
 
-        self.assertEqual(
-            xml_doc.getroottree().getroot().tag,
-            '{%s}DTE' % DTE_XMLNS)
+        self.assertEqual(xml_doc.getroottree().getroot().tag, '{%s}DTE' % DTE_XMLNS)
 
     def test_validate_dte_xml_fail_x(self) -> None:
         # TODO: implement more cases
@@ -79,78 +77,80 @@ class FunctionValidateDteXmlTest(unittest.TestCase):
         file_bytes = self.dte_bad_xml_1_xml_bytes
         xml_doc = xml_utils.parse_untrusted_xml(file_bytes)
 
-        self.assertEqual(
-            xml_doc.getroottree().getroot().tag,
-            'DTE')
+        self.assertEqual(xml_doc.getroottree().getroot().tag, 'DTE')
 
         with self.assertRaises(xml_utils.XmlSchemaDocValidationError) as cm:
             validate_dte_xml(xml_doc)
         self.assertSequenceEqual(
             cm.exception.args,
-            ("Element 'DTE': No matching global declaration available for the validation root., "
-             "line 2", )
+            (
+                "Element 'DTE': No matching global declaration available for the validation root., "
+                "line 2",
+            ),
         )
 
     def test_validate_dte_xml_fail_dte_2(self) -> None:
         file_bytes = self.dte_bad_xml_2_xml_bytes
         xml_doc = xml_utils.parse_untrusted_xml(file_bytes)
 
-        self.assertEqual(
-            xml_doc.getroottree().getroot().tag,
-            'DTE')
+        self.assertEqual(xml_doc.getroottree().getroot().tag, 'DTE')
 
         with self.assertRaises(xml_utils.XmlSchemaDocValidationError) as cm:
             validate_dte_xml(xml_doc)
         self.assertSequenceEqual(
             cm.exception.args,
-            ("Element 'DTE': No matching global declaration available for the validation root., "
-             "line 2", )
+            (
+                "Element 'DTE': No matching global declaration available for the validation root., "
+                "line 2",
+            ),
         )
 
     def test_validate_dte_xml_fail_dte_3(self) -> None:
         file_bytes = self.dte_bad_xml_3_xml_bytes
         xml_doc = xml_utils.parse_untrusted_xml(file_bytes)
 
-        self.assertEqual(
-            xml_doc.getroottree().getroot().tag,
-            'DTE')
+        self.assertEqual(xml_doc.getroottree().getroot().tag, 'DTE')
 
         with self.assertRaises(xml_utils.XmlSchemaDocValidationError) as cm:
             validate_dte_xml(xml_doc)
         self.assertSequenceEqual(
             cm.exception.args,
-            ("Element 'DTE': No matching global declaration available for the validation root., "
-             "line 2", )
+            (
+                "Element 'DTE': No matching global declaration available for the validation root., "
+                "line 2",
+            ),
         )
 
 
 class FunctionCleanDteXmlTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
 
         cls.dte_bad_xml_1_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170.xml'
+        )
         cls.dte_bad_xml_2_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76399752-9--33--25568.xml')
+            'test_data/sii-dte/DTE--76399752-9--33--25568.xml'
+        )
         cls.dte_bad_xml_3_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--60910000-1--33--2336600.xml')
+            'test_data/sii-dte/DTE--60910000-1--33--2336600.xml'
+        )
 
     def test_clean_dte_xml_ok_1(self) -> None:
         file_bytes = self.dte_bad_xml_1_xml_bytes
         xml_doc = xml_utils.parse_untrusted_xml(file_bytes)
 
-        self.assertEqual(
-            xml_doc.getroottree().getroot().tag,
-            'DTE')
+        self.assertEqual(xml_doc.getroottree().getroot().tag, 'DTE')
 
         with self.assertRaises(xml_utils.XmlSchemaDocValidationError) as cm:
             validate_dte_xml(xml_doc)
         self.assertSequenceEqual(
             cm.exception.args,
-            ("Element 'DTE': No matching global declaration available for the validation root., "
-             "line 2", )
+            (
+                "Element 'DTE': No matching global declaration available for the validation root., "
+                "line 2",
+            ),
         )
 
         xml_doc_cleaned, modified = clean_dte_xml(
@@ -205,26 +205,26 @@ class FunctionCleanDteXmlTest(unittest.TestCase):
         file_bytes_diff_gen = difflib.diff_bytes(
             dfunc=difflib.unified_diff,
             a=file_bytes.splitlines(),
-            b=file_bytes_rewritten.splitlines())
+            b=file_bytes_rewritten.splitlines(),
+        )
         self.assertSequenceEqual(
-            [diff_line for diff_line in file_bytes_diff_gen],
-            expected_file_bytes_diff
+            [diff_line for diff_line in file_bytes_diff_gen], expected_file_bytes_diff
         )
 
     def test_clean_dte_xml_ok_2(self) -> None:
         file_bytes = self.dte_bad_xml_2_xml_bytes
         xml_doc = xml_utils.parse_untrusted_xml(file_bytes)
 
-        self.assertEqual(
-            xml_doc.getroottree().getroot().tag,
-            'DTE')
+        self.assertEqual(xml_doc.getroottree().getroot().tag, 'DTE')
 
         with self.assertRaises(xml_utils.XmlSchemaDocValidationError) as cm:
             validate_dte_xml(xml_doc)
         self.assertSequenceEqual(
             cm.exception.args,
-            ("Element 'DTE': No matching global declaration available for the validation root., "
-             "line 2", )
+            (
+                "Element 'DTE': No matching global declaration available for the validation root., "
+                "line 2",
+            ),
         )
 
         xml_doc_cleaned, modified = clean_dte_xml(
@@ -279,26 +279,27 @@ class FunctionCleanDteXmlTest(unittest.TestCase):
         file_bytes_diff_gen = difflib.diff_bytes(
             dfunc=difflib.unified_diff,
             a=file_bytes.splitlines(),
-            b=file_bytes_rewritten.splitlines())
+            b=file_bytes_rewritten.splitlines(),
+        )
         self.assertSequenceEqual(
             [diff_line for diff_line in file_bytes_diff_gen],
-            expected_file_bytes_diff
+            expected_file_bytes_diff,
         )
 
     def test_clean_dte_xml_ok_3(self) -> None:
         file_bytes = self.dte_bad_xml_3_xml_bytes
         xml_doc = xml_utils.parse_untrusted_xml(file_bytes)
 
-        self.assertEqual(
-            xml_doc.getroottree().getroot().tag,
-            'DTE')
+        self.assertEqual(xml_doc.getroottree().getroot().tag, 'DTE')
 
         with self.assertRaises(xml_utils.XmlSchemaDocValidationError) as cm:
             validate_dte_xml(xml_doc)
         self.assertSequenceEqual(
             cm.exception.args,
-            ("Element 'DTE': No matching global declaration available for the validation root., "
-             "line 2", )
+            (
+                "Element 'DTE': No matching global declaration available for the validation root., "
+                "line 2",
+            ),
         )
 
         xml_doc_cleaned, modified = clean_dte_xml(
@@ -335,10 +336,10 @@ class FunctionCleanDteXmlTest(unittest.TestCase):
         file_bytes_diff_gen = difflib.diff_bytes(
             dfunc=difflib.unified_diff,
             a=file_bytes.splitlines(),
-            b=file_bytes_rewritten.splitlines())
+            b=file_bytes_rewritten.splitlines(),
+        )
         self.assertSequenceEqual(
-            [diff_line for diff_line in file_bytes_diff_gen],
-            expected_file_bytes_diff
+            [diff_line for diff_line in file_bytes_diff_gen], expected_file_bytes_diff
         )
 
     def test_clean_dte_xml_fail(self) -> None:
@@ -363,52 +364,73 @@ class FunctionCleanDteXmlTest(unittest.TestCase):
 
 
 class FunctionParseDteXmlTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
 
         cls.dte_bad_xml_1_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170.xml'
+        )
         cls.dte_bad_xml_2_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76399752-9--33--25568.xml')
+            'test_data/sii-dte/DTE--76399752-9--33--25568.xml'
+        )
         cls.dte_bad_xml_3_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--60910000-1--33--2336600.xml')
+            'test_data/sii-dte/DTE--60910000-1--33--2336600.xml'
+        )
 
         cls.dte_clean_xml_1_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned.xml'
+        )
         cls.dte_clean_xml_2_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76399752-9--33--25568--cleaned.xml')
+            'test_data/sii-dte/DTE--76399752-9--33--25568--cleaned.xml'
+        )
         cls.dte_clean_xml_3_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--60910000-1--33--2336600--cleaned.xml')
+            'test_data/sii-dte/DTE--60910000-1--33--2336600--cleaned.xml'
+        )
         cls.dte_clean_xml_1b_xml_bytes = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-empty-emails.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-empty-emails.xml'
+        )
 
         cls.dte_clean_xml_1_cert_pem_bytes = encoding_utils.clean_base64(
             crypto_utils.remove_pem_cert_header_footer(
-                read_test_file_bytes('test_data/sii-crypto/DTE--76354771-K--33--170-cert.pem')))
+                read_test_file_bytes('test_data/sii-crypto/DTE--76354771-K--33--170-cert.pem')
+            )
+        )
         cls.dte_clean_xml_1_cert_der = read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der')
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der'
+        )
         cls.dte_clean_xml_2_cert_pem_bytes = encoding_utils.clean_base64(
             crypto_utils.remove_pem_cert_header_footer(
-                read_test_file_bytes('test_data/sii-crypto/DTE--76399752-9--33--25568-cert.pem')))
+                read_test_file_bytes('test_data/sii-crypto/DTE--76399752-9--33--25568-cert.pem')
+            )
+        )
         cls.dte_clean_xml_2_cert_der = read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76399752-9--33--25568-cert.der')
+            'test_data/sii-crypto/DTE--76399752-9--33--25568-cert.der'
+        )
         cls.dte_clean_xml_3_cert_pem_bytes = encoding_utils.clean_base64(
             crypto_utils.remove_pem_cert_header_footer(
-                read_test_file_bytes('test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.pem')))
+                read_test_file_bytes('test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.pem')
+            )
+        )
         cls.dte_clean_xml_3_cert_der = read_test_file_bytes(
-            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der')
+            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der'
+        )
 
         cls._TEST_DTE_1_SIGNATURE_VALUE = encoding_utils.decode_base64_strict(
             read_test_file_bytes(
-                'test_data/sii-crypto/DTE--76354771-K--33--170-signature-value-base64.txt'))
+                'test_data/sii-crypto/DTE--76354771-K--33--170-signature-value-base64.txt'
+            )
+        )
         cls._TEST_DTE_2_SIGNATURE_VALUE = encoding_utils.decode_base64_strict(
             read_test_file_bytes(
-                'test_data/sii-crypto/DTE--76399752-9--33--25568-signature-value-base64.txt'))
+                'test_data/sii-crypto/DTE--76399752-9--33--25568-signature-value-base64.txt'
+            )
+        )
         cls._TEST_DTE_3_SIGNATURE_VALUE = encoding_utils.decode_base64_strict(
             read_test_file_bytes(
-                'test_data/sii-crypto/DTE--60910000-1--33--2336600-signature-value-base64.txt'))
+                'test_data/sii-crypto/DTE--60910000-1--33--2336600-signature-value-base64.txt'
+            )
+        )
 
     def test_data(self):
         self.assertEqual(
@@ -417,7 +439,8 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             b'\x0b\x16\xef\xc12\x00^\xbe\xc1.\xb9o_p\xbf\x1e\x97\xe8\xe2\xf8\xaak\x14\xae\xd4'
             b'\xe1\x85\x80\xf9\xe4u\xd0\xc8\x17\x08\xfff\xc5]m\xd0~2\x1aJ\x93(Z\xf3tq\x84\x9a'
             b'X\x05PX\xdd\xcf\xb2\xf4\x9e\xa81\xf7Ht\xc0\x18^\x11$\x17\x0f0\xebr\x87\xca\x17_'
-            b'\xd8O]\x9d\xb2\xa2\xc2\xa4\xb1\r\xc6#M>\xaf^\xc2\xcf\xad\x99')
+            b'\xd8O]\x9d\xb2\xa2\xc2\xa4\xb1\r\xc6#M>\xaf^\xc2\xcf\xad\x99',
+        )
         self.assertEqual(
             self._TEST_DTE_2_SIGNATURE_VALUE,
             b"\xc3\x03\x8cB\xe1jk\xa79\x836\x12'\x93\xd6~\x8d\x0e\x88\x07\xfe\xc8\xd7\t+\xac1"
@@ -429,7 +452,8 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             b"\xa3\xdap&\xf5\x18\x00b\xce\xbf&\x95Q\x19\x82\x06`&\xe9\xcc\x0c(i\x15\x0c\x84"
             b"\x8a\x04\x970\xaeH\xef~\xc0s\xc0\xf6o\x0e\xd6\x07\x8e\xd6\x8fU\x81/{\x02\x15\x10"
             b"\xe5]E\xed\x9c\xcb\xc2\x84\x15i\xd0tT]\x8b\x8a\x1f'\xe9\x0b:\x88\x05|\xa0b\xb2"
-            b"\x19{\x1cW\x80\xe4\xa7*\xef\xf2\x1a")
+            b"\x19{\x1cW\x80\xe4\xa7*\xef\xf2\x1a",
+        )
         self.assertEqual(
             self._TEST_DTE_3_SIGNATURE_VALUE,
             b"&{\x924\xcd\x80\xe9\xc2\x89pN9\x1ec\xf9\x8b&,\xec\xc8\x08\xa6[\x8ajo\xad\xed"
@@ -441,17 +465,21 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             b"\x92\xc9lg2\x90\x99G\x87\x8e\x0c4&\x11b\x86\x1b\xc2\xe0)\xea` \xe6\x1f6\xcf\xc1"
             b"\x1a\xce/\x05\xf8-\x12f\xf4\n!0\xa0wWh\xf8f`4e\t\x07T\x1a+\xf29\xacN\xd6\r\xf8k"
             b"\xe6\x83\xb0\xaaMEy\x03\x08/\xf4\x19\xa8s\x91x\x8c\xa8\x1e\xbe\xd6Ur)5\x06\x8e"
-            b"\xfcr\xa5W\x8e\x9dJ\xe5\xb3d")
+            b"\xfcr\xa5W\x8e\x9dJ\xe5\xb3d",
+        )
 
         self.assertEqual(
             crypto_utils.x509_cert_pem_to_der(self.dte_clean_xml_1_cert_pem_bytes),
-            self.dte_clean_xml_1_cert_der)
+            self.dte_clean_xml_1_cert_der,
+        )
         self.assertEqual(
             crypto_utils.x509_cert_pem_to_der(self.dte_clean_xml_2_cert_pem_bytes),
-            self.dte_clean_xml_2_cert_der)
+            self.dte_clean_xml_2_cert_der,
+        )
         self.assertEqual(
             crypto_utils.x509_cert_pem_to_der(self.dte_clean_xml_3_cert_pem_bytes),
-            self.dte_clean_xml_3_cert_der)
+            self.dte_clean_xml_3_cert_der,
+        )
 
     def test_parse_dte_xml_ok_1(self) -> None:
         xml_doc = xml_utils.parse_untrusted_xml(self.dte_clean_xml_1_xml_bytes)
@@ -471,13 +499,15 @@ class FunctionParseDteXmlTest(unittest.TestCase):
                 fecha_vencimiento_date=None,
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                     dt=datetime(2019, 4, 1, 1, 36, 40),
-                    tz=DteDataL2.DATETIME_FIELDS_TZ),
+                    tz=DteDataL2.DATETIME_FIELDS_TZ,
+                ),
                 signature_value=self._TEST_DTE_1_SIGNATURE_VALUE,
                 signature_x509_cert_der=self.dte_clean_xml_1_cert_der,
                 emisor_giro='Ingenieria y Construccion',
                 emisor_email='ENACONLTDA@GMAIL.COM',
                 receptor_email=None,
-            ))
+            ),
+        )
 
     def test_parse_dte_xml_ok_3(self) -> None:
         xml_doc = xml_utils.parse_untrusted_xml(self.dte_clean_xml_3_xml_bytes)
@@ -497,13 +527,15 @@ class FunctionParseDteXmlTest(unittest.TestCase):
                 fecha_vencimiento_date=date(2019, 8, 8),
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                     dt=datetime(2019, 8, 9, 9, 41, 9),
-                    tz=DteDataL2.DATETIME_FIELDS_TZ),
+                    tz=DteDataL2.DATETIME_FIELDS_TZ,
+                ),
                 signature_value=self._TEST_DTE_3_SIGNATURE_VALUE,
                 signature_x509_cert_der=self.dte_clean_xml_3_cert_der,
                 emisor_giro='Corporación Educacional y Servicios                 Profesionales',
                 emisor_email=None,
                 receptor_email=None,
-            ))
+            ),
+        )
 
     def test_parse_dte_xml_ok_1b(self) -> None:
         xml_doc = xml_utils.parse_untrusted_xml(self.dte_clean_xml_1b_xml_bytes)
@@ -523,13 +555,15 @@ class FunctionParseDteXmlTest(unittest.TestCase):
                 fecha_vencimiento_date=None,
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                     dt=datetime(2019, 4, 1, 1, 36, 40),
-                    tz=DteDataL2.DATETIME_FIELDS_TZ),
+                    tz=DteDataL2.DATETIME_FIELDS_TZ,
+                ),
                 signature_value=self._TEST_DTE_1_SIGNATURE_VALUE,
                 signature_x509_cert_der=self.dte_clean_xml_1_cert_der,
                 emisor_giro='Ingenieria y Construccion',
                 emisor_email=None,
                 receptor_email=None,
-            ))
+            ),
+        )
 
     def test_parse_dte_xml_ok_2(self) -> None:
         xml_doc = xml_utils.parse_untrusted_xml(self.dte_clean_xml_2_xml_bytes)
@@ -549,13 +583,15 @@ class FunctionParseDteXmlTest(unittest.TestCase):
                 fecha_vencimiento_date=None,
                 firma_documento_dt=tz_utils.convert_naive_dt_to_tz_aware(
                     dt=datetime(2019, 3, 28, 13, 59, 52),
-                    tz=DteDataL2.DATETIME_FIELDS_TZ),
+                    tz=DteDataL2.DATETIME_FIELDS_TZ,
+                ),
                 signature_value=self._TEST_DTE_2_SIGNATURE_VALUE,
                 signature_x509_cert_der=self.dte_clean_xml_2_cert_der,
                 emisor_giro='COMERCIALIZACION DE PRODUCTOS PARA EL HOGAR',
                 emisor_email='ANGEL.PEZO@APCASESORIAS.CL',
                 receptor_email=None,
-            ))
+            ),
+        )
 
     def test_parse_dte_xml_fail_x(self) -> None:
         # TODO: implement more cases
@@ -568,7 +604,7 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             parse_dte_xml(xml_doc)
         self.assertSequenceEqual(
             cm.exception.args,
-            ("Top level XML element 'Document' is required.", )
+            ("Top level XML element 'Document' is required.",),
         )
 
     def test_parse_dte_xml_fail_2(self) -> None:
@@ -578,7 +614,7 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             parse_dte_xml(xml_doc)
         self.assertSequenceEqual(
             cm.exception.args,
-            ("Top level XML element 'Document' is required.", )
+            ("Top level XML element 'Document' is required.",),
         )
 
     def test_parse_dte_xml_fail_3(self) -> None:
@@ -588,5 +624,5 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             parse_dte_xml(xml_doc)
         self.assertSequenceEqual(
             cm.exception.args,
-            ("Top level XML element 'Document' is required.", )
+            ("Top level XML element 'Document' is required.",),
         )

--- a/tests/test_extras_mm_fields.py
+++ b/tests/test_extras_mm_fields.py
@@ -16,9 +16,7 @@ from cl_sii.extras.mm_fields import (
 
 
 class RutFieldTest(unittest.TestCase):
-
     def setUp(self) -> None:
-
         class MyObj:
             def __init__(self, emisor_rut: Rut, other_field: int = None) -> None:
                 self.emisor_rut = emisor_rut
@@ -29,7 +27,6 @@ class RutFieldTest(unittest.TestCase):
                 self.some_field = some_field
 
         class MyMmSchema(marshmallow.Schema):
-
             class Meta:
                 strict = False
 
@@ -42,7 +39,6 @@ class RutFieldTest(unittest.TestCase):
             )
 
         class MyMmSchemaStrict(marshmallow.Schema):
-
             class Meta:
                 strict = True
 
@@ -125,7 +121,9 @@ class RutFieldTest(unittest.TestCase):
 
         result = schema.load(data_invalid_1)
         self.assertDictEqual(dict(result.data), {})
-        self.assertDictEqual(dict(result.errors), {'RUT of Emisor': ['Not a syntactically valid RUT.']})  # noqa: E501
+        self.assertDictEqual(
+            dict(result.errors), {'RUT of Emisor': ['Not a syntactically valid RUT.']}
+        )
 
         result = schema.load(data_invalid_2)
         self.assertDictEqual(dict(result.data), {})
@@ -137,7 +135,9 @@ class RutFieldTest(unittest.TestCase):
 
         result = schema.load(data_invalid_4)
         self.assertDictEqual(dict(result.data), {})
-        self.assertDictEqual(dict(result.errors), {'RUT of Emisor': ['Missing data for required field.']})  # noqa: E501
+        self.assertDictEqual(
+            dict(result.errors), {'RUT of Emisor': ['Missing data for required field.']}
+        )
 
     def test_dump_fail(self) -> None:
         schema = self.MyMmSchema()
@@ -157,9 +157,7 @@ class RutFieldTest(unittest.TestCase):
 
 
 class TipoDteFieldTest(unittest.TestCase):
-
     def setUp(self) -> None:
-
         class MyObj:
             def __init__(self, tipo_dte: TipoDte, other_field: int = None) -> None:
                 self.tipo_dte = tipo_dte
@@ -170,7 +168,6 @@ class TipoDteFieldTest(unittest.TestCase):
                 self.some_field = some_field
 
         class MyMmSchema(marshmallow.Schema):
-
             class Meta:
                 strict = False
 
@@ -183,7 +180,6 @@ class TipoDteFieldTest(unittest.TestCase):
             )
 
         class MyMmSchemaStrict(marshmallow.Schema):
-
             class Meta:
                 strict = True
 
@@ -278,7 +274,9 @@ class TipoDteFieldTest(unittest.TestCase):
 
         result = schema.load(data_invalid_4)
         self.assertDictEqual(dict(result.data), {})
-        self.assertDictEqual(dict(result.errors), {'source field name': ['Missing data for required field.']})  # noqa: E501
+        self.assertDictEqual(
+            dict(result.errors), {'source field name': ['Missing data for required field.']}
+        )
 
     def test_dump_fail(self) -> None:
         schema = self.MyMmSchema()
@@ -302,9 +300,7 @@ class TipoDteFieldTest(unittest.TestCase):
 
 
 class RcvTipoDoctoFieldTest(unittest.TestCase):
-
     def setUp(self) -> None:
-
         class MyObj:
             def __init__(self, tipo_docto: RcvTipoDocto, other_field: int = None) -> None:
                 self.tipo_docto = tipo_docto
@@ -315,7 +311,6 @@ class RcvTipoDoctoFieldTest(unittest.TestCase):
                 self.some_field = some_field
 
         class MyMmSchema(marshmallow.Schema):
-
             class Meta:
                 strict = False
 
@@ -328,7 +323,6 @@ class RcvTipoDoctoFieldTest(unittest.TestCase):
             )
 
         class MyMmSchemaStrict(marshmallow.Schema):
-
             class Meta:
                 strict = True
 
@@ -411,7 +405,9 @@ class RcvTipoDoctoFieldTest(unittest.TestCase):
 
         result = schema.load(data_invalid_1)
         self.assertDictEqual(dict(result.data), {})
-        self.assertDictEqual(dict(result.errors), {'source field name': ["Not a valid RCV's Tipo de Documento."]})  # noqa: E501
+        self.assertDictEqual(
+            dict(result.errors), {'source field name': ["Not a valid RCV's Tipo de Documento."]}
+        )
 
         result = schema.load(data_invalid_2)
         self.assertDictEqual(dict(result.data), {})
@@ -423,7 +419,9 @@ class RcvTipoDoctoFieldTest(unittest.TestCase):
 
         result = schema.load(data_invalid_4)
         self.assertDictEqual(dict(result.data), {})
-        self.assertDictEqual(dict(result.errors), {'source field name': ['Missing data for required field.']})  # noqa: E501
+        self.assertDictEqual(
+            dict(result.errors), {'source field name': ['Missing data for required field.']}
+        )
 
     def test_dump_fail(self) -> None:
         schema = self.MyMmSchema()

--- a/tests/test_libs_crypto_utils.py
+++ b/tests/test_libs_crypto_utils.py
@@ -34,7 +34,6 @@ _SII_CERT_CERTIFICADORA_EMISORA_RUT_OID = oid.ObjectIdentifier("1.3.6.1.4.1.8321
 
 
 class FunctionsTest(unittest.TestCase):
-
     def test_add_pem_cert_header_footer(self) -> None:
         # TODO: implement for function 'add_pem_cert_header_footer'.
         pass
@@ -45,10 +44,10 @@ class FunctionsTest(unittest.TestCase):
 
 
 class LoadPemX509CertTest(unittest.TestCase):
-
     def test_load_der_x509_cert_ok(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/crypto/wildcard-google-com-cert.der')
+            'test_data/crypto/wildcard-google-com-cert.der',
+        )
 
         x509_cert = load_der_x509_cert(cert_der_bytes)
 
@@ -60,23 +59,29 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         self.assertEqual(
             x509_cert.version,
-            cryptography.x509.Version.v3)
+            cryptography.x509.Version.v3,
+        )
         self.assertIsInstance(
             x509_cert.signature_hash_algorithm,
-            cryptography.hazmat.primitives.hashes.SHA256)
+            cryptography.hazmat.primitives.hashes.SHA256,
+        )
         self.assertEqual(
             x509_cert.signature_algorithm_oid,
-            oid.SignatureAlgorithmOID.RSA_WITH_SHA256)
+            oid.SignatureAlgorithmOID.RSA_WITH_SHA256,
+        )
 
         self.assertEqual(
             x509_cert.serial_number,
-            122617997729991213273569581938043448870)
+            122617997729991213273569581938043448870,
+        )
         self.assertEqual(
             x509_cert.not_valid_after,
-            datetime(2019, 6, 18, 13, 24))
+            datetime(2019, 6, 18, 13, 24),
+        )
         self.assertEqual(
             x509_cert.not_valid_before,
-            datetime(2019, 3, 26, 13, 40, 40))
+            datetime(2019, 3, 26, 13, 40, 40),
+        )
 
         #######################################################################
         # issuer
@@ -85,13 +90,16 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(len(x509_cert.issuer.rdns), 3)
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.COUNTRY_NAME)[0].value,
-            'US')
+            'US',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.ORGANIZATION_NAME)[0].value,
-            'Google Trust Services')
+            'Google Trust Services',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.COMMON_NAME)[0].value,
-            'Google Internet Authority G3')
+            'Google Internet Authority G3',
+        )
 
         #######################################################################
         # subject
@@ -100,19 +108,24 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(len(x509_cert.subject.rdns), 5)
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.COUNTRY_NAME)[0].value,
-            'US')
+            'US',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.STATE_OR_PROVINCE_NAME)[0].value,
-            'California')
+            'California',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.LOCALITY_NAME)[0].value,
-            'Mountain View')
+            'Mountain View',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.ORGANIZATION_NAME)[0].value,
-            'Google LLC')
+            'Google LLC',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.COMMON_NAME)[0].value,
-            '*.google.com')
+            '*.google.com',
+        )
 
         #######################################################################
         # extensions
@@ -123,14 +136,16 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         # BASIC_CONSTRAINTS
         basic_constraints_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.BasicConstraints)
+            cryptography.x509.extensions.BasicConstraints
+        )
         self.assertEqual(basic_constraints_ext.critical, True)
         self.assertEqual(basic_constraints_ext.value.ca, False)
         self.assertIs(basic_constraints_ext.value.path_length, None)
 
         # KEY_USAGE
         key_usage_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.KeyUsage)
+            cryptography.x509.extensions.KeyUsage
+        )
         self.assertEqual(key_usage_ext.critical, True)
         self.assertEqual(key_usage_ext.value.content_commitment, False)
         self.assertEqual(key_usage_ext.value.crl_sign, False)
@@ -142,53 +157,64 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         # EXTENDED_KEY_USAGE
         extended_key_usage_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.ExtendedKeyUsage)
+            cryptography.x509.extensions.ExtendedKeyUsage
+        )
         self.assertEqual(extended_key_usage_ext.critical, False)
         self.assertEqual(
             extended_key_usage_ext.value._usages,
-            [oid.ExtendedKeyUsageOID.SERVER_AUTH])
+            [oid.ExtendedKeyUsageOID.SERVER_AUTH],
+        )
 
         # SUBJECT_ALTERNATIVE_NAME
         subject_alt_name_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.SubjectAlternativeName)
+            cryptography.x509.extensions.SubjectAlternativeName
+        )
         self.assertEqual(subject_alt_name_ext.critical, False)
         self.assertEqual(len(subject_alt_name_ext.value._general_names._general_names), 67)
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].value,
-            '*.google.com')
+            '*.google.com',
+        )
 
         # AUTHORITY_INFORMATION_ACCESS
         authority_information_access_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.AuthorityInformationAccess)
+            cryptography.x509.extensions.AuthorityInformationAccess
+        )
         self.assertEqual(authority_information_access_ext.critical, False)
         self.assertEqual(len(authority_information_access_ext.value._descriptions), 2)
 
         # SUBJECT_KEY_IDENTIFIER
         subject_key_identifier_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.SubjectKeyIdentifier)
+            cryptography.x509.extensions.SubjectKeyIdentifier
+        )
         self.assertEqual(subject_key_identifier_ext.critical, False)
         self.assertEqual(
             subject_key_identifier_ext.value.digest,
-            b'\xcf\x02\xda\x1aM\x80\x92\xff\x04E\xff\xcb7\x81\xe3O\x1d\x85\xb6\xb6')
+            b'\xcf\x02\xda\x1aM\x80\x92\xff\x04E\xff\xcb7\x81\xe3O\x1d\x85\xb6\xb6',
+        )
 
         # AUTHORITY_KEY_IDENTIFIER
         authority_key_identifier_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.AuthorityKeyIdentifier)
+            cryptography.x509.extensions.AuthorityKeyIdentifier
+        )
         self.assertEqual(authority_key_identifier_ext.critical, False)
         self.assertIs(authority_key_identifier_ext.value.authority_cert_issuer, None)
         self.assertIs(authority_key_identifier_ext.value.authority_cert_serial_number, None)
         self.assertEqual(
             authority_key_identifier_ext.value.key_identifier,
-            b'w\xc2\xb8P\x9agvv\xb1-\xc2\x86\xd0\x83\xa0~\xa6~\xbaK'
+            b'w\xc2\xb8P\x9agvv\xb1-\xc2\x86\xd0\x83\xa0~\xa6~\xbaK',
         )
 
         # CERTIFICATE_POLICIES
         certificate_policies_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.CertificatePolicies)
+            cryptography.x509.extensions.CertificatePolicies
+        )
         self.assertEqual(certificate_policies_ext.critical, False)
         self.assertSetEqual(
-            {policy_info.policy_identifier.dotted_string for policy_info in
-             certificate_policies_ext.value._policies},
+            {
+                policy_info.policy_identifier.dotted_string
+                for policy_info in certificate_policies_ext.value._policies
+            },
             {
                 # 'Google Trust Services'
                 #   https://github.com/zmap/constants/blob/0816f6f/x509/certificate_policies.csv#L34
@@ -196,24 +222,27 @@ class LoadPemX509CertTest(unittest.TestCase):
                 # 'CA/B Forum Organization Validated'
                 #   https://github.com/zmap/constants/blob/0816f6f/x509/certificate_policies.csv#L193
                 '2.23.140.1.2.2',
-            }
+            },
         )
 
         # CRL_DISTRIBUTION_POINTS
         crl_distribution_points_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.CRLDistributionPoints)
+            cryptography.x509.extensions.CRLDistributionPoints
+        )
         self.assertEqual(crl_distribution_points_ext.critical, False)
         self.assertEqual(len(crl_distribution_points_ext.value._distribution_points), 1)
         self.assertEqual(
             crl_distribution_points_ext.value._distribution_points[0].full_name[0].value,
-            'http://crl.pki.goog/GTSGIAG3.crl')
+            'http://crl.pki.goog/GTSGIAG3.crl',
+        )
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].crl_issuer, None)
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].reasons, None)
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].relative_name, None)
 
     def test_load_der_x509_cert_ok_cert_real_dte_1(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der')
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der'
+        )
 
         x509_cert = load_der_x509_cert(cert_der_bytes)
 
@@ -225,23 +254,29 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         self.assertEqual(
             x509_cert.version,
-            cryptography.x509.Version.v3)
+            cryptography.x509.Version.v3,
+        )
         self.assertIsInstance(
             x509_cert.signature_hash_algorithm,
-            cryptography.hazmat.primitives.hashes.SHA1)
+            cryptography.hazmat.primitives.hashes.SHA1,
+        )
         self.assertEqual(
             x509_cert.signature_algorithm_oid,
-            oid.SignatureAlgorithmOID.RSA_WITH_SHA1)
+            oid.SignatureAlgorithmOID.RSA_WITH_SHA1,
+        )
 
         self.assertEqual(
             x509_cert.serial_number,
-            232680798042554446173213)
+            232680798042554446173213,
+        )
         self.assertEqual(
             x509_cert.not_valid_after,
-            datetime(2020, 9, 3, 21, 11, 12))
+            datetime(2020, 9, 3, 21, 11, 12),
+        )
         self.assertEqual(
             x509_cert.not_valid_before,
-            datetime(2017, 9, 4, 21, 11, 12))
+            datetime(2017, 9, 4, 21, 11, 12),
+        )
 
         #######################################################################
         # issuer
@@ -250,25 +285,32 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(len(x509_cert.issuer.rdns), 7)
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.COUNTRY_NAME)[0].value,
-            'CL')
+            'CL',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.STATE_OR_PROVINCE_NAME)[0].value,
-            'Region Metropolitana')
+            'Region Metropolitana',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.LOCALITY_NAME)[0].value,
-            'Santiago')
+            'Santiago',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.ORGANIZATION_NAME)[0].value,
-            'E-CERTCHILE')
+            'E-CERTCHILE',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.ORGANIZATIONAL_UNIT_NAME)[0].value,
-            'Autoridad Certificadora')
+            'Autoridad Certificadora',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.COMMON_NAME)[0].value,
-            'E-CERTCHILE CA FIRMA ELECTRONICA SIMPLE')
+            'E-CERTCHILE CA FIRMA ELECTRONICA SIMPLE',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.EMAIL_ADDRESS)[0].value,
-            'sclientes@e-certchile.cl')
+            'sclientes@e-certchile.cl',
+        )
 
         #######################################################################
         # subject
@@ -277,25 +319,32 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(len(x509_cert.subject.rdns), 7)
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.COUNTRY_NAME)[0].value,
-            'CL')
+            'CL',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.STATE_OR_PROVINCE_NAME)[0].value,
-            'VALPARAISO ')
+            'VALPARAISO ',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.LOCALITY_NAME)[0].value,
-            'Quillota')
+            'Quillota',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.ORGANIZATION_NAME)[0].value,
-            'Servicios Bonilla y Lopez y Cia. Ltda.')
+            'Servicios Bonilla y Lopez y Cia. Ltda.',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.ORGANIZATIONAL_UNIT_NAME)[0].value,
-            'Ingeniería y Construcción')
+            'Ingeniería y Construcción',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.COMMON_NAME)[0].value,
-            'Ramon humberto Lopez  Jara')
+            'Ramon humberto Lopez  Jara',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.EMAIL_ADDRESS)[0].value,
-            'enaconltda@gmail.com')
+            'enaconltda@gmail.com',
+        )
 
         #######################################################################
         # extensions
@@ -306,7 +355,8 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         # KEY_USAGE
         key_usage_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.KeyUsage)
+            cryptography.x509.extensions.KeyUsage
+        )
         self.assertEqual(key_usage_ext.critical, False)
         self.assertEqual(key_usage_ext.value.content_commitment, True)
         self.assertEqual(key_usage_ext.value.crl_sign, False)
@@ -318,61 +368,75 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         # ISSUER_ALTERNATIVE_NAME
         issuer_alt_name_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.IssuerAlternativeName)
+            cryptography.x509.extensions.IssuerAlternativeName
+        )
         self.assertEqual(issuer_alt_name_ext.critical, False)
         self.assertEqual(len(issuer_alt_name_ext.value._general_names._general_names), 1)
         self.assertEqual(
             issuer_alt_name_ext.value._general_names._general_names[0].type_id,
-            _SII_CERT_CERTIFICADORA_EMISORA_RUT_OID)
+            _SII_CERT_CERTIFICADORA_EMISORA_RUT_OID,
+        )
         self.assertEqual(
             issuer_alt_name_ext.value._general_names._general_names[0].value,
-            b'\x16\n96928180-5')
+            b'\x16\n96928180-5',
+        )
 
         # SUBJECT_ALTERNATIVE_NAME
         subject_alt_name_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.SubjectAlternativeName)
+            cryptography.x509.extensions.SubjectAlternativeName
+        )
         self.assertEqual(subject_alt_name_ext.critical, False)
         self.assertEqual(len(subject_alt_name_ext.value._general_names._general_names), 1)
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].type_id,
-            SII_CERT_TITULAR_RUT_OID)
+            SII_CERT_TITULAR_RUT_OID,
+        )
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].value,
-            b'\x16\n13185095-6')
+            b'\x16\n13185095-6',
+        )
 
         # AUTHORITY_INFORMATION_ACCESS
         authority_information_access_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.AuthorityInformationAccess)
+            cryptography.x509.extensions.AuthorityInformationAccess
+        )
         self.assertEqual(authority_information_access_ext.critical, False)
         self.assertEqual(len(authority_information_access_ext.value._descriptions), 1)
         self.assertEqual(
             authority_information_access_ext.value._descriptions[0].access_location.value,
-            'http://ocsp.ecertchile.cl/ocsp')
+            'http://ocsp.ecertchile.cl/ocsp',
+        )
         self.assertEqual(
             authority_information_access_ext.value._descriptions[0].access_method,
-            oid.AuthorityInformationAccessOID.OCSP)
+            oid.AuthorityInformationAccessOID.OCSP,
+        )
 
         # SUBJECT_KEY_IDENTIFIER
         subject_key_identifier_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.SubjectKeyIdentifier)
+            cryptography.x509.extensions.SubjectKeyIdentifier
+        )
         self.assertEqual(subject_key_identifier_ext.critical, False)
         self.assertEqual(
             subject_key_identifier_ext.value.digest,
-            a2b_hex('D5:D5:47:84:5D:14:55:EE:D1:5C:8C:F8:72:39:77:FD:57:B0:FA:AA'.replace(':', '')))
+            a2b_hex('D5:D5:47:84:5D:14:55:EE:D1:5C:8C:F8:72:39:77:FD:57:B0:FA:AA'.replace(':', '')),
+        )
 
         # AUTHORITY_KEY_IDENTIFIER
         authority_key_identifier_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.AuthorityKeyIdentifier)
+            cryptography.x509.extensions.AuthorityKeyIdentifier
+        )
         self.assertEqual(authority_key_identifier_ext.critical, False)
         self.assertIs(authority_key_identifier_ext.value.authority_cert_issuer, None)
         self.assertIs(authority_key_identifier_ext.value.authority_cert_serial_number, None)
         self.assertEqual(
             authority_key_identifier_ext.value.key_identifier,
-            a2b_hex('78:E1:3E:9F:D2:12:B3:7A:3C:8D:CD:30:0E:53:B3:43:29:07:B3:55'.replace(':', '')))
+            a2b_hex('78:E1:3E:9F:D2:12:B3:7A:3C:8D:CD:30:0E:53:B3:43:29:07:B3:55'.replace(':', '')),
+        )
 
         # CERTIFICATE_POLICIES
         certificate_policies_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.CertificatePolicies)
+            cryptography.x509.extensions.CertificatePolicies
+        )
         self.assertEqual(certificate_policies_ext.critical, False)
         self.assertEqual(len(certificate_policies_ext.value._policies), 1)
         # note: parent of OID '1.3.6.1.4.1.8658.5' is '1.3.6.1.4.1.42346'
@@ -381,26 +445,34 @@ class LoadPemX509CertTest(unittest.TestCase):
         #   http://oid-info.com/get/1.3.6.1.4.1.8658
         self.assertEqual(
             certificate_policies_ext.value._policies[0].policy_identifier,
-            oid.ObjectIdentifier("1.3.6.1.4.1.8658.5"))
+            oid.ObjectIdentifier("1.3.6.1.4.1.8658.5"),
+        )
         self.assertEqual(len(certificate_policies_ext.value._policies[0].policy_qualifiers), 2)
         self.assertEqual(
             certificate_policies_ext.value._policies[0].policy_qualifiers[0],
-            "http://www.e-certchile.cl/CPS.htm")
+            "http://www.e-certchile.cl/CPS.htm",
+        )
         self.assertEqual(
             certificate_policies_ext.value._policies[0].policy_qualifiers[1],
             cryptography.x509.extensions.UserNotice(
                 notice_reference=None,
-                explicit_text="Certificado Firma Simple. Ha sido validado en forma presencial, "
-                              "quedando habilitado el Certificado para uso tributario"))
+                explicit_text=(
+                    "Certificado Firma Simple. Ha sido validado en forma presencial, "
+                    "quedando habilitado el Certificado para uso tributario"
+                ),
+            ),
+        )
 
         # CRL_DISTRIBUTION_POINTS
         crl_distribution_points_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.CRLDistributionPoints)
+            cryptography.x509.extensions.CRLDistributionPoints
+        )
         self.assertEqual(crl_distribution_points_ext.critical, False)
         self.assertEqual(len(crl_distribution_points_ext.value._distribution_points), 1)
         self.assertEqual(
             crl_distribution_points_ext.value._distribution_points[0].full_name[0].value,
-            'http://crl.e-certchile.cl/ecertchilecaFES.crl')
+            'http://crl.e-certchile.cl/ecertchilecaFES.crl',
+        )
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].crl_issuer, None)
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].reasons, None)
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].relative_name, None)
@@ -420,7 +492,8 @@ class LoadPemX509CertTest(unittest.TestCase):
 
     def test_load_der_x509_cert_ok_cert_real_dte_3(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der')
+            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der'
+        )
 
         x509_cert = load_der_x509_cert(cert_der_bytes)
 
@@ -432,23 +505,29 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         self.assertEqual(
             x509_cert.version,
-            cryptography.x509.Version.v3)
+            cryptography.x509.Version.v3,
+        )
         self.assertIsInstance(
             x509_cert.signature_hash_algorithm,
-            cryptography.hazmat.primitives.hashes.SHA256)
+            cryptography.hazmat.primitives.hashes.SHA256,
+        )
         self.assertEqual(
             x509_cert.signature_algorithm_oid,
-            oid.SignatureAlgorithmOID.RSA_WITH_SHA256)
+            oid.SignatureAlgorithmOID.RSA_WITH_SHA256,
+        )
 
         self.assertEqual(
             x509_cert.serial_number,
-            6504844188525727926)
+            6504844188525727926,
+        )
         self.assertEqual(
             x509_cert.not_valid_after,
-            datetime(2019, 9, 6, 21, 13, 0))
+            datetime(2019, 9, 6, 21, 13, 0),
+        )
         self.assertEqual(
             x509_cert.not_valid_before,
-            datetime(2018, 9, 6, 21, 13, 0))
+            datetime(2018, 9, 6, 21, 13, 0),
+        )
 
         #######################################################################
         # issuer
@@ -457,19 +536,24 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(len(x509_cert.issuer.rdns), 5)
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.COUNTRY_NAME)[0].value,
-            'CL')
+            'CL',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.ORGANIZATION_NAME)[0].value,
-            'E-Sign S.A.')
+            'E-Sign S.A.',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.ORGANIZATIONAL_UNIT_NAME)[0].value,
-            'Terms of use at www.esign-la.com/acuerdoterceros')
+            'Terms of use at www.esign-la.com/acuerdoterceros',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.COMMON_NAME)[0].value,
-            'E-Sign Class 2 Firma Tributaria CA')
+            'E-Sign Class 2 Firma Tributaria CA',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.EMAIL_ADDRESS)[0].value,
-            'e-sign@esign-la.com')
+            'e-sign@esign-la.com',
+        )
 
         #######################################################################
         # subject
@@ -478,19 +562,24 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(len(x509_cert.subject.rdns), 5)
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.COUNTRY_NAME)[0].value,
-            'CL')
+            'CL',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.ORGANIZATION_NAME)[0].value,
-            'E-Sign S.A.')
+            'E-Sign S.A.',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.ORGANIZATIONAL_UNIT_NAME)[0].value,
-            'Terms of use at www.esign-la.com/acuerdoterceros')
+            'Terms of use at www.esign-la.com/acuerdoterceros',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.COMMON_NAME)[0].value,
-            'Jorge Enrique Cabello Ortiz')
+            'Jorge Enrique Cabello Ortiz',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.EMAIL_ADDRESS)[0].value,
-            'jcabello@nic.cl')
+            'jcabello@nic.cl',
+        )
 
         #######################################################################
         # extensions
@@ -501,7 +590,8 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         # KEY_USAGE
         key_usage_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.KeyUsage)
+            cryptography.x509.extensions.KeyUsage
+        )
         self.assertEqual(key_usage_ext.critical, True)
         self.assertEqual(key_usage_ext.value.content_commitment, False)
         self.assertEqual(key_usage_ext.value.crl_sign, False)
@@ -513,67 +603,83 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         # ISSUER_ALTERNATIVE_NAME
         issuer_alt_name_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.IssuerAlternativeName)
+            cryptography.x509.extensions.IssuerAlternativeName
+        )
         self.assertEqual(issuer_alt_name_ext.critical, False)
         self.assertEqual(len(issuer_alt_name_ext.value._general_names._general_names), 1)
         self.assertEqual(
             issuer_alt_name_ext.value._general_names._general_names[0].type_id,
-            _SII_CERT_CERTIFICADORA_EMISORA_RUT_OID)
+            _SII_CERT_CERTIFICADORA_EMISORA_RUT_OID,
+        )
         self.assertEqual(
             issuer_alt_name_ext.value._general_names._general_names[0].value,
-            b'\x16\n99551740-K')
+            b'\x16\n99551740-K',
+        )
 
         # SUBJECT_ALTERNATIVE_NAME
         subject_alt_name_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.SubjectAlternativeName)
+            cryptography.x509.extensions.SubjectAlternativeName
+        )
         self.assertEqual(subject_alt_name_ext.critical, False)
         self.assertEqual(len(subject_alt_name_ext.value._general_names._general_names), 1)
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].type_id,
-            SII_CERT_TITULAR_RUT_OID)
+            SII_CERT_TITULAR_RUT_OID,
+        )
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].value,
-            b'\x16\t8480437-1')
+            b'\x16\t8480437-1',
+        )
 
         # AUTHORITY_INFORMATION_ACCESS
         authority_information_access_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.AuthorityInformationAccess)
+            cryptography.x509.extensions.AuthorityInformationAccess
+        )
         self.assertEqual(authority_information_access_ext.critical, False)
         self.assertEqual(len(authority_information_access_ext.value._descriptions), 2)
         self.assertEqual(
             authority_information_access_ext.value._descriptions[0].access_location.value,
-            'http://pki.esign-la.com/cacerts/pkiClass2FirmaTributariaCA.crt')
+            'http://pki.esign-la.com/cacerts/pkiClass2FirmaTributariaCA.crt',
+        )
         self.assertEqual(
             authority_information_access_ext.value._descriptions[0].access_method,
-            oid.AuthorityInformationAccessOID.CA_ISSUERS)
+            oid.AuthorityInformationAccessOID.CA_ISSUERS,
+        )
         self.assertEqual(
             authority_information_access_ext.value._descriptions[1].access_location.value,
-            'http://ocsp.esign-la.com')
+            'http://ocsp.esign-la.com',
+        )
         self.assertEqual(
             authority_information_access_ext.value._descriptions[1].access_method,
-            oid.AuthorityInformationAccessOID.OCSP)
+            oid.AuthorityInformationAccessOID.OCSP,
+        )
 
         # SUBJECT_KEY_IDENTIFIER
         subject_key_identifier_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.SubjectKeyIdentifier)
+            cryptography.x509.extensions.SubjectKeyIdentifier
+        )
         self.assertEqual(subject_key_identifier_ext.critical, False)
         self.assertEqual(
             subject_key_identifier_ext.value.digest,
-            a2b_hex('E9:FE:44:7A:91:0A:F0:40:F2:9D:86:B4:E2:4C:F6:FA:1D:07:5B:C7'.replace(':', '')))
+            a2b_hex('E9:FE:44:7A:91:0A:F0:40:F2:9D:86:B4:E2:4C:F6:FA:1D:07:5B:C7'.replace(':', '')),
+        )
 
         # AUTHORITY_KEY_IDENTIFIER
         authority_key_identifier_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.AuthorityKeyIdentifier)
+            cryptography.x509.extensions.AuthorityKeyIdentifier
+        )
         self.assertEqual(authority_key_identifier_ext.critical, False)
         self.assertIs(authority_key_identifier_ext.value.authority_cert_issuer, None)
         self.assertIs(authority_key_identifier_ext.value.authority_cert_serial_number, None)
         self.assertEqual(
             authority_key_identifier_ext.value.key_identifier,
-            a2b_hex('F9:4A:FA:C2:C7:6E:C2:E7:12:9C:57:45:35:84:1A:6D:28:E9:4A:A4'.replace(':', '')))
+            a2b_hex('F9:4A:FA:C2:C7:6E:C2:E7:12:9C:57:45:35:84:1A:6D:28:E9:4A:A4'.replace(':', '')),
+        )
 
         # CERTIFICATE_POLICIES
         certificate_policies_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.CertificatePolicies)
+            cryptography.x509.extensions.CertificatePolicies
+        )
         self.assertEqual(certificate_policies_ext.critical, False)
         self.assertEqual(len(certificate_policies_ext.value._policies), 1)
         # note: parent of OID '1.3.6.1.4.1.42346.1.4.1.2' is '1.3.6.1.4.1.42346' ("E-SIGN S.A.").
@@ -581,32 +687,37 @@ class LoadPemX509CertTest(unittest.TestCase):
         #   http://oid-info.com/get/1.3.6.1.4.1.42346
         self.assertEqual(
             certificate_policies_ext.value._policies[0].policy_identifier,
-            oid.ObjectIdentifier("1.3.6.1.4.1.42346.1.4.1.2"))
+            oid.ObjectIdentifier("1.3.6.1.4.1.42346.1.4.1.2"),
+        )
         self.assertEqual(len(certificate_policies_ext.value._policies[0].policy_qualifiers), 2)
         self.assertEqual(
             certificate_policies_ext.value._policies[0].policy_qualifiers[0],
             cryptography.x509.extensions.UserNotice(
                 notice_reference=None,
-                explicit_text='Certificado para uso Tributario, Comercio, Pagos y Otros'))
+                explicit_text='Certificado para uso Tributario, Comercio, Pagos y Otros',
+            ),
+        )
         self.assertEqual(
             certificate_policies_ext.value._policies[0].policy_qualifiers[1],
-            "http://www.esign-la.com/cps")
+            "http://www.esign-la.com/cps",
+        )
 
         # CRL_DISTRIBUTION_POINTS
         crl_distribution_points_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.CRLDistributionPoints)
+            cryptography.x509.extensions.CRLDistributionPoints
+        )
         self.assertEqual(crl_distribution_points_ext.critical, False)
         self.assertEqual(len(crl_distribution_points_ext.value._distribution_points), 1)
         self.assertEqual(
             crl_distribution_points_ext.value._distribution_points[0].full_name[0].value,
-            'http://pki.esign-la.com/crl/pkiClass2FirmaTributaria/enduser.crl')
+            'http://pki.esign-la.com/crl/pkiClass2FirmaTributaria/enduser.crl',
+        )
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].crl_issuer, None)
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].reasons, None)
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].relative_name, None)
 
     def test_load_der_x509_cert_ok_prueba_sii(self) -> None:
-        cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/prueba-sii-cert.der')
+        cert_der_bytes = utils.read_test_file_bytes('test_data/sii-crypto/prueba-sii-cert.der')
 
         x509_cert = load_der_x509_cert(cert_der_bytes)
 
@@ -618,23 +729,29 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         self.assertEqual(
             x509_cert.version,
-            cryptography.x509.Version.v3)
+            cryptography.x509.Version.v3,
+        )
         self.assertIsInstance(
             x509_cert.signature_hash_algorithm,
-            cryptography.hazmat.primitives.hashes.MD5)
+            cryptography.hazmat.primitives.hashes.MD5,
+        )
         self.assertEqual(
             x509_cert.signature_algorithm_oid,
-            oid.SignatureAlgorithmOID.RSA_WITH_MD5)
+            oid.SignatureAlgorithmOID.RSA_WITH_MD5,
+        )
 
         self.assertEqual(
             x509_cert.serial_number,
-            131466)
+            131466,
+        )
         self.assertEqual(
             x509_cert.not_valid_after,
-            datetime(2003, 10, 2, 0, 0))
+            datetime(2003, 10, 2, 0, 0),
+        )
         self.assertEqual(
             x509_cert.not_valid_before,
-            datetime(2002, 10, 2, 19, 11, 59))
+            datetime(2002, 10, 2, 19, 11, 59),
+        )
 
         #######################################################################
         # issuer
@@ -643,22 +760,28 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(len(x509_cert.issuer.rdns), 6)
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.COUNTRY_NAME)[0].value,
-            'CL')
+            'CL',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.STATE_OR_PROVINCE_NAME)[0].value,
-            'Region Metropolitana')
+            'Region Metropolitana',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.LOCALITY_NAME)[0].value,
-            'Santiago')
+            'Santiago',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.ORGANIZATION_NAME)[0].value,
-            'E-CERTCHILE')
+            'E-CERTCHILE',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.ORGANIZATIONAL_UNIT_NAME)[0].value,
-            'Empresa Nacional de Certificacion Electronica')
+            'Empresa Nacional de Certificacion Electronica',
+        )
         self.assertEqual(
             x509_cert.issuer.get_attributes_for_oid(oid.NameOID.COMMON_NAME)[0].value,
-            'E-Certchile CA Intermedia')
+            'E-Certchile CA Intermedia',
+        )
 
         #######################################################################
         # subject
@@ -667,25 +790,32 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(len(x509_cert.subject.rdns), 7)
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.COUNTRY_NAME)[0].value,
-            'CL')
+            'CL',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.STATE_OR_PROVINCE_NAME)[0].value,
-            'Region Metropolitana')
+            'Region Metropolitana',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.LOCALITY_NAME)[0].value,
-            'Santiago')
+            'Santiago',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.ORGANIZATION_NAME)[0].value,
-            'Servicio de Impuestos Internos')
+            'Servicio de Impuestos Internos',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.ORGANIZATIONAL_UNIT_NAME)[0].value,
-            'Servicio de Impuestos Internos')
+            'Servicio de Impuestos Internos',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.COMMON_NAME)[0].value,
-            'Wilibaldo Gonzalez Cabrera')
+            'Wilibaldo Gonzalez Cabrera',
+        )
         self.assertEqual(
             x509_cert.subject.get_attributes_for_oid(oid.NameOID.EMAIL_ADDRESS)[0].value,
-            'wgonzalez@sii.cl')
+            'wgonzalez@sii.cl',
+        )
 
         #######################################################################
         # extensions
@@ -696,7 +826,8 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         # KEY_USAGE
         key_usage_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.KeyUsage)
+            cryptography.x509.extensions.KeyUsage
+        )
         self.assertEqual(key_usage_ext.critical, False)
         self.assertEqual(key_usage_ext.value.content_commitment, True)
         self.assertEqual(key_usage_ext.value.crl_sign, False)
@@ -708,33 +839,40 @@ class LoadPemX509CertTest(unittest.TestCase):
 
         # ISSUER_ALTERNATIVE_NAME
         issuer_alt_name_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.IssuerAlternativeName)
+            cryptography.x509.extensions.IssuerAlternativeName
+        )
         self.assertEqual(issuer_alt_name_ext.critical, False)
         self.assertEqual(len(issuer_alt_name_ext.value._general_names._general_names), 1)
         self.assertEqual(
             issuer_alt_name_ext.value._general_names._general_names[0].type_id,
-            _SII_CERT_CERTIFICADORA_EMISORA_RUT_OID)
+            _SII_CERT_CERTIFICADORA_EMISORA_RUT_OID,
+        )
         self.assertEqual(
             issuer_alt_name_ext.value._general_names._general_names[0].value,
-            b'\x16\n96928180-5')
+            b'\x16\n96928180-5',
+        )
 
         # SUBJECT_ALTERNATIVE_NAME
         subject_alt_name_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.SubjectAlternativeName)
+            cryptography.x509.extensions.SubjectAlternativeName
+        )
         self.assertEqual(subject_alt_name_ext.critical, False)
         self.assertEqual(len(subject_alt_name_ext.value._general_names._general_names), 1)
         # TODO: find out where did OID '1.3.6.1.4.1.8658.1' come from.
         #   Shouldn't it have been equal to 'cl_sii.rut.constants.SII_CERT_TITULAR_RUT_OID'?
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].type_id,
-            oid.ObjectIdentifier("1.3.6.1.4.1.8658.1"))
+            oid.ObjectIdentifier("1.3.6.1.4.1.8658.1"),
+        )
         self.assertEqual(
             subject_alt_name_ext.value._general_names._general_names[0].value,
-            b'\x16\n07880442-4')
+            b'\x16\n07880442-4',
+        )
 
         # CERTIFICATE_POLICIES
         certificate_policies_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.CertificatePolicies)
+            cryptography.x509.extensions.CertificatePolicies
+        )
         self.assertEqual(certificate_policies_ext.critical, False)
         self.assertEqual(len(certificate_policies_ext.value._policies), 1)
         # TODO: find out where did OID '1.3.6.1.4.1.8658.0' come from.
@@ -742,24 +880,29 @@ class LoadPemX509CertTest(unittest.TestCase):
         #   https://oidref.com/1.3.6.1.4.1.8658
         self.assertEqual(
             certificate_policies_ext.value._policies[0].policy_identifier,
-            oid.ObjectIdentifier("1.3.6.1.4.1.8658.0"))
+            oid.ObjectIdentifier("1.3.6.1.4.1.8658.0"),
+        )
         self.assertEqual(len(certificate_policies_ext.value._policies[0].policy_qualifiers), 2)
         self.assertEqual(
             certificate_policies_ext.value._policies[0].policy_qualifiers[0],
-            "http://www.e-certchile.cl/politica/cps.htm")
+            "http://www.e-certchile.cl/politica/cps.htm",
+        )
         self.assertEqual(
             certificate_policies_ext.value._policies[0].policy_qualifiers[1].explicit_text,
             "El titular ha sido validado en forma presencial, quedando habilitado el Certificado "
-            "para uso tributario, pagos, comercio u otros")
+            "para uso tributario, pagos, comercio u otros",
+        )
 
         # CRL_DISTRIBUTION_POINTS
         crl_distribution_points_ext = cert_extensions.get_extension_for_class(
-            cryptography.x509.extensions.CRLDistributionPoints)
+            cryptography.x509.extensions.CRLDistributionPoints
+        )
         self.assertEqual(crl_distribution_points_ext.critical, False)
         self.assertEqual(len(crl_distribution_points_ext.value._distribution_points), 1)
         self.assertEqual(
             crl_distribution_points_ext.value._distribution_points[0].full_name[0].value,
-            'http://crl.e-certchile.cl/EcertchileCAI.crl')
+            'http://crl.e-certchile.cl/EcertchileCAI.crl',
+        )
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].crl_issuer, None)
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].reasons, None)
         self.assertIs(crl_distribution_points_ext.value._distribution_points[0].relative_name, None)
@@ -767,20 +910,20 @@ class LoadPemX509CertTest(unittest.TestCase):
     def test_load_der_x509_cert_fail_type_error(self) -> None:
         with self.assertRaises(TypeError) as cm:
             load_der_x509_cert(1)
-        self.assertEqual(cm.exception.args, ("Value must be bytes.", ))
+        self.assertEqual(cm.exception.args, ("Value must be bytes.",))
 
     def test_load_der_x509_cert_fail_value_error(self) -> None:
         with self.assertRaises(ValueError) as cm:
             load_der_x509_cert(b'hello')
-        self.assertEqual(
-            cm.exception.args,
-            ("Unable to load certificate", ))
+        self.assertEqual(cm.exception.args, ("Unable to load certificate",))
 
     def test_load_pem_x509_cert_ok(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/crypto/wildcard-google-com-cert.der')
+            'test_data/crypto/wildcard-google-com-cert.der',
+        )
         cert_pem_bytes = utils.read_test_file_bytes(
-            'test_data/crypto/wildcard-google-com-cert.pem')
+            'test_data/crypto/wildcard-google-com-cert.pem',
+        )
 
         x509_cert_from_der = load_der_x509_cert(cert_der_bytes)
         x509_cert_from_pem = load_pem_x509_cert(cert_pem_bytes)
@@ -790,9 +933,11 @@ class LoadPemX509CertTest(unittest.TestCase):
 
     def test_load_pem_x509_cert_ok_cert_real_dte_1(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der')
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der'
+        )
         cert_pem_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.pem')
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.pem'
+        )
 
         x509_cert_from_der = load_der_x509_cert(cert_der_bytes)
         x509_cert_from_pem = load_pem_x509_cert(cert_pem_bytes)
@@ -802,9 +947,11 @@ class LoadPemX509CertTest(unittest.TestCase):
 
     def test_load_pem_x509_cert_ok_cert_real_dte_3(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der')
+            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der'
+        )
         cert_pem_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.pem')
+            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.pem'
+        )
 
         x509_cert_from_der = load_der_x509_cert(cert_der_bytes)
         x509_cert_from_pem = load_pem_x509_cert(cert_pem_bytes)
@@ -814,9 +961,11 @@ class LoadPemX509CertTest(unittest.TestCase):
 
     def test_load_pem_x509_cert_ok_prueba_sii(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/prueba-sii-cert.der')
+            'test_data/sii-crypto/prueba-sii-cert.der',
+        )
         cert_pem_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/prueba-sii-cert.pem')
+            'test_data/sii-crypto/prueba-sii-cert.pem',
+        )
 
         x509_cert_from_der = load_der_x509_cert(cert_der_bytes)
         x509_cert_from_pem = load_pem_x509_cert(cert_pem_bytes)
@@ -826,14 +975,16 @@ class LoadPemX509CertTest(unittest.TestCase):
 
     def test_load_pem_x509_cert_ok_str_ascii(self) -> None:
         cert_pem_str_ascii = utils.read_test_file_str_ascii(
-            'test_data/crypto/wildcard-google-com-cert.pem')
+            'test_data/crypto/wildcard-google-com-cert.pem'
+        )
 
         x509_cert = load_pem_x509_cert(cert_pem_str_ascii)
         self.assertIsInstance(x509_cert, X509Cert)
 
     def test_load_pem_x509_cert_ok_str_utf8(self) -> None:
         cert_pem_str_utf8 = utils.read_test_file_str_utf8(
-            'test_data/crypto/wildcard-google-com-cert.pem')
+            'test_data/crypto/wildcard-google-com-cert.pem'
+        )
 
         x509_cert = load_pem_x509_cert(cert_pem_str_utf8)
         self.assertIsInstance(x509_cert, X509Cert)
@@ -841,74 +992,89 @@ class LoadPemX509CertTest(unittest.TestCase):
     def test_load_pem_x509_cert_fail_type_error(self) -> None:
         with self.assertRaises(TypeError) as cm:
             load_pem_x509_cert(1)
-        self.assertEqual(cm.exception.args, ("Value must be str or bytes.", ))
+        self.assertEqual(cm.exception.args, ("Value must be str or bytes.",))
 
     def test_load_pem_x509_cert_fail_value_error(self) -> None:
         with self.assertRaises(ValueError) as cm:
             load_pem_x509_cert('hello')
         self.assertEqual(
             cm.exception.args,
-            ("Unable to load certificate. See "
-             "https://cryptography.io/en/latest/faq.html#why-can-t-i-import-my-pem-file "
-             "for more details.", ))
+            (
+                "Unable to load certificate. See "
+                "https://cryptography.io/en/latest/faq.html#why-can-t-i-import-my-pem-file "
+                "for more details.",
+            ),
+        )
 
     def test_x509_cert_der_to_pem_pem_to_der_ok_1(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/crypto/wildcard-google-com-cert.der')
+            'test_data/crypto/wildcard-google-com-cert.der',
+        )
         cert_pem_bytes = utils.read_test_file_bytes(
-            'test_data/crypto/wildcard-google-com-cert.pem')
+            'test_data/crypto/wildcard-google-com-cert.pem',
+        )
 
         # note: we test the function with a double call because the input PEM data
         #   may have different line lengths and different line separators.
         self.assertEqual(
             x509_cert_pem_to_der(x509_cert_der_to_pem(cert_der_bytes)),
-            x509_cert_pem_to_der(cert_pem_bytes))
+            x509_cert_pem_to_der(cert_pem_bytes),
+        )
 
     def test_x509_cert_der_to_pem_pem_to_der_ok_cert_real_dte_1(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der')
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der'
+        )
         cert_pem_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.pem')
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.pem'
+        )
 
         # note: we test the function with a double call because the input PEM data
         #   may have different line lengths and different line separators.
         self.assertEqual(
             x509_cert_pem_to_der(x509_cert_der_to_pem(cert_der_bytes)),
-            x509_cert_pem_to_der(cert_pem_bytes))
+            x509_cert_pem_to_der(cert_pem_bytes),
+        )
 
     def test_x509_cert_der_to_pem_pem_to_der_ok_cert_real_dte_3(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der')
+            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.der'
+        )
         cert_pem_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.pem')
+            'test_data/sii-crypto/DTE--60910000-1--33--2336600-cert.pem'
+        )
 
         # note: we test the function with a double call because the input PEM data
         #   may have different line lengths and different line separators.
         self.assertEqual(
             x509_cert_pem_to_der(x509_cert_der_to_pem(cert_der_bytes)),
-            x509_cert_pem_to_der(cert_pem_bytes))
+            x509_cert_pem_to_der(cert_pem_bytes),
+        )
 
     def test_x509_cert_der_to_pem_pem_to_der_ok_prueba_sii(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/prueba-sii-cert.der')
+            'test_data/sii-crypto/prueba-sii-cert.der',
+        )
         cert_pem_bytes = utils.read_test_file_bytes(
-            'test_data/sii-crypto/prueba-sii-cert.pem')
+            'test_data/sii-crypto/prueba-sii-cert.pem',
+        )
 
         # note: we test the function with a double call because the input PEM data
         #   may have different line lengths and different line separators.
         self.assertEqual(
             x509_cert_pem_to_der(x509_cert_der_to_pem(cert_der_bytes)),
-            x509_cert_pem_to_der(cert_pem_bytes))
+            x509_cert_pem_to_der(cert_pem_bytes),
+        )
 
     def test_x509_cert_der_to_pem_type_error(self) -> None:
         with self.assertRaises(TypeError) as cm:
             x509_cert_der_to_pem(1)
-        self.assertEqual(cm.exception.args, ("Value must be bytes.", ))
+        self.assertEqual(cm.exception.args, ("Value must be bytes.",))
 
     def test_x509_cert_pem_to_der_type_error(self) -> None:
         with self.assertRaises(TypeError) as cm:
             x509_cert_pem_to_der(1)
-        self.assertEqual(cm.exception.args, ("Value must be bytes.", ))
+        self.assertEqual(cm.exception.args, ("Value must be bytes.",))
 
     def test_x509_cert_pem_to_der_valuetype_error(self) -> None:
         with self.assertRaises(ValueError) as cm:
@@ -919,7 +1085,8 @@ class LoadPemX509CertTest(unittest.TestCase):
                 "Input is not a valid base64 value.",
                 "Invalid base64-encoded string: number of data characters (5) cannot be 1 more "
                 "than a multiple of 4",
-            ))
+            ),
+        )
 
     def test_add_pem_cert_header_footer(self) -> None:
         # TODO: implement for 'add_pem_cert_header_footer'

--- a/tests/test_libs_csv_utils.py
+++ b/tests/test_libs_csv_utils.py
@@ -4,7 +4,6 @@ from cl_sii.libs.csv_utils import create_csv_dict_reader  # noqa: F401
 
 
 class FunctionsTest(unittest.TestCase):
-
     def test_create_csv_dict_reader(self):
         # TODO: implement for 'create_csv_dict_reader'.
         pass

--- a/tests/test_libs_dataclass_utils.py
+++ b/tests/test_libs_dataclass_utils.py
@@ -34,22 +34,22 @@ class DataclassBWithMixin(DataclassBWithoutMixin, DcDeepCompareMixin):
 
 
 class NotADataclassWithMixin(DcDeepCompareMixin):
-
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
 
 
 class DcDeepCompareTest(unittest.TestCase):
-
     def test__dc_deep_compare_ok(self) -> None:
         value_a_1 = DataclassA(field_1=23)
         value_a_2 = DataclassA(field_1='break typing hint, nobody cares')
 
         value_b_1 = DataclassBWithoutMixin(
-            field_1=-56, field_2=dict(x=True), field_3=('hello', None, True), field_4=value_a_1)
+            field_1=-56, field_2=dict(x=True), field_3=('hello', None, True), field_4=value_a_1
+        )
         value_b_2 = DataclassBWithoutMixin(
-            field_1=-56, field_2=dict(a='b'), field_3=('hello', None, True), field_4=value_a_1)
+            field_1=-56, field_2=dict(a='b'), field_3=('hello', None, True), field_4=value_a_1
+        )
         value_b_3 = dataclasses.replace(value_b_1, field_5='some str')
         value_b_4 = dataclasses.replace(value_b_2, field_5='non-default value')
         value_b_5 = dataclasses.replace(value_b_2, field_4=value_a_2)
@@ -88,60 +88,65 @@ class DcDeepCompareTest(unittest.TestCase):
         self.assertEqual(
             dc_deep_compare(
                 DataclassA(field_1=23),
-                DataclassA(field_1=23)),
-            DcDeepComparison.EQUAL)
+                DataclassA(field_1=23),
+            ),
+            DcDeepComparison.EQUAL,
+        )
         self.assertEqual(
             dc_deep_compare(
                 DataclassA(field_1=23),
-                DataclassA(field_1='break typing hint, nobody cares')),
-            DcDeepComparison.CONFLICTED)
+                DataclassA(field_1='break typing hint, nobody cares'),
+            ),
+            DcDeepComparison.CONFLICTED,
+        )
 
     def test_mixin_ok(self) -> None:
         value_a = DataclassBWithMixin(
-            field_1=-56, field_2=dict(a='b'), field_3=('hello', None, True),
-            field_4=DataclassA(field_1=23))
+            field_1=-56,
+            field_2=dict(a='b'),
+            field_3=('hello', None, True),
+            field_4=DataclassA(field_1=23),
+        )
         value_b = dataclasses.replace(value_a, field_5='some str')
-        self.assertEqual(
-            value_a.deep_compare_to(value_b),
-            DcDeepComparison.SUBSET)
-        self.assertEqual(
-            value_b.deep_compare_to(value_a),
-            DcDeepComparison.SUPERSET)
+        self.assertEqual(value_a.deep_compare_to(value_b), DcDeepComparison.SUBSET)
+        self.assertEqual(value_b.deep_compare_to(value_a), DcDeepComparison.SUPERSET)
 
     def test__dc_deep_compare_type_mismatch(self) -> None:
         value_a = DataclassA(field_1=23)
         value_b = DataclassBWithoutMixin(
-            field_1=-56, field_2=dict(a='b'), field_3=('hello', None, True), field_4=value_a)
+            field_1=-56, field_2=dict(a='b'), field_3=('hello', None, True), field_4=value_a
+        )
 
         with self.assertRaises(TypeError) as cm:
             _dc_deep_compare_to(value_b, value_a)
-        self.assertEqual(cm.exception.args, ("Values to be compared must be of the same type.", ))
+        self.assertEqual(cm.exception.args, ("Values to be compared must be of the same type.",))
         with self.assertRaises(TypeError) as cm:
             _dc_deep_compare_to(value_a, value_b)
-        self.assertEqual(cm.exception.args, ("Values to be compared must be of the same type.", ))
+        self.assertEqual(cm.exception.args, ("Values to be compared must be of the same type.",))
 
     def test_func_not_a_dataclass(self) -> None:
         dc_value_a = DataclassA(field_1=23)
         dc_value_b = DataclassBWithoutMixin(
-            field_1=-56, field_2=dict(a='b'), field_3=('hello', None, True), field_4=dc_value_a)
+            field_1=-56, field_2=dict(a='b'), field_3=('hello', None, True), field_4=dc_value_a
+        )
 
         with self.assertRaises(Exception) as cm:
             dc_deep_compare(dict(), 123)
-        self.assertEqual(cm.exception.args, ("Values must be dataclass instances.", ))
+        self.assertEqual(cm.exception.args, ("Values must be dataclass instances.",))
 
         with self.assertRaises(TypeError) as cm:
             dc_deep_compare(dc_value_a, None)
-        self.assertEqual(cm.exception.args, ("Values must be dataclass instances.", ))
+        self.assertEqual(cm.exception.args, ("Values must be dataclass instances.",))
         with self.assertRaises(TypeError) as cm:
             dc_deep_compare(dc_value_b, None)
-        self.assertEqual(cm.exception.args, ("Values must be dataclass instances.", ))
+        self.assertEqual(cm.exception.args, ("Values must be dataclass instances.",))
 
         with self.assertRaises(TypeError) as cm:
             dc_deep_compare(dc_value_a, ('abc', 56, []))
-        self.assertEqual(cm.exception.args, ("Values must be dataclass instances.", ))
+        self.assertEqual(cm.exception.args, ("Values must be dataclass instances.",))
         with self.assertRaises(TypeError) as cm:
             dc_deep_compare(dc_value_b, ('abc', 56, []))
-        self.assertEqual(cm.exception.args, ("Values must be dataclass instances.", ))
+        self.assertEqual(cm.exception.args, ("Values must be dataclass instances.",))
 
     def test_mixin_self_not_a_dataclass(self) -> None:
         value_1 = NotADataclassWithMixin(field_1='kjdhsf')
@@ -151,17 +156,19 @@ class DcDeepCompareTest(unittest.TestCase):
             value_1.deep_compare_to(value_2)
         self.assertEqual(
             cm.exception.args,
-            ("Programming error. Only dataclasses may subclass 'DcDeepCompareMixin'.", ))
+            ("Programming error. Only dataclasses may subclass 'DcDeepCompareMixin'.",),
+        )
 
     def test_mixin_value_not_a_dataclass(self) -> None:
         value_a = DataclassA(field_1=23)
         value_b = DataclassBWithMixin(
-            field_1=-56, field_2=dict(a='b'), field_3=('hello', None, True), field_4=value_a)
+            field_1=-56, field_2=dict(a='b'), field_3=('hello', None, True), field_4=value_a
+        )
 
         with self.assertRaises(TypeError) as cm:
             value_b.deep_compare_to(None)
-        self.assertEqual(cm.exception.args, ("Value must be a dataclass instance.", ))
+        self.assertEqual(cm.exception.args, ("Value must be a dataclass instance.",))
 
         with self.assertRaises(TypeError) as cm:
             value_b.deep_compare_to(('abc', 56, []))
-        self.assertEqual(cm.exception.args, ("Value must be a dataclass instance.", ))
+        self.assertEqual(cm.exception.args, ("Value must be a dataclass instance.",))

--- a/tests/test_libs_encoding_utils.py
+++ b/tests/test_libs_encoding_utils.py
@@ -8,7 +8,6 @@ from cl_sii.libs.encoding_utils import (  # noqa: F401
 
 
 class FunctionsTest(unittest.TestCase):
-
     def test_clean_base64(self):
         # TODO: implement for function 'clean_base64'.
         pass

--- a/tests/test_libs_io_utils.py
+++ b/tests/test_libs_io_utils.py
@@ -8,7 +8,6 @@ from cl_sii.libs.io_utils import with_encoding_utf8, with_mode_binary, with_mode
 
 
 class FunctionsTest(unittest.TestCase):
-
     def test_with_encoding_utf8(self):
         filename = pathlib.Path(__file__).with_name('test_libs_io_utils-test-file-1.tmp')
         filename.touch()

--- a/tests/test_libs_mm_utils.py
+++ b/tests/test_libs_mm_utils.py
@@ -7,14 +7,12 @@ from cl_sii.libs.mm_utils import (  # noqa: F401
 
 
 class CustomMarshmallowDateFieldTest(unittest.TestCase):
-
     def test_x(self) -> None:
         # TODO: implement for 'CustomMarshmallowDateField'.
         pass
 
 
 class FunctionsTest(unittest.TestCase):
-
     def test_validate_no_unexpected_input_fields(self):
         # TODO: implement for 'validate_no_unexpected_input_fields'.
         pass

--- a/tests/test_libs_rows_processing.py
+++ b/tests/test_libs_rows_processing.py
@@ -7,7 +7,6 @@ from cl_sii.libs.rows_processing import (  # noqa: F401
 
 
 class FunctionsTest(unittest.TestCase):
-
     def test_csv_rows_mm_deserialization_iterator(self):
         # TODO: implement for 'csv_rows_mm_deserialization_iterator'.
         pass

--- a/tests/test_libs_tz_utils.py
+++ b/tests/test_libs_tz_utils.py
@@ -16,7 +16,6 @@ from cl_sii.libs.tz_utils import (  # noqa: F401
 
 
 class FunctionsTest(unittest.TestCase):
-
     def test_get_now_tz_aware(self) -> None:
         # TODO: implement for 'get_now_tz_aware'
         # Reuse doctests/examples in function docstring.

--- a/tests/test_libs_xml_utils.py
+++ b/tests/test_libs_xml_utils.py
@@ -22,19 +22,17 @@ from .utils import read_test_file_bytes
 
 
 class FunctionParseUntrustedXmlTests(unittest.TestCase):
-
     def test_parse_untrusted_xml_valid(self) -> None:
         value = (
             b'<root>\n'
             b'   <element key="value">text</element>\n'
             b'   <element>text</element>tail\n'
             b'   <empty-element/>\n'
-            b'</root>')
+            b'</root>'
+        )
         xml = parse_untrusted_xml(value)
         self.assertIsInstance(xml, XmlElement)
-        self.assertEqual(
-            lxml.etree.tostring(xml, pretty_print=False),
-            value)
+        self.assertEqual(lxml.etree.tostring(xml, pretty_print=False), value)
 
     def test_bytes_text(self) -> None:
         value = b'not xml'  # type: ignore
@@ -43,7 +41,7 @@ class FunctionParseUntrustedXmlTests(unittest.TestCase):
 
         self.assertSequenceEqual(
             cm.exception.args,
-            ("XML syntax error. Start tag expected, '<' not found, line 1, column 1.", )
+            ("XML syntax error. Start tag expected, '<' not found, line 1, column 1.",),
         )
 
     def test_attack_billion_laughs_1(self) -> None:
@@ -53,7 +51,7 @@ class FunctionParseUntrustedXmlTests(unittest.TestCase):
 
         self.assertSequenceEqual(
             cm.exception.args,
-            ("XML syntax error. Detected an entity reference loop, line 1, column 7.", )
+            ("XML syntax error. Detected an entity reference loop, line 1, column 7.",),
         )
 
     def test_attack_billion_laughs_2(self) -> None:
@@ -63,7 +61,7 @@ class FunctionParseUntrustedXmlTests(unittest.TestCase):
 
         self.assertSequenceEqual(
             cm.exception.args,
-            ("XML syntax error. Detected an entity reference loop, line 1, column 4.", )
+            ("XML syntax error. Detected an entity reference loop, line 1, column 4.",),
         )
 
     def test_attack_quadratic_blowup(self) -> None:
@@ -73,7 +71,7 @@ class FunctionParseUntrustedXmlTests(unittest.TestCase):
 
         self.assertSequenceEqual(
             cm.exception.args,
-            ("XML uses or contains a forbidden feature.", )
+            ("XML uses or contains a forbidden feature.",),
         )
 
     def test_attack_external_entity_expansion_remote(self) -> None:
@@ -83,7 +81,7 @@ class FunctionParseUntrustedXmlTests(unittest.TestCase):
 
         self.assertSequenceEqual(
             cm.exception.args,
-            ("XML uses or contains a forbidden feature.", )
+            ("XML uses or contains a forbidden feature.",),
         )
 
     def test_type_error(self) -> None:
@@ -93,7 +91,7 @@ class FunctionParseUntrustedXmlTests(unittest.TestCase):
 
         self.assertSequenceEqual(
             cm.exception.args,
-            ("Value to be parsed as XML must be bytes.", )
+            ("Value to be parsed as XML must be bytes.",),
         )
 
 
@@ -118,49 +116,61 @@ class FunctionWriteXmlDocTest(unittest.TestCase):
 
 
 class FunctionVerifyXmlSignatureTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
 
         cls.any_x509_cert_pem_file = read_test_file_bytes(
-            'test_data/crypto/wildcard-google-com-cert.pem')
+            'test_data/crypto/wildcard-google-com-cert.pem'
+        )
 
         cls.xml_doc_cert_pem_bytes = read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.pem')
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.pem'
+        )
         cls.xml_doc_2_cert_pem_bytes = read_test_file_bytes(
-            'test_data/sii-crypto/DTE--76399752-9--33--25568-cert.pem')
+            'test_data/sii-crypto/DTE--76399752-9--33--25568-cert.pem'
+        )
 
         cls.with_valid_signature = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned.xml'
+        )
         cls.with_valid_signature_signed_data = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-signed_data.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-signed_data.xml'
+        )
         cls.with_valid_signature_signed_xml = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-signed_xml.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-signed_xml.xml'
+        )
         cls.with_valid_signature_signature_xml = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-signature_xml.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-signature_xml.xml'
+        )
 
-        cls.trivial_without_signature = read_test_file_bytes(
-            'test_data/xml/trivial-doc.xml')
+        cls.trivial_without_signature = read_test_file_bytes('test_data/xml/trivial-doc.xml')
         cls.with_too_many_signatures = read_test_file_bytes(
-            'test_data/sii-rtc/AEC--76354771-K--33--170--SEQ-2.xml')
+            'test_data/sii-rtc/AEC--76354771-K--33--170--SEQ-2.xml'
+        )
         cls.without_signature = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-removed-signature.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-removed-signature.xml'
+        )
         cls.with_bad_cert = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-bad-cert.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-bad-cert.xml'
+        )
         cls.with_bad_cert_no_base64 = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-bad-cert-no-base64.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-bad-cert-no-base64.xml'
+        )
         cls.with_signature_and_modified = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-changed-monto.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-changed-monto.xml'
+        )
         cls.with_replaced_cert = read_test_file_bytes(
-            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-replaced-cert.xml')
+            'test_data/sii-dte/DTE--76354771-K--33--170--cleaned-mod-replaced-cert.xml'
+        )
 
     def test_ok_external_trusted_cert(self) -> None:
         xml_doc = parse_untrusted_xml(self.with_valid_signature)
         cert = load_pem_x509_cert(self.xml_doc_cert_pem_bytes)
 
         signed_data, signed_xml, signature_xml = verify_xml_signature(
-            xml_doc, trusted_x509_cert=cert)
+            xml_doc, trusted_x509_cert=cert
+        )
 
         self.assertEqual(signed_data, self.with_valid_signature_signed_data)
 
@@ -189,7 +199,8 @@ class FunctionVerifyXmlSignatureTest(unittest.TestCase):
             _ = verify_xml_signature(xml_doc, trusted_x509_cert=cert)
         self.assertEqual(
             cm.exception.args,
-            ("'trusted_x509_cert' must be a 'crypto_utils.X509Cert' instance, or None.", ))
+            ("'trusted_x509_cert' must be a 'crypto_utils.X509Cert' instance, or None.",),
+        )
 
     def test_fail_xml_doc_type_error(self) -> None:
         cert = self.any_x509_cert_pem_file
@@ -198,7 +209,8 @@ class FunctionVerifyXmlSignatureTest(unittest.TestCase):
             _ = verify_xml_signature(xml_doc=object(), trusted_x509_cert=cert)
         self.assertEqual(
             cm.exception.args,
-            ("'xml_doc' must be an XML document/element.", ))
+            ("'xml_doc' must be an XML document/element.",),
+        )
 
     def test_fail_verify_with_other_cert(self) -> None:
         xml_doc = parse_untrusted_xml(self.with_valid_signature_signature_xml)
@@ -208,7 +220,8 @@ class FunctionVerifyXmlSignatureTest(unittest.TestCase):
             verify_xml_signature(xml_doc, trusted_x509_cert=cert)
         self.assertEqual(
             cm.exception.args,
-            ("Signature verification failed: wrong signature length", ))
+            ("Signature verification failed: wrong signature length",),
+        )
 
     def test_bad_cert_included(self) -> None:
         # If the included certificate is bad, it does not matter, as long as it does not break XML.
@@ -223,8 +236,11 @@ class FunctionVerifyXmlSignatureTest(unittest.TestCase):
             verify_xml_signature(xml_doc_with_bad_cert_no_base64, trusted_x509_cert=cert)
         self.assertEqual(
             cm.exception.args,
-            ("Element '{http://www.w3.org/2000/09/xmldsig#}X509Certificate': '\nabc\n"
-             "' is not a valid value of the atomic type 'xs:base64Binary'., line 30", ))
+            (
+                "Element '{http://www.w3.org/2000/09/xmldsig#}X509Certificate': '\nabc\n"
+                "' is not a valid value of the atomic type 'xs:base64Binary'., line 30",
+            ),
+        )
 
     def test_fail_replaced_cert(self) -> None:
         xml_doc = parse_untrusted_xml(self.with_replaced_cert)
@@ -234,7 +250,8 @@ class FunctionVerifyXmlSignatureTest(unittest.TestCase):
             verify_xml_signature(xml_doc, trusted_x509_cert=cert)
         self.assertEqual(
             cm.exception.args,
-            ("Signature verification failed: header too long", ))
+            ("Signature verification failed: header too long",),
+        )
 
     def test_fail_included_cert_not_from_a_known_ca(self) -> None:
         xml_doc = parse_untrusted_xml(self.with_valid_signature)
@@ -244,7 +261,8 @@ class FunctionVerifyXmlSignatureTest(unittest.TestCase):
             verify_xml_signature(xml_doc, trusted_x509_cert=None)
         self.assertEqual(
             cm.exception.args,
-            ("[20, 0, 'unable to get local issuer certificate']", ))
+            ("[20, 0, 'unable to get local issuer certificate']",),
+        )
 
     def test_fail_signed_data_modified(self) -> None:
         xml_doc = parse_untrusted_xml(self.with_signature_and_modified)
@@ -252,14 +270,15 @@ class FunctionVerifyXmlSignatureTest(unittest.TestCase):
 
         with self.assertRaises(XmlSignatureUnverified) as cm:
             verify_xml_signature(xml_doc, trusted_x509_cert=cert)
-        self.assertEqual(cm.exception.args, ("Digest mismatch for reference 0", ))
+        self.assertEqual(cm.exception.args, ("Digest mismatch for reference 0",))
 
     def test_xml_doc_without_signature_1(self) -> None:
         xml_doc = parse_untrusted_xml(self.without_signature)
 
         expected_exc_args = (
             'Invalid input.',
-            'Expected to find XML element Signature in {http://www.sii.cl/SiiDte}DTE')
+            'Expected to find XML element Signature in {http://www.sii.cl/SiiDte}DTE',
+        )
 
         # Without cert:
         with self.assertRaises(ValueError) as cm:
@@ -276,7 +295,9 @@ class FunctionVerifyXmlSignatureTest(unittest.TestCase):
         xml_doc = parse_untrusted_xml(self.trivial_without_signature)
 
         expected_exc_args = (
-            'Invalid input.', 'Expected to find XML element Signature in data')
+            'Invalid input.',
+            'Expected to find XML element Signature in data',
+        )
 
         # Without cert:
         with self.assertRaises(ValueError) as cm:
@@ -292,7 +313,7 @@ class FunctionVerifyXmlSignatureTest(unittest.TestCase):
     def test_fail_xml_doc_with_too_many_signatures(self) -> None:
         xml_doc = parse_untrusted_xml(self.with_too_many_signatures)
 
-        expected_exc_args = ("XML document with more than one signature is not supported.", )
+        expected_exc_args = ("XML document with more than one signature is not supported.",)
 
         # Without cert:
         with self.assertRaises(NotImplementedError) as cm:

--- a/tests/test_rcv_constants.py
+++ b/tests/test_rcv_constants.py
@@ -6,21 +6,17 @@ from cl_sii.rcv.constants import RcEstadoContable, RcvKind, RcvTipoDocto  # noqa
 
 
 class RcvKindTest(unittest.TestCase):
-
     def test_members(self):
         self.assertSetEqual(
             {x for x in RcvKind},
             {
                 RcvKind.COMPRAS,
                 RcvKind.VENTAS,
-            }
+            },
         )
 
     def test_values_type(self):
-        self.assertSetEqual(
-            {type(x.value) for x in RcvKind},
-            {str}
-        )
+        self.assertSetEqual({type(x.value) for x in RcvKind}, {str})
 
     def test_is_estado_contable_compatible(self):
         self.assertTrue(RcvKind.VENTAS.is_estado_contable_compatible(None))
@@ -37,7 +33,6 @@ class RcvKindTest(unittest.TestCase):
 
 
 class RcEstadoContableTest(unittest.TestCase):
-
     def test_members(self):
         self.assertSetEqual(
             {x for x in RcEstadoContable},
@@ -46,18 +41,14 @@ class RcEstadoContableTest(unittest.TestCase):
                 RcEstadoContable.NO_INCLUIR,
                 RcEstadoContable.RECLAMADO,
                 RcEstadoContable.PENDIENTE,
-            }
+            },
         )
 
     def test_values_type(self):
-        self.assertSetEqual(
-            {type(x.value) for x in RcEstadoContable},
-            {str}
-        )
+        self.assertSetEqual({type(x.value) for x in RcEstadoContable}, {str})
 
 
 class RcvTipoDoctoTest(unittest.TestCase):
-
     def test_members(self):
         self.assertSetEqual(
             {x for x in RcvTipoDocto},
@@ -71,7 +62,7 @@ class RcvTipoDoctoTest(unittest.TestCase):
                 RcvTipoDocto.FACTURA_COMPRA_ELECTRONICA,
                 RcvTipoDocto.FACTURA_EXPORTACION,
                 RcvTipoDocto.FACTURA_EXPORTACION_ELECTRONICA,
-
+                #
                 RcvTipoDocto.NOTA_DEBITO,
                 RcvTipoDocto.NOTA_DEBITO_ELECTRONICA,
                 RcvTipoDocto.NOTA_CREDITO,
@@ -80,15 +71,15 @@ class RcvTipoDoctoTest(unittest.TestCase):
                 RcvTipoDocto.NOTA_DEBITO_EXPORTACION_ELECTRONICA,
                 RcvTipoDocto.NOTA_CREDITO_EXPORTACION,
                 RcvTipoDocto.NOTA_CREDITO_EXPORTACION_ELECTRONICA,
-
+                #
                 RcvTipoDocto.LIQUIDACION_FACTURA,
                 RcvTipoDocto.LIQUIDACION_FACTURA_ELECTRONICA,
-
+                #
                 RcvTipoDocto.TOTAL_OP_DEL_MES_BOLETA_AFECTA,
                 RcvTipoDocto.TOTAL_OP_DEL_MES_BOLETA_EXENTA,
                 RcvTipoDocto.TOTAL_OP_DEL_MES_BOLETA_EXENTA_ELECTR,
                 RcvTipoDocto.TOTAL_OP_DEL_MES_BOLETA_ELECTR,
-
+                #
                 RcvTipoDocto.TIPO_47,
                 RcvTipoDocto.TIPO_48,
                 RcvTipoDocto.TIPO_102,
@@ -111,14 +102,11 @@ class RcvTipoDoctoTest(unittest.TestCase):
                 RcvTipoDocto.TIPO_920,
                 RcvTipoDocto.TIPO_922,
                 RcvTipoDocto.TIPO_924,
-            }
+            },
         )
 
     def test_values_type(self):
-        self.assertSetEqual(
-            {type(x.value) for x in RcvTipoDocto},
-            {int}
-        )
+        self.assertSetEqual({type(x.value) for x in RcvTipoDocto}, {int})
 
     def test_of_some_member(self):
         value = RcvTipoDocto.FACTURA_ELECTRONICA
@@ -129,10 +117,11 @@ class RcvTipoDoctoTest(unittest.TestCase):
     def test_as_tipo_dte(self):
         self.assertEqual(
             RcvTipoDocto.FACTURA_ELECTRONICA.as_tipo_dte(),
-            TipoDte.FACTURA_ELECTRONICA)
+            TipoDte.FACTURA_ELECTRONICA,
+        )
 
         with self.assertRaises(ValueError) as cm:
             RcvTipoDocto.FACTURA.as_tipo_dte()
         self.assertEqual(
-            cm.exception.args,
-            ("There is no equivalent 'TipoDte' for 'RcvTipoDocto.FACTURA'.", ))
+            cm.exception.args, ("There is no equivalent 'TipoDte' for 'RcvTipoDocto.FACTURA'.",)
+        )

--- a/tests/test_rcv_data_models.py
+++ b/tests/test_rcv_data_models.py
@@ -21,13 +21,12 @@ from cl_sii.rut import Rut
 
 
 class PeriodoTributarioTest(unittest.TestCase):
-
     def setUp(self) -> None:
         super().setUp()
 
         self.periodo_tributario_1 = PeriodoTributario(
             year=2019,
-            month=4
+            month=4,
         )
 
     def test_validate_year_range(self) -> None:
@@ -86,7 +85,6 @@ class PeriodoTributarioTest(unittest.TestCase):
 
 
 class RcvDetalleEntryTest(unittest.TestCase):
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -99,7 +97,8 @@ class RcvDetalleEntryTest(unittest.TestCase):
             monto_total=2996301,
             fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 1, 1, 36, 40),
-                tz=RcvDetalleEntry.DATETIME_FIELDS_TZ),
+                tz=RcvDetalleEntry.DATETIME_FIELDS_TZ,
+            ),
         )
 
     def test_validate_folio_range(self) -> None:
@@ -162,11 +161,12 @@ class RcvDetalleEntryTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('fecha_recepcion_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
         ]
@@ -187,7 +187,6 @@ class RcvDetalleEntryTest(unittest.TestCase):
 
 
 class RvDetalleEntryTest(unittest.TestCase):
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -201,13 +200,16 @@ class RvDetalleEntryTest(unittest.TestCase):
             receptor_razon_social='MINERA LOS PELAMBRES',
             fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 1, 1, 36, 40),
-                tz=RvDetalleEntry.DATETIME_FIELDS_TZ),
+                tz=RvDetalleEntry.DATETIME_FIELDS_TZ,
+            ),
             fecha_acuse_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 8, 10, 21, 18),
-                tz=RvDetalleEntry.DATETIME_FIELDS_TZ),
+                tz=RvDetalleEntry.DATETIME_FIELDS_TZ,
+            ),
             fecha_reclamo_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 8, 10, 21, 18),
-                tz=RvDetalleEntry.DATETIME_FIELDS_TZ),
+                tz=RvDetalleEntry.DATETIME_FIELDS_TZ,
+            ),
         )
 
     def test_constants_match(self):
@@ -264,11 +266,12 @@ class RvDetalleEntryTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('fecha_acuse_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
         ]
@@ -314,11 +317,12 @@ class RvDetalleEntryTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('fecha_reclamo_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
         ]
@@ -339,7 +343,6 @@ class RvDetalleEntryTest(unittest.TestCase):
 
 
 class RcRegistroDetalleEntryTest(unittest.TestCase):
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -353,10 +356,12 @@ class RcRegistroDetalleEntryTest(unittest.TestCase):
             emisor_razon_social='INGENIERIA ENACON SPA',
             fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 1, 1, 36, 40),
-                tz=RcRegistroDetalleEntry.DATETIME_FIELDS_TZ),
+                tz=RcRegistroDetalleEntry.DATETIME_FIELDS_TZ,
+            ),
             fecha_acuse_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 8, 10, 21, 18),
-                tz=RcRegistroDetalleEntry.DATETIME_FIELDS_TZ),
+                tz=RcRegistroDetalleEntry.DATETIME_FIELDS_TZ,
+            ),
         )
 
     def test_constants_match(self):
@@ -412,11 +417,12 @@ class RcRegistroDetalleEntryTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('fecha_acuse_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
         ]
@@ -437,7 +443,6 @@ class RcRegistroDetalleEntryTest(unittest.TestCase):
 
 
 class RcNoIncluirDetalleEntryTest(unittest.TestCase):
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -451,15 +456,16 @@ class RcNoIncluirDetalleEntryTest(unittest.TestCase):
             emisor_razon_social='INGENIERIA ENACON SPA',
             fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 1, 1, 36, 40),
-                tz=SII_OFFICIAL_TZ),
+                tz=SII_OFFICIAL_TZ,
+            ),
             fecha_acuse_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 8, 10, 21, 18),
-                tz=SII_OFFICIAL_TZ),
+                tz=SII_OFFICIAL_TZ,
+            ),
         )
 
 
 class RcReclamadoDetalleEntryTest(unittest.TestCase):
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -473,10 +479,12 @@ class RcReclamadoDetalleEntryTest(unittest.TestCase):
             emisor_razon_social='INGENIERIA ENACON SPA',
             fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 1, 1, 36, 40),
-                tz=RcReclamadoDetalleEntry.DATETIME_FIELDS_TZ),
+                tz=RcReclamadoDetalleEntry.DATETIME_FIELDS_TZ,
+            ),
             fecha_reclamo_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 8, 10, 21, 18),
-                tz=RcReclamadoDetalleEntry.DATETIME_FIELDS_TZ),
+                tz=RcReclamadoDetalleEntry.DATETIME_FIELDS_TZ,
+            ),
         )
 
     def test_constants_match(self):
@@ -532,11 +540,12 @@ class RcReclamadoDetalleEntryTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('fecha_reclamo_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
         ]
@@ -557,7 +566,6 @@ class RcReclamadoDetalleEntryTest(unittest.TestCase):
 
 
 class RcPendienteDetalleEntryTest(unittest.TestCase):
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -571,7 +579,8 @@ class RcPendienteDetalleEntryTest(unittest.TestCase):
             emisor_razon_social='INGENIERIA ENACON SPA',
             fecha_recepcion_dt=tz_utils.convert_naive_dt_to_tz_aware(
                 dt=datetime(2019, 4, 1, 1, 36, 40),
-                tz=SII_OFFICIAL_TZ),
+                tz=SII_OFFICIAL_TZ,
+            ),
         )
 
     def test_validate_emisor_razon_social_empty(self) -> None:

--- a/tests/test_rcv_parse_csv.py
+++ b/tests/test_rcv_parse_csv.py
@@ -49,7 +49,6 @@ class RcvCompraPendienteCsvRowSchemaTest(unittest.TestCase):
 
 
 class FunctionsTest(unittest.TestCase):
-
     def test_parse_rcv_venta_csv_file(self) -> None:
         # TODO: implement for 'parse_rcv_venta_csv_file'.
         pass

--- a/tests/test_rtc_data_models.py
+++ b/tests/test_rtc_data_models.py
@@ -249,11 +249,12 @@ class CesionAltNaturalKeyTest(unittest.TestCase):
 
         expected_validation_error = {
             'loc': ('fecha_cesion_dt',),
-            'msg':
+            'msg': (
                 '('
                 '''"Timezone of datetime value must be 'America/Santiago'.",'''
                 ' datetime.datetime(2019, 4, 5, 12, 57, tzinfo=<UTC>)'
-                ')',
+                ')'
+            ),
             'type': 'value_error',
         }
 
@@ -426,8 +427,7 @@ class CesionL0Test(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('dte_key',),
-                'msg':
-                    """('Value is not "cedible".', <TipoDte.NOTA_CREDITO_ELECTRONICA: 61>)""",
+                'msg': """('Value is not "cedible".', <TipoDte.NOTA_CREDITO_ELECTRONICA: 61>)""",
                 'type': 'value_error',
             },
         ]
@@ -503,11 +503,12 @@ class CesionL0Test(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('fecha_cesion_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
         ]
@@ -651,7 +652,7 @@ class CesionL1Test(CesionL0Test):
         self._set_obj_1()
 
         obj = self.obj_1
-        test_values = [-1, 10 ** 18 + 1]
+        test_values = [-1, 10**18 + 1]
 
         for test_value in test_values:
             expected_validation_errors = [
@@ -680,8 +681,7 @@ class CesionL1Test(CesionL0Test):
         expected_validation_errors = [
             {
                 'loc': ('__root__',),
-                'msg':
-                    """('Value of "cesión" must be <= value of DTE.', 1000, 999)""",
+                'msg': """('Value of "cesión" must be <= value of DTE.', 1000, 999)""",
                 'type': 'value_error',
             },
         ]
@@ -912,20 +912,22 @@ class CesionL2Test(CesionL1Test):
         expected_validation_errors = [
             {
                 'loc': ('fecha_cesion_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
             {
                 'loc': ('fecha_firma_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
         ]

--- a/tests/test_rtc_data_models_aec.py
+++ b/tests/test_rtc_data_models_aec.py
@@ -459,8 +459,7 @@ class AecXmlTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('dte',),
-                'msg':
-                    """('Value is not "cedible".', <TipoDte.NOTA_CREDITO_ELECTRONICA: 61>)""",
+                'msg': """('Value is not "cedible".', <TipoDte.NOTA_CREDITO_ELECTRONICA: 61>)""",
                 'type': 'value_error',
             },
         ]
@@ -510,11 +509,12 @@ class AecXmlTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('fecha_firma_dt',),
-                'msg':
+                'msg': (
                     '('
                     '''"Timezone of datetime value must be 'America/Santiago'.",'''
                     ' datetime.datetime(2019, 4, 5, 12, 57, 32, tzinfo=<UTC>)'
-                    ')',
+                    ')'
+                ),
                 'type': 'value_error',
             },
         ]
@@ -621,7 +621,7 @@ class AecXmlTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('__root__',),
-                'msg':
+                'msg': (
                     "'dte' of CesionAecXml with CesionNaturalKey("
                     "dte_key=DteNaturalKey("
                     "emisor_rut=Rut('76354771-K'),"
@@ -633,7 +633,8 @@ class AecXmlTest(unittest.TestCase):
                     "emisor_rut=Rut('76354771-K'),"
                     " tipo_dte=<TipoDte.FACTURA_ELECTRONICA: 33>,"
                     " folio=170"
-                    ").",
+                    ")."
+                ),
                 'type': 'value_error',
             },
         ]
@@ -666,11 +667,12 @@ class AecXmlTest(unittest.TestCase):
         expected_validation_errors = [
             {
                 'loc': ('__root__',),
-                'msg':
+                'msg': (
                     "'cedente_rut' of last 'cesion' must match 'cedente_rut':"
                     " Rut('76389992-6')"
                     " !="
-                    " Rut('76598556-0').",
+                    " Rut('76598556-0')."
+                ),
                 'type': 'value_error',
             },
         ]

--- a/tests/test_rtc_data_models_cesiones_periodo.py
+++ b/tests/test_rtc_data_models_cesiones_periodo.py
@@ -32,7 +32,8 @@ class CesionesPeriodoEntryTest(unittest.TestCase):
             cesionario_emails='un-poco@pobres.cl,super.ejecutivo@pobres.cl',
             deudor_email=None,
             fecha_cesion_dt=convert_naive_dt_to_tz_aware(
-                datetime(2019, 3, 7, 13, 32), tz=SII_OFFICIAL_TZ),
+                datetime(2019, 3, 7, 13, 32), tz=SII_OFFICIAL_TZ
+            ),
             fecha_cesion=date(2019, 3, 7),
             monto_cedido=256357,
             fecha_ultimo_vencimiento=date(2019, 4, 12),
@@ -44,42 +45,52 @@ class CesionesPeriodoEntryTest(unittest.TestCase):
         self.assertTrue(obj.monto_cedido_eq_dte_monto_total)
 
     def test_init_ok_2(self) -> None:
-        self.valid_kwargs.update(dict(
-            monto_cedido=self.valid_kwargs['dte_monto_total'] - 1,
-        ))
+        self.valid_kwargs.update(
+            dict(
+                monto_cedido=self.valid_kwargs['dte_monto_total'] - 1,
+            )
+        )
         obj = CesionesPeriodoEntry(**self.valid_kwargs)
         self.assertFalse(obj.monto_cedido_eq_dte_monto_total)
 
     def test_init_error_monto_cedido_1(self) -> None:
-        self.valid_kwargs.update(dict(
-            monto_cedido=-1,
-        ))
+        self.valid_kwargs.update(
+            dict(
+                monto_cedido=-1,
+            )
+        )
         with self.assertRaises(ValueError) as cm:
             CesionesPeriodoEntry(**self.valid_kwargs)
-        self.assertEqual(
-            cm.exception.args,
-            ("Amount 'monto_cedido' must be >= 0.", -1))
+        self.assertEqual(cm.exception.args, ("Amount 'monto_cedido' must be >= 0.", -1))
 
     def test_init_error_monto_cedido_2(self) -> None:
-        self.valid_kwargs.update(dict(
-            monto_cedido=self.valid_kwargs['dte_monto_total'] + 1,
-        ))
+        self.valid_kwargs.update(
+            dict(
+                monto_cedido=self.valid_kwargs['dte_monto_total'] + 1,
+            )
+        )
         with self.assertRaises(ValueError) as cm:
             CesionesPeriodoEntry(**self.valid_kwargs)
         self.assertEqual(
             cm.exception.args,
-            ('Value of "cesión" must be <= value of DTE.', 256358, 256357))
+            ('Value of "cesión" must be <= value of DTE.', 256358, 256357),
+        )
 
     def test_init_error_dte_tipo_dte_1(self) -> None:
-        self.valid_kwargs.update(dict(
-            dte_tipo_dte=TipoDte.NOTA_CREDITO_ELECTRONICA,
-        ))
+        self.valid_kwargs.update(
+            dict(
+                dte_tipo_dte=TipoDte.NOTA_CREDITO_ELECTRONICA,
+            )
+        )
         with self.assertRaises(ValueError) as cm:
             CesionesPeriodoEntry(**self.valid_kwargs)
         self.assertEqual(
             cm.exception.args,
-            ("The \"tipo DTE\" in 'dte_tipo_dte' is not \"cedible\".",
-             TipoDte.NOTA_CREDITO_ELECTRONICA))
+            (
+                "The \"tipo DTE\" in 'dte_tipo_dte' is not \"cedible\".",
+                TipoDte.NOTA_CREDITO_ELECTRONICA,
+            ),
+        )
 
     def test_as_dte_data_l1_ok_1(self) -> None:
         obj = CesionesPeriodoEntry(**self.valid_kwargs)
@@ -99,9 +110,11 @@ class CesionesPeriodoEntryTest(unittest.TestCase):
         self.assertEqual(dte_obj.comprador_rut, obj.dte_deudor_rut)
 
     def test_as_dte_data_l1_ok_2(self) -> None:
-        self.valid_kwargs.update(dict(
-            dte_tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA,
-        ))
+        self.valid_kwargs.update(
+            dict(
+                dte_tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA,
+            )
+        )
         obj = CesionesPeriodoEntry(**self.valid_kwargs)
         dte_obj = cl_sii.dte.data_models.DteDataL1(
             emisor_rut=Rut('75320502-0'),
@@ -155,9 +168,11 @@ class CesionesPeriodoEntryTest(unittest.TestCase):
         self.assertEqual(obj_cesion_l2.dte_receptor_rut, obj.dte_deudor_rut)
 
     def test_as_cesion_l2_ok_2(self) -> None:
-        self.valid_kwargs.update(dict(
-            dte_tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA,
-        ))
+        self.valid_kwargs.update(
+            dict(
+                dte_tipo_dte=TipoDte.FACTURA_COMPRA_ELECTRONICA,
+            )
+        )
         obj = CesionesPeriodoEntry(**self.valid_kwargs)
         expected_output = CesionL2(
             dte_key=cl_sii.dte.data_models.DteNaturalKey(

--- a/tests/test_rtc_xml_utils.py
+++ b/tests/test_rtc_xml_utils.py
@@ -63,7 +63,6 @@ class AecXmlValidatorTest(unittest.TestCase):
 
 
 class FunctionVerifyAecSignatureTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()

--- a/tests/test_rut.py
+++ b/tests/test_rut.py
@@ -67,7 +67,8 @@ class RutTest(unittest.TestCase):
     def test_ok_same_type(self) -> None:
         self.assertEqual(
             rut.Rut(rut.Rut('1-1')),
-            rut.Rut('1-1'))
+            rut.Rut('1-1'),
+        )
 
     def test_instance_empty_string(self) -> None:
         rut_value = ''
@@ -326,7 +327,7 @@ class RutTest(unittest.TestCase):
 
         self.assertListEqual(
             list(context_manager.exception.args),
-            ["Must be a sequence of digits."]
+            ["Must be a sequence of digits."],
         )
 
     def test_calc_dv_string_lowercase(self) -> None:
@@ -336,7 +337,7 @@ class RutTest(unittest.TestCase):
 
         self.assertListEqual(
             list(context_manager.exception.args),
-            ["Must be a sequence of digits."]
+            ["Must be a sequence of digits."],
         )
 
     def test_random(self) -> None:

--- a/tests/test_rut_crypto_utils.py
+++ b/tests/test_rut_crypto_utils.py
@@ -33,7 +33,7 @@ class FunctionsTest(unittest.TestCase):
 
     def test_get_subject_rut_from_certificate_pfx_fails_if_rut_info_is_missing(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
-            'test_data/crypto/wildcard-google-com-cert.der'
+            'test_data/crypto/wildcard-google-com-cert.der',
         )
 
         x509_cert = load_der_x509_cert(cert_der_bytes)

--- a/tests/test_scripts_clean_dte_xml_file.py
+++ b/tests/test_scripts_clean_dte_xml_file.py
@@ -1,2 +1,1 @@
-
 # TODO: implement tests for script 'clean_dte_xml_file.py'


### PR DESCRIPTION
- Install Python package 'black'.
- Add configuration for Python source code formatter 'Black'.
- Add Make tasks for Python source code formatter 'Black'.
- setup: Reformat source code using 'Black'.
- cl_sii.*: Reformat source code using 'Black'.
- test: Reformat source code using 'Black'.

## About Black

> *Black* is the uncompromising Python code formatter. By using it, you agree to cede control over minutiae of hand-formatting. In return, *Black* gives you speed, determinism, and freedom from `pycodestyle` nagging about formatting. You will save time and mental energy for more important matters.
>
> Blackened code looks the same regardless of the project you're
> reading. Formatting becomes transparent after a while and you can
> focus on the content instead.
>
> *Black* makes code review faster by producing the smallest diffs
> possible.

- Web site: https://github.com/psf/black/
- VCS: https://github.com/psf/black.git
- Documentation: https://black.readthedocs.io/
- Python Package Index: https://pypi.org/project/black/

-----

Internal Ref: https://cordada.aha.io/features/COMPCLDATA-27