### PR TITLE
chore: Increase Dependabot's open pull request limit for `pip`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,6 @@ updates:
       interval: daily
       time: "08:30"
       timezone: America/Santiago
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 20
     labels:
       - dependencies


### PR DESCRIPTION
We have multiple open pull requests that were created by Dependabot that have not been merged for various reasons, which prevents Dependabot from creating pull requests for other dependencies that may be of higher priority.