### PR TITLE
fix(rut): `AttributeError` for `GeneralName` object without `type_id`

### DIFF
--- a/cl_sii/rut/crypto_utils.py
+++ b/cl_sii/rut/crypto_utils.py
@@ -36,7 +36,7 @@ def get_subject_rut_from_certificate_pfx(pfx_file_bytes: bytes, password: Option
         results = [
             x.value
             for x in subject_alt_name_ext.value._general_names
-            if x.type_id == constants.SII_CERT_TITULAR_RUT_OID
+            if hasattr(x, 'type_id') and x.type_id == constants.SII_CERT_TITULAR_RUT_OID
         ]
     except AttributeError:
         raise Exception('Certificate has no RUT information')

--- a/cl_sii/rut/crypto_utils.py
+++ b/cl_sii/rut/crypto_utils.py
@@ -38,8 +38,8 @@ def get_subject_rut_from_certificate_pfx(pfx_file_bytes: bytes, password: Option
             for x in subject_alt_name_ext.value._general_names
             if hasattr(x, 'type_id') and x.type_id == constants.SII_CERT_TITULAR_RUT_OID
         ]
-    except AttributeError:
-        raise Exception('Certificate has no RUT information')
+    except AttributeError as exc:
+        raise Exception(f'Malformed certificate extension: {subject_alt_name_ext.oid}') from exc
 
     if not results:
         raise Exception('Certificate has no RUT information')

--- a/tests/test_rut_crypto_utils.py
+++ b/tests/test_rut_crypto_utils.py
@@ -1,11 +1,12 @@
 import unittest
 from unittest.mock import Mock, patch
 
+import cryptography.x509
 from cryptography.hazmat.backends.openssl import backend as crypto_x509_backend
 
 from cl_sii import rut
 from cl_sii.libs.crypto_utils import load_der_x509_cert
-from cl_sii.rut.crypto_utils import get_subject_rut_from_certificate_pfx
+from cl_sii.rut.crypto_utils import constants, get_subject_rut_from_certificate_pfx
 from . import utils
 
 
@@ -51,3 +52,48 @@ class FunctionsTest(unittest.TestCase):
                     password=password,
                 )
             self.assertEqual(cm.exception.args, ('Certificate has no RUT information',))
+
+    def test_get_subject_rut_from_certificate_pfx_does_not_throw_attribute_error_if_has_object_without_type_id(  # noqa: E501
+        self,
+    ) -> None:
+        cert_der_bytes = utils.read_test_file_bytes(
+            'test_data/sii-crypto/DTE--76354771-K--33--170-cert.der'
+        )
+        x509_cert = load_der_x509_cert(cert_der_bytes)
+
+        general_name_with_type_id = cryptography.x509.general_name.OtherName(
+            type_id=constants.SII_CERT_TITULAR_RUT_OID,
+            value=b'\x16\n17178452-2',
+        )
+        general_name_without_type_id = cryptography.x509.general_name.RFC822Name(
+            value='test string',
+        )
+        general_names = cryptography.x509.extensions.GeneralNames(
+            general_names=[general_name_without_type_id, general_name_with_type_id],
+        )
+        certificate_extension_value = cryptography.x509.extensions.SubjectAlternativeName(
+            general_names=general_names,
+        )
+        certificate_extension = cryptography.x509.extensions.Extension(
+            oid=constants.SII_CERT_TITULAR_RUT_OID,
+            critical=False,
+            value=certificate_extension_value,
+        )
+
+        with patch.object(
+            crypto_x509_backend,
+            'load_key_and_certificates_from_pkcs12',
+            Mock(return_value=(None, x509_cert, None)),
+        ), patch.object(
+            x509_cert.extensions,
+            'get_extension_for_class',
+            Mock(return_value=certificate_extension),
+        ):
+            pfx_file_bytes = b'hello'
+            password = 'fake_password'
+            subject_rut = get_subject_rut_from_certificate_pfx(
+                pfx_file_bytes=pfx_file_bytes,
+                password=password,
+            )
+            self.assertIsInstance(subject_rut, rut.Rut)
+            self.assertEqual(subject_rut, rut.Rut('17178452-2'))


### PR DESCRIPTION
When searching for the rut information in the certificate, some
objects inside it could not have the `type_id` attribute. For this
reason, it is necessary to check if this attribute exist before
accessing it.

Ref: https://cordada.aha.io/requirements/COMPCLDATA-67-1
Ref: https://cordada.aha.io/features/COMPCLDATA-67

Fixes: https://github.com/fyntex/lib-cl-sii-python/issues/307