### PR TITLE
chore(requirements-dev): Update package `readme-renderer` to 35.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -108,7 +108,7 @@ pycodestyle==2.8.0
 pyflakes==2.4.0
 # Pygments
 # pyparsing
-readme-renderer==25.0
+readme-renderer==35.0
 requests-toolbelt==0.9.1
 requests==2.25.1
 # SecretStorage


### PR DESCRIPTION
Changelog:

- 35.0 (2022-04-19):
  https://github.com/pypa/readme_renderer/releases/tag/35.0
- 34.0 (2022-03-13):
  https://github.com/pypa/readme_renderer/releases/tag/34.0
- 33.0 (2022-03-05):
  https://github.com/pypa/readme_renderer/releases/tag/33.0
- 32.0 (2021-12-13):
  https://github.com/pypa/readme_renderer/releases/tag/32.0
- 31.0 (2021-12-09):
  https://github.com/pypa/readme_renderer/releases/tag/31.0
- 30.0 (2021-09-30):
  https://github.com/pypa/readme_renderer/releases/tag/30.0
- 29.0 (2021-02-23):
  https://github.com/pypa/readme_renderer/releases/tag/29.0
- 28.0 (2020-10-20):
  https://github.com/pypa/readme_renderer/releases/tag/28.0
- 27.0 (2020-10-09):
  https://github.com/pypa/readme_renderer/releases/tag/27.0
- 26.0 (2020-04-22):
  https://github.com/pypa/readme_renderer/releases/tag/26.0

Code diff: https://github.com/pypa/readme_renderer/compare/25.0...35.0