### PR TITLE
chore: Increase Django REST Framework required maximum version to 3.13.x

### DIFF
--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -2,7 +2,7 @@
 
 # Required packages:
 Django>=2.2.24
-djangorestframework>=3.10.3,<3.13
+djangorestframework>=3.10.3,<3.14
 
 # Packages dependencies:
 #   - Django:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ requirements = [
 
 extras_requirements = {
     'django': ['Django>=2.2.24'],
-    'djangorestframework': ['djangorestframework>=3.10.3,<3.13'],
+    'djangorestframework': ['djangorestframework>=3.10.3,<3.14'],
 }
 
 setup_requirements = [


### PR DESCRIPTION
Increase limit to 3.14 as the latest release is at version 3.13.1.

Changelog:

- 3.13.1 (2021-12-15):
  https://www.django-rest-framework.org/community/release-notes/#3131
- 3.13.0 (2021-12-13):
  https://www.django-rest-framework.org/community/release-notes/#3130

Code diff: https://github.com/encode/django-rest-framework/compare/3.12.4...3.13.1

Fixes: https://github.com/fyntex/lib-cl-sii-python/issues/270