### PR TITLE
Enable Python dependency sync check for Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,16 +67,16 @@ jobs:
             make test-coverage-report-console
             make test-coverage-report-html
 
-      # - when:
-      #     condition:
-      #       matches: { pattern: "^3\\.7\\.\\d+$", value: << parameters.python_version >> }
-      #     steps:
-      - run:
-          name: Check that compiled Python dependency manifests are up-to-date with their sources
-          command: |
-            . venv/bin/activate
-            make --ignore-errors python-deps-sync-check
-            # FIXME: Ignore errors because of issues related to testing with Python versions.
+      - when:
+          condition:
+            # FIXME: There are issues related to testing with multiple Python versions.
+            matches: { pattern: "^3\\.7\\.\\d+$", value: << parameters.python_version >> }
+          steps:
+            - run:
+                name: Check that compiled Python dependency manifests are up-to-date with their sources
+                command: |
+                  . venv/bin/activate
+                  make python-deps-sync-check
 
       - store_artifacts:
           path: test-reports

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,6 +46,16 @@ flake8==4.0.1
     # via -r requirements-dev.in
 idna==2.10
     # via requests
+importlib-metadata==1.6.0
+    # via
+    #   -c requirements.txt
+    #   click
+    #   flake8
+    #   keyring
+    #   pluggy
+    #   tox
+    #   twine
+    #   virtualenv
 isort==5.10.1
     # via -r requirements-dev.in
 jeepney==0.8.0
@@ -115,6 +125,10 @@ tqdm==4.64.0
     # via twine
 twine==3.1.1
     # via -r requirements-dev.in
+typed-ast==1.5.4
+    # via
+    #   black
+    #   mypy
 typing-extensions==4.3.0
     # via
     #   -c requirements.txt
@@ -128,6 +142,10 @@ webencodings==0.5.1
     # via bleach
 wheel==0.38.4
     # via -r requirements-dev.in
+zipp==3.8.1
+    # via
+    #   -c requirements.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,11 @@ django==3.2.16
 djangorestframework==3.14.0
     # via -r requirements.in
 importlib-metadata==1.6.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   jsonschema
+importlib-resources==5.10.0
+    # via jsonschema
 jsonschema==4.16.0
     # via -r requirements.in
 lxml==4.9.1
@@ -35,6 +39,8 @@ lxml==4.9.1
     #   signxml
 marshmallow==2.21.0
     # via -r requirements.in
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
 pycparser==2.20
     # via cffi
 pydantic==1.10.2
@@ -55,6 +61,11 @@ signxml==2.10.1
 sqlparse==0.4.2
     # via django
 typing-extensions==4.3.0
-    # via pydantic
+    # via
+    #   asgiref
+    #   jsonschema
+    #   pydantic
 zipp==3.8.1
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources


### PR DESCRIPTION
- chore(deps): Recompile Python dependency manifests using Python 3.7.
- chore: Enable Python dependency sync check for Python 3.7.