### PR TITLE
fix(deps): Remove Python version constraint for `importlib-metadata`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,7 +46,7 @@ flake8==4.0.1
     # via -r requirements-dev.in
 idna==2.10
     # via requests
-importlib-metadata==1.6.0 ; python_version < "3.8"
+importlib-metadata==1.6.0
     # via
     #   -c requirements.txt
     #   click

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ cryptography==37.0.4
 defusedxml==0.6.0
 Django>=2.2.24
 djangorestframework>=3.10.3,<3.14
-importlib-metadata==1.6.0 ; python_version < "3.8"
+importlib-metadata==1.6.0
 jsonschema==3.2.0
 lxml==4.9.1
 marshmallow==2.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ eight==1.0.1
     # via signxml
 future==0.18.2
     # via eight
-importlib-metadata==1.6.0 ; python_version < "3.8"
+importlib-metadata==1.6.0
     # via
     #   -r requirements.in
     #   jsonschema


### PR DESCRIPTION
Ref: https://cordada.aha.io/features/COMPCLDATA-130