### PR TITLE
chore(deps): Update 'pydantic' from version 1.6.2 to 1.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ djangorestframework>=3.10.3,<3.14
 jsonschema==3.2.0
 lxml==4.9.1
 marshmallow==2.21.0
-pydantic==1.6.2
+pydantic==1.10.1
 pyOpenSSL==18.0.0
 pytz==2022.2.1
 signxml==2.9.0
@@ -34,6 +34,8 @@ signxml==2.9.0
 #       - pyrsistent
 #       - setuptools
 #       - six
+#   - pydantic:
+#       - typing-extensions
 #   - pyOpenSSL:
 #       - cryptography
 #       - six
@@ -55,4 +57,5 @@ pyrsistent==0.17.3
 # setuptools
 six==1.16.0
 # sqlparse
+typing-extensions==4.3.0
 zipp==3.4.0 ; python_version < "3.8"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     'jsonschema>=3.1.1',
     'lxml>=4.6.5,<5',
     'marshmallow>=2.19.2,<3',
-    'pydantic>=1.6.2',
+    'pydantic>=1.6.2,!=1.7.*,!=1.8.*,!=1.9.*',
     # TODO: remove upper-bound after a new release of 'signxml' drops the requirement 'pyOpenSSL<21'
     'pyOpenSSL>=18.0.0,<21',
     'pytz>=2019.3',


### PR DESCRIPTION
Changelog:

- 1.10.1 (2022-08-31):
  https://github.com/pydantic/pydantic/blob/v1.10.1/HISTORY.md#v1101-2022-08-31
- 1.10.0 (2022-08-30):
  https://github.com/pydantic/pydantic/blob/v1.10.0/HISTORY.md#v1100-2022-08-30
- …
- 1.9.0 (2021-12-31):
  https://github.com/pydantic/pydantic/blob/v1.10.0/HISTORY.md#v190-2021-12-31
- 1.8.2 (2021-05-11):
  https://pydantic-docs.helpmanual.io/changelog/#v182-2021-05-11
- 1.8.1 (2021-03-03):
  https://pydantic-docs.helpmanual.io/changelog/#v181-2021-03-03
- 1.8 (2021-02-26):
  https://pydantic-docs.helpmanual.io/changelog/#v18-2021-02-26
- …
- 1.7 (2020-10-26):
  https://pydantic-docs.helpmanual.io/changelog/#v17-2020-10-26

Code diff: https://github.com/pydantic/pydantic/compare/v1.6.2...v1.10.1

---

Add version exclusions for Pydantic 1.7.*, 1.8.*, and 1.9.* to Setuptools configuration (`setup.py`) because those versions have a buggy `dataclasses` implementation (see GitHub issue https://github.com/pydantic/pydantic/issues/2162, created by @jtrh).

```python
>>> import packaging.specifiers
>>> pydantic_specifier_set = packaging.specifiers.SpecifierSet('>=1.6.2,!=1.7.*,!=1.8.*,!=1.9.*')
>>> pydantic_specifier_set.contains('1.6.2')
True
>>> pydantic_specifier_set.contains('1.7')
False
>>> pydantic_specifier_set.contains('1.7.0')
False
>>> pydantic_specifier_set.contains('1.8.1')
False
>>> pydantic_specifier_set.contains('1.9.2')
False
>>> pydantic_specifier_set.contains('1.10.0a1')
False
>>> pydantic_specifier_set.contains('1.10.0b1')
False
>>> pydantic_specifier_set.contains('1.10.0')
True
```