### PR TITLE
chore: Add code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code Owners
+#
+# Use this file to define individuals or teams that are responsible for code in a repository.
+#
+# Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default
+* @fyntex/developers


### PR DESCRIPTION
> # About code owners
>
> You can use a CODEOWNERS file to define individuals or teams that are
> responsible for code in a repository.

Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners