### PR TITLE
Release v0.18.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,8 @@
 [bumpversion]
-current_version = 0.17.3
+current_version = 0.18.0
 commit = True
 tag = True
 message = chore: Bump version from {current_version} to {new_version}
 
 [bumpversion:file:cl_sii/__init__.py]
+

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,5 +2,6 @@
 current_version = 0.17.3
 commit = True
 tag = True
+message = chore: Bump version from {current_version} to {new_version}
 
 [bumpversion:file:cl_sii/__init__.py]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,14 +48,7 @@ jobs:
             . venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade setuptools wheel
-            pip install -r requirements.txt
-            pip install -r requirements-dev.txt
-
-      - run:
-          name: Check Dependencies
-          command: |
-            . venv/bin/activate
-            pip check
+            make install-dev
 
       - run:
           name: run tests
@@ -94,14 +87,7 @@ jobs:
             . venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade setuptools wheel
-            pip install -r requirements.txt
-            pip install -r requirements-dev.txt
-
-      - run:
-          name: Check Dependencies
-          command: |
-            . venv/bin/activate
-            pip check
+            make install-dev
 
       - run:
           name: make dist

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 # GitHub Dependabot Configuration
 #
+# Dependabot can maintain your repository's dependencies automatically.
+#
 # Documentation:
-#   https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+# - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
 
 version: 2
 
@@ -9,9 +12,7 @@ updates:
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: daily
-      time: "08:30"
-      timezone: America/Santiago
-    open-pull-requests-limit: 20
+      interval: weekly
+    open-pull-requests-limit: 10
     labels:
       - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 10
     labels:
       - dependencies

--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -1,0 +1,18 @@
+# GitHub Actions Workflow for Git Commit Linter
+
+name: Git Commit Linter
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  git-commit-lint:
+    name: Git Commit Linter
+    uses: cordada/github-actions-utils/.github/workflows/git-commit-lint.yaml@master

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code Owners
+#
+# Use this file to define individuals or teams that are responsible for code in a repository.
+#
+# Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default
+* @fyntex/developers

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,28 @@
 History
 -------
 
+0.18.0 (2022-08-26)
++++++++++++++++++++++++
+
+* (PR #343, 2022-07-08) chore: Update Dependabot configuration
+* (PR #281, 2022-07-21) build(deps): bump six from 1.15.0 to 1.16.0
+* (PR #340, 2022-07-21) build(deps): bump lxml from 4.6.5 to 4.9.1
+* (PR #334, 2022-07-22) build(deps): bump certifi from 2020.12.5 to 2022.6.15
+* (PR #350, 2022-08-11) chore: Add code owners
+* (PR #352, 2022-08-18) chore: Change Dependabot schedule interval from `weekly` to `monthly`
+* (PR #338, 2022-08-22) build(deps-dev): bump tox from 3.20.1 to 3.25.1
+* (PR #342, 2022-08-22) chore(deps): Bump cryptography from 3.3.2 to 37.0.4
+* (PR #286, 2022-08-24) build(deps): bump eight from 1.0.0 to 1.0.1
+* (PR #355, 2022-08-24) chore: Add Make tasks for installation
+* (PR #332, 2022-08-24) build(deps-dev): bump pkginfo from 1.7.0 to 1.8.3
+* (PR #288, 2022-08-24) build(deps): bump pluggy from 0.13.1 to 1.0.0
+* (PR #287, 2022-08-25) build(deps): bump wheel from 0.35.1 to 0.37.1
+* (PR #356, 2022-08-25) chore(deps): bump marshmallow from 2.19.5 to 2.21.0
+* (PR #339, 2022-08-25) build(deps): bump cffi from 1.14.0 to 1.15.1
+* (PR #312, 2022-08-25) build(deps-dev): bump tqdm from 4.45.0 to 4.64.0
+* (PR #359, 2022-08-25) chore: Add Git commit linter
+* (PR #360, 2022-08-26) Update files for Git commit linter
+
 0.17.3 (2022-07-04)
 +++++++++++++++++++++++
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BLACK = black --config .black.cfg.toml
 .DEFAULT_GOAL := help
 .PHONY: help
 .PHONY: clean clean-build clean-pyc clean-test
+.PHONY: install-dev install-deps-dev
 .PHONY: lint lint-fix test test-all test-coverage test-coverage-report-console test-coverage-report-html
 .PHONY: dist upload-release
 
@@ -34,6 +35,18 @@ clean-test: ## remove test, lint and coverage artifacts
 	rm -rf htmlcov/
 	rm -rf test-reports/
 	rm -rf .mypy_cache/
+
+install-dev: install-deps-dev
+install-dev: ## Install for development
+	python -m pip install --editable .
+	python -m pip check
+
+install-deps-dev: ## Install dependencies for development
+	python -m pip install -r requirements.txt
+	python -m pip check
+
+	python -m pip install -r requirements-dev.txt
+	python -m pip check
 
 lint: ## run tools for code style analysis, static type check, etc
 	flake8 --config=setup.cfg  cl_sii  scripts  tests

--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,7 @@ Tests
 
 Requirements::
 
-    pip install -r requirements.txt
-    pip install -r requirements-dev.txt
+    make install-dev
 
 Run test suite for all supported Python versions and run tools for
 code style analysis, static type check, etc::

--- a/cl_sii/__init__.py
+++ b/cl_sii/__init__.py
@@ -5,4 +5,4 @@ cl-sii Python lib
 """
 
 
-__version__ = '0.17.3'
+__version__ = '0.18.0'

--- a/cl_sii/rut/crypto_utils.py
+++ b/cl_sii/rut/crypto_utils.py
@@ -27,6 +27,8 @@ def get_subject_rut_from_certificate_pfx(pfx_file_bytes: bytes, password: Option
     )
     # https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/#cryptography.hazmat.primitives.serialization.pkcs12.load_key_and_certificates  # noqa: E501
 
+    assert x509_cert is not None
+
     subject_alt_name_ext = x509_cert.extensions.get_extension_for_class(
         cryptography.x509.extensions.SubjectAlternativeName,
     )

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,10 @@
+/*
+Commitlint Configuration
+
+Commitlint is a Git commit message linter.
+
+- Web site: https://commitlint.js.org/
+- Documentation: https://github.com/conventional-changelog/commitlint#readme
+*/
+
+module.exports = { extends: ["@cordada/commitlint-config-cordada"] };

--- a/docs/project-maintenance.rst
+++ b/docs/project-maintenance.rst
@@ -36,7 +36,7 @@ Add new entry to changelog including the changes summary (remember to format as 
 
     nano 'HISTORY.rst'
     git add 'HISTORY.rst'
-    git commit -m "HISTORY: update for new version"
+    git commit -m "chore: Update history for new version"
 
 2) Bump package version
 +++++++++++++++++++

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -115,7 +115,7 @@ requests==2.25.1
 # six
 toml==0.10.2
 tomli==2.0.0
-tqdm==4.45.0
+tqdm==4.64.0
 typed-ast==1.4.2
 typing-extensions==4.0.1
 # urllib3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ mypy==0.790
 setuptools==50.3.0
 tox==3.25.1
 twine==3.1.1
-wheel==0.35.1
+wheel==0.37.1
 
 # Packages dependencies:
 #   - black:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ flake8==4.0.1
 isort==5.10.1
 mypy==0.790
 setuptools==50.3.0
-tox==3.20.1
+tox==3.25.1
 twine==3.1.1
 wheel==0.35.1
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -102,7 +102,7 @@ packaging==20.4
 pathspec==0.9.0
 pkginfo==1.8.3
 platformdirs==2.4.1
-pluggy==0.13.1
+pluggy==1.0.0
 py==1.10.0
 pycodestyle==2.8.0
 pyflakes==2.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -100,7 +100,7 @@ mccabe==0.6.1
 mypy-extensions==0.4.3
 packaging==20.4
 pathspec==0.9.0
-pkginfo==1.7.0
+pkginfo==1.8.3
 platformdirs==2.4.1
 pluggy==0.13.1
 py==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 # note: it is mandatory to register all dependencies of the required packages.
 
 # Required packages:
-cryptography==3.3.2
+cryptography==37.0.4
 defusedxml==0.6.0
 Django>=2.2.24
 djangorestframework>=3.10.3,<3.14
@@ -24,7 +24,6 @@ signxml==2.9.0
 #   - cryptography:
 #       - cffi:
 #           - pycparser
-#       - six
 #   - Django:
 #       - pytz
 #       - sqlparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ signxml==2.9.0
 #       - pyOpenSSL
 attrs==20.3.0
 certifi==2022.6.15
-cffi==1.14.0
+cffi==1.15.1
 eight==1.0.1
 future==0.18.2
 importlib-metadata==1.6.0; python_version<'3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Django>=2.2.24
 djangorestframework>=3.10.3,<3.14
 jsonschema==3.2.0
 lxml==4.9.1
-marshmallow==2.19.5
+marshmallow==2.21.0
 pydantic==1.6.2
 pyOpenSSL==18.0.0
 pytz==2019.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ defusedxml==0.6.0
 Django>=2.2.24
 djangorestframework>=3.10.3,<3.14
 jsonschema==3.2.0
-lxml==4.6.5
+lxml==4.9.1
 marshmallow==2.19.5
 pydantic==1.6.2
 pyOpenSSL==18.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,6 @@ importlib-metadata==1.6.0; python_version<'3.8'
 pycparser==2.20
 pyrsistent==0.17.3
 # setuptools
-six==1.15.0
+six==1.16.0
 # sqlparse
 zipp==3.4.0 ; python_version < "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ signxml==2.9.0
 attrs==20.3.0
 certifi==2022.6.15
 cffi==1.14.0
-eight==1.0.0
+eight==1.0.1
 future==0.18.2
 importlib-metadata==1.6.0; python_version<'3.8'
 pycparser==2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ signxml==2.9.0
 #       - lxml
 #       - pyOpenSSL
 attrs==20.3.0
-certifi==2020.12.5
+certifi==2022.6.15
 cffi==1.14.0
 eight==1.0.0
 future==0.18.2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 requirements = [
-    'cryptography>=2.8',
+    'cryptography>=37.0.1',
     'defusedxml>=0.6.0,<1',
     'jsonschema>=3.1.1',
     'lxml>=4.6.5,<5',

--- a/tests/test_extras_mm_fields.py
+++ b/tests/test_extras_mm_fields.py
@@ -127,7 +127,7 @@ class RutFieldTest(unittest.TestCase):
 
         result = schema.load(data_invalid_2)
         self.assertDictEqual(dict(result.data), {})
-        self.assertDictEqual(dict(result.errors), {'RUT of Emisor': ['Invalid input type.']})
+        self.assertDictEqual(dict(result.errors), {'RUT of Emisor': ['Invalid type.']})
 
         result = schema.load(data_invalid_3)
         self.assertDictEqual(dict(result.data), {})
@@ -147,7 +147,7 @@ class RutFieldTest(unittest.TestCase):
         obj_invalid_3 = self.MyObj(emisor_rut='')
 
         data, errors = schema.dump(obj_invalid_1)
-        self.assertDictEqual(errors, {'emisor_rut': ['Invalid input type.']})
+        self.assertDictEqual(errors, {'emisor_rut': ['Invalid type.']})
 
         data, errors = schema.dump(obj_invalid_2)
         self.assertDictEqual(errors, {'emisor_rut': ['Not a syntactically valid RUT.']})
@@ -266,7 +266,7 @@ class TipoDteFieldTest(unittest.TestCase):
 
         result = schema.load(data_invalid_2)
         self.assertDictEqual(dict(result.data), {})
-        self.assertDictEqual(dict(result.errors), {'source field name': ['Invalid input type.']})
+        self.assertDictEqual(dict(result.errors), {'source field name': ['Invalid type.']})
 
         result = schema.load(data_invalid_3)
         self.assertDictEqual(dict(result.data), {})
@@ -290,13 +290,13 @@ class TipoDteFieldTest(unittest.TestCase):
         data, errors = schema.dump(obj_invalid_1)
         self.assertDictEqual(errors, {'tipo_dte': ['Not a valid Tipo DTE.']})
         data, errors = schema.dump(obj_invalid_2)
-        self.assertDictEqual(errors, {'tipo_dte': ['Invalid input type.']})
+        self.assertDictEqual(errors, {'tipo_dte': ['Invalid type.']})
         data, errors = schema.dump(obj_invalid_3)
-        self.assertDictEqual(errors, {'tipo_dte': ['Invalid input type.']})
+        self.assertDictEqual(errors, {'tipo_dte': ['Invalid type.']})
         data, errors = schema.dump(obj_invalid_4)
-        self.assertDictEqual(errors, {'tipo_dte': ['Invalid input type.']})
+        self.assertDictEqual(errors, {'tipo_dte': ['Invalid type.']})
         data, errors = schema.dump(obj_invalid_5)
-        self.assertDictEqual(errors, {'tipo_dte': ['Invalid input type.']})
+        self.assertDictEqual(errors, {'tipo_dte': ['Invalid type.']})
 
 
 class RcvTipoDoctoFieldTest(unittest.TestCase):
@@ -411,7 +411,7 @@ class RcvTipoDoctoFieldTest(unittest.TestCase):
 
         result = schema.load(data_invalid_2)
         self.assertDictEqual(dict(result.data), {})
-        self.assertDictEqual(dict(result.errors), {'source field name': ['Invalid input type.']})
+        self.assertDictEqual(dict(result.errors), {'source field name': ['Invalid type.']})
 
         result = schema.load(data_invalid_3)
         self.assertDictEqual(dict(result.data), {})
@@ -435,13 +435,13 @@ class RcvTipoDoctoFieldTest(unittest.TestCase):
         data, errors = schema.dump(obj_invalid_1)
         self.assertDictEqual(errors, {'tipo_docto': ["Not a valid RCV's Tipo de Documento."]})
         data, errors = schema.dump(obj_invalid_2)
-        self.assertDictEqual(errors, {'tipo_docto': ['Invalid input type.']})
+        self.assertDictEqual(errors, {'tipo_docto': ['Invalid type.']})
         data, errors = schema.dump(obj_invalid_3)
-        self.assertDictEqual(errors, {'tipo_docto': ['Invalid input type.']})
+        self.assertDictEqual(errors, {'tipo_docto': ['Invalid type.']})
         data, errors = schema.dump(obj_invalid_4)
-        self.assertDictEqual(errors, {'tipo_docto': ['Invalid input type.']})
+        self.assertDictEqual(errors, {'tipo_docto': ['Invalid type.']})
         data, errors = schema.dump(obj_invalid_5)
-        self.assertDictEqual(errors, {'tipo_docto': ['Invalid input type.']})
+        self.assertDictEqual(errors, {'tipo_docto': ['Invalid type.']})
 
 
 class RcvPeriodoTributarioFieldTest(unittest.TestCase):
@@ -583,7 +583,7 @@ class RcvPeriodoTributarioFieldTest(unittest.TestCase):
 
         result = schema.load(data_invalid_2)
         self.assertEqual(dict(result.data), {})
-        self.assertEqual(dict(result.errors), {'source field name': ['Invalid input type.']})
+        self.assertEqual(dict(result.errors), {'source field name': ['Invalid type.']})
 
         result = schema.load(data_invalid_3)
         self.assertEqual(dict(result.data), {})
@@ -616,12 +616,12 @@ class RcvPeriodoTributarioFieldTest(unittest.TestCase):
         data, errors = schema.dump(obj_invalid_1)
         self.assertEqual(errors, {'periodo_tributario': ["Not a valid RCV Periodo Tributario."]})
         data, errors = schema.dump(obj_invalid_2)
-        self.assertEqual(errors, {'periodo_tributario': ['Invalid input type.']})
+        self.assertEqual(errors, {'periodo_tributario': ['Invalid type.']})
         data, errors = schema.dump(obj_invalid_3)
-        self.assertEqual(errors, {'periodo_tributario': ['Invalid input type.']})
+        self.assertEqual(errors, {'periodo_tributario': ['Invalid type.']})
         data, errors = schema.dump(obj_invalid_4)
         self.assertEqual(errors, {'periodo_tributario': ["Not a valid RCV Periodo Tributario."]})
         data, errors = schema.dump(obj_invalid_5)
-        self.assertEqual(errors, {'periodo_tributario': ['Invalid input type.']})
+        self.assertEqual(errors, {'periodo_tributario': ['Invalid type.']})
         data, errors = schema.dump(obj_invalid_6)
         self.assertEqual(errors, {'periodo_tributario': ["Not a valid RCV Periodo Tributario."]})

--- a/tests/test_libs_crypto_utils.py
+++ b/tests/test_libs_crypto_utils.py
@@ -915,7 +915,9 @@ class LoadPemX509CertTest(unittest.TestCase):
     def test_load_der_x509_cert_fail_value_error(self) -> None:
         with self.assertRaises(ValueError) as cm:
             load_der_x509_cert(b'hello')
-        self.assertEqual(cm.exception.args, ("Unable to load certificate",))
+        self.assertEqual(
+            cm.exception.args, ("error parsing asn1 value: ParseError { kind: ShortData }",)
+        )
 
     def test_load_pem_x509_cert_ok(self) -> None:
         cert_der_bytes = utils.read_test_file_bytes(
@@ -1000,9 +1002,9 @@ class LoadPemX509CertTest(unittest.TestCase):
         self.assertEqual(
             cm.exception.args,
             (
-                "Unable to load certificate. See "
-                "https://cryptography.io/en/latest/faq.html#why-can-t-i-import-my-pem-file "
-                "for more details.",
+                "Unable to load PEM file. See "
+                "https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file "
+                "for more details. InvalidData(InvalidLength)",
             ),
         )
 

--- a/tests/test_libs_xml_utils.py
+++ b/tests/test_libs_xml_utils.py
@@ -250,7 +250,7 @@ class FunctionVerifyXmlSignatureTest(unittest.TestCase):
             verify_xml_signature(xml_doc, trusted_x509_cert=cert)
         self.assertEqual(
             cm.exception.args,
-            ("Signature verification failed: header too long",),
+            ("Signature verification failed: []",),
         )
 
     def test_fail_included_cert_not_from_a_known_ca(self) -> None:


### PR DESCRIPTION
- (PR #343, 2022-07-08) chore: Update Dependabot configuration
- (PR #281, 2022-07-21) build(deps): bump six from 1.15.0 to 1.16.0
- (PR #340, 2022-07-21) build(deps): bump lxml from 4.6.5 to 4.9.1
- (PR #334, 2022-07-22) build(deps): bump certifi from 2020.12.5 to 2022.6.15
- (PR #350, 2022-08-11) chore: Add code owners
- (PR #352, 2022-08-18) chore: Change Dependabot schedule interval from `weekly` to `monthly`
- (PR #338, 2022-08-22) build(deps-dev): bump tox from 3.20.1 to 3.25.1
- (PR #342, 2022-08-22) chore(deps): Bump cryptography from 3.3.2 to 37.0.4
- (PR #286, 2022-08-24) build(deps): bump eight from 1.0.0 to 1.0.1
- (PR #355, 2022-08-24) chore: Add Make tasks for installation
- (PR #332, 2022-08-24) build(deps-dev): bump pkginfo from 1.7.0 to 1.8.3
- (PR #288, 2022-08-24) build(deps): bump pluggy from 0.13.1 to 1.0.0
- (PR #287, 2022-08-25) build(deps): bump wheel from 0.35.1 to 0.37.1
- (PR #356, 2022-08-25) chore(deps): bump marshmallow from 2.19.5 to 2.21.0
- (PR #339, 2022-08-25) build(deps): bump cffi from 1.14.0 to 1.15.1
- (PR #312, 2022-08-25) build(deps-dev): bump tqdm from 4.45.0 to 4.64.0
- (PR #359, 2022-08-25) chore: Add Git commit linter
- (PR #360, 2022-08-26) Update files for Git commit linter