### PR TITLE
Improve type checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ install-deps-dev: ## Install dependencies for development
 
 lint: ## run tools for code style analysis, static type check, etc
 	flake8 --config=setup.cfg  cl_sii  scripts  tests
-	mypy --config-file setup.cfg  cl_sii  scripts
+	mypy cl_sii  scripts
 	isort --check-only .
 	$(BLACK) --check .
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ install-deps-dev: ## Install dependencies for development
 
 lint: ## run tools for code style analysis, static type check, etc
 	flake8 --config=setup.cfg  cl_sii  scripts  tests
-	mypy cl_sii  scripts
+	mypy
 	isort --check-only .
 	$(BLACK) --check .
 

--- a/cl_sii/libs/tz_utils.py
+++ b/cl_sii/libs/tz_utils.py
@@ -11,7 +11,7 @@ These concept are defined in Python standard library module datetime
 
 """
 from datetime import datetime
-from typing import Union
+from typing import Optional, Union
 
 import pytz
 import pytz.tzinfo
@@ -85,7 +85,7 @@ def convert_naive_dt_to_tz_aware(dt: datetime, tz: PytzTimezone) -> datetime:
     return dt_tz_aware
 
 
-def convert_tz_aware_dt_to_naive(dt: datetime, tz: PytzTimezone = None) -> datetime:
+def convert_tz_aware_dt_to_naive(dt: datetime, tz: Optional[PytzTimezone] = None) -> datetime:
     """
     Convert a timezone-aware datetime object to an offset-naive one.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,53 @@
+[mypy]
+python_version = 3.7
+platform = linux
+plugins =
+    pydantic.mypy
+
+follow_imports = normal
+ignore_missing_imports = False
+strict_optional = True
+disallow_untyped_defs = True
+check_untyped_defs = True
+warn_return_any = True
+
+show_column_numbers = True
+show_error_codes = True
+show_error_context = True
+error_summary = True
+
+[mypy-cryptography.*]
+ignore_missing_imports = True
+
+[mypy-defusedxml.*]
+ignore_missing_imports = True
+
+[mypy-django.*]
+ignore_missing_imports = True
+
+[mypy-jsonschema]
+ignore_missing_imports = True
+
+[mypy-lxml.*]
+ignore_missing_imports = True
+
+[mypy-marshmallow.*]
+ignore_missing_imports = True
+
+[mypy-OpenSSL.*]
+ignore_missing_imports = True
+
+[mypy-signxml.*]
+ignore_missing_imports = True
+
+[mypy-rest_framework.*]
+ignore_missing_imports = True
+
+[mypy-pytz.*]
+ignore_missing_imports = True
+
+[pydantic-mypy]
+init_forbid_extra = True
+init_typed = True
+warn_required_dynamic_aliases = True
+warn_untyped_fields = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,9 @@
 [mypy]
 python_version = 3.7
 platform = linux
+files =
+    cl_sii,
+    scripts
 plugins =
     pydantic.mypy
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -46,9 +46,6 @@ ignore_missing_imports = True
 [mypy-rest_framework.*]
 ignore_missing_imports = True
 
-[mypy-pytz.*]
-ignore_missing_imports = True
-
 [pydantic-mypy]
 init_forbid_extra = True
 init_typed = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -40,9 +40,6 @@ ignore_missing_imports = True
 [mypy-OpenSSL.*]
 ignore_missing_imports = True
 
-[mypy-signxml.*]
-ignore_missing_imports = True
-
 [mypy-rest_framework.*]
 ignore_missing_imports = True
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -13,4 +13,5 @@ isort==5.10.1
 mypy==0.991
 tox==3.25.1
 twine==3.1.1
+types-pytz==2022.7.1.0
 wheel==0.38.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -129,6 +129,8 @@ typed-ast==1.5.4
     # via
     #   black
     #   mypy
+types-pytz==2022.7.1.0
+    # via -r requirements-dev.in
 typing-extensions==4.3.0
     # via
     #   -c requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,60 +16,6 @@ show_missing = True
 [coverage:html]
 directory = test-reports/coverage/html
 
-[mypy]
-python_version = 3.7
-platform = linux
-plugins =
-    pydantic.mypy
-
-follow_imports = normal
-ignore_missing_imports = False
-strict_optional = True
-disallow_untyped_defs = True
-check_untyped_defs = True
-warn_return_any = True
-
-show_column_numbers = True
-show_error_codes = True
-show_error_context = True
-error_summary = True
-
-[mypy-cryptography.*]
-ignore_missing_imports = True
-
-[mypy-defusedxml.*]
-ignore_missing_imports = True
-
-[mypy-django.*]
-ignore_missing_imports = True
-
-[mypy-jsonschema]
-ignore_missing_imports = True
-
-[mypy-lxml.*]
-ignore_missing_imports = True
-
-[mypy-marshmallow.*]
-ignore_missing_imports = True
-
-[mypy-OpenSSL.*]
-ignore_missing_imports = True
-
-[mypy-signxml.*]
-ignore_missing_imports = True
-
-[mypy-rest_framework.*]
-ignore_missing_imports = True
-
-[mypy-pytz.*]
-ignore_missing_imports = True
-
-[pydantic-mypy]
-init_forbid_extra = True
-init_typed = True
-warn_required_dynamic_aliases = True
-warn_untyped_fields = True
-
 [flake8]
 ignore =
     # W503 line break before binary operator

--- a/tests/test_dte_constants.py
+++ b/tests/test_dte_constants.py
@@ -5,7 +5,7 @@ from cl_sii.dte.constants import TipoDte
 
 
 class TipoDteTest(unittest.TestCase):
-    def test_members(self):
+    def test_members(self) -> None:
         self.assertSetEqual(
             {x for x in TipoDte},
             {
@@ -19,7 +19,7 @@ class TipoDteTest(unittest.TestCase):
             },
         )
 
-    def test_FACTURA_ELECTRONICA(self):
+    def test_FACTURA_ELECTRONICA(self) -> None:
         value = TipoDte.FACTURA_ELECTRONICA
 
         self.assertEqual(value.name, 'FACTURA_ELECTRONICA')
@@ -37,7 +37,7 @@ class TipoDteTest(unittest.TestCase):
         for (result, expected) in assertions:
             self.assertEqual(result, expected)
 
-    def test_FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA(self):
+    def test_FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA(self) -> None:
         value = TipoDte.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA
 
         self.assertEqual(value.name, 'FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA')
@@ -55,7 +55,7 @@ class TipoDteTest(unittest.TestCase):
         for (result, expected) in assertions:
             self.assertTrue(result is expected)
 
-    def test_LIQUIDACION_FACTURA_ELECTRONICA(self):
+    def test_LIQUIDACION_FACTURA_ELECTRONICA(self) -> None:
         value = TipoDte.LIQUIDACION_FACTURA_ELECTRONICA
 
         self.assertEqual(value.name, 'LIQUIDACION_FACTURA_ELECTRONICA')
@@ -73,7 +73,7 @@ class TipoDteTest(unittest.TestCase):
         for (result, expected) in assertions:
             self.assertEqual(result, expected)
 
-    def test_FACTURA_COMPRA_ELECTRONICA(self):
+    def test_FACTURA_COMPRA_ELECTRONICA(self) -> None:
         value = TipoDte.FACTURA_COMPRA_ELECTRONICA
 
         self.assertEqual(value.name, 'FACTURA_COMPRA_ELECTRONICA')
@@ -91,7 +91,7 @@ class TipoDteTest(unittest.TestCase):
         for (result, expected) in assertions:
             self.assertTrue(result is expected)
 
-    def test_GUIA_DESPACHO_ELECTRONICA(self):
+    def test_GUIA_DESPACHO_ELECTRONICA(self) -> None:
         value = TipoDte.GUIA_DESPACHO_ELECTRONICA
 
         self.assertEqual(value.name, 'GUIA_DESPACHO_ELECTRONICA')
@@ -109,7 +109,7 @@ class TipoDteTest(unittest.TestCase):
         for (result, expected) in assertions:
             self.assertTrue(result is expected)
 
-    def test_NOTA_DEBITO_ELECTRONICA(self):
+    def test_NOTA_DEBITO_ELECTRONICA(self) -> None:
         value = TipoDte.NOTA_DEBITO_ELECTRONICA
 
         self.assertEqual(value.name, 'NOTA_DEBITO_ELECTRONICA')
@@ -127,7 +127,7 @@ class TipoDteTest(unittest.TestCase):
         for (result, expected) in assertions:
             self.assertTrue(result is expected)
 
-    def test_NOTA_CREDITO_ELECTRONICA(self):
+    def test_NOTA_CREDITO_ELECTRONICA(self) -> None:
         value = TipoDte.NOTA_CREDITO_ELECTRONICA
 
         self.assertEqual(value.name, 'NOTA_CREDITO_ELECTRONICA')

--- a/tests/test_dte_data_models.py
+++ b/tests/test_dte_data_models.py
@@ -317,7 +317,7 @@ class DteDataL2Test(unittest.TestCase):
             receptor_email=None,
         )
 
-    def test_constants_match(self):
+    def test_constants_match(self) -> None:
         self.assertEqual(
             DteXmlData.DATETIME_FIELDS_TZ,
             DteDataL2.DATETIME_FIELDS_TZ,
@@ -775,7 +775,7 @@ class DteXmlDataTest(unittest.TestCase):
             receptor_email=None,
         )
 
-    def test_constants_match(self):
+    def test_constants_match(self) -> None:
         self.assertEqual(
             DteXmlData.DATETIME_FIELDS_TZ,
             DteDataL2.DATETIME_FIELDS_TZ,

--- a/tests/test_dte_parse.py
+++ b/tests/test_dte_parse.py
@@ -432,7 +432,7 @@ class FunctionParseDteXmlTest(unittest.TestCase):
             )
         )
 
-    def test_data(self):
+    def test_data(self) -> None:
         self.assertEqual(
             self._TEST_DTE_1_SIGNATURE_VALUE,
             b'~\xc6\x0f\xe6\x9f\xe55\xfa\x1f\x03?\x0f9(k&:\x97t\x14\xcd6\xdb\xef\xe3\xf4\xd6'

--- a/tests/test_libs_csv_utils.py
+++ b/tests/test_libs_csv_utils.py
@@ -4,6 +4,6 @@ from cl_sii.libs.csv_utils import create_csv_dict_reader  # noqa: F401
 
 
 class FunctionsTest(unittest.TestCase):
-    def test_create_csv_dict_reader(self):
+    def test_create_csv_dict_reader(self) -> None:
         # TODO: implement for 'create_csv_dict_reader'.
         pass

--- a/tests/test_libs_dataclass_utils.py
+++ b/tests/test_libs_dataclass_utils.py
@@ -34,7 +34,7 @@ class DataclassBWithMixin(DataclassBWithoutMixin, DcDeepCompareMixin):
 
 
 class NotADataclassWithMixin(DcDeepCompareMixin):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: object, **kwargs: object) -> None:
         self.args = args
         self.kwargs = kwargs
 

--- a/tests/test_libs_encoding_utils.py
+++ b/tests/test_libs_encoding_utils.py
@@ -8,14 +8,14 @@ from cl_sii.libs.encoding_utils import (  # noqa: F401
 
 
 class FunctionsTest(unittest.TestCase):
-    def test_clean_base64(self):
+    def test_clean_base64(self) -> None:
         # TODO: implement for function 'clean_base64'.
         pass
 
-    def test_decode_base64_strict(self):
+    def test_decode_base64_strict(self) -> None:
         # TODO: implement for function 'decode_base64_strict'.
         pass
 
-    def test_validate_base64(self):
+    def test_validate_base64(self) -> None:
         # TODO: implement for function 'validate_base64'.
         pass

--- a/tests/test_libs_io_utils.py
+++ b/tests/test_libs_io_utils.py
@@ -8,7 +8,7 @@ from cl_sii.libs.io_utils import with_encoding_utf8, with_mode_binary, with_mode
 
 
 class FunctionsTest(unittest.TestCase):
-    def test_with_encoding_utf8(self):
+    def test_with_encoding_utf8(self) -> None:
         filename = pathlib.Path(__file__).with_name('test_libs_io_utils-test-file-1.tmp')
         filename.touch()
 
@@ -99,7 +99,7 @@ class FunctionsTest(unittest.TestCase):
 
         filename.unlink()
 
-    def test_with_mode_x(self):
+    def test_with_mode_x(self) -> None:
         # For the sake of simplicity test here both 'with_mode_binary' and 'with_mode_text'.
 
         filename = pathlib.Path(__file__).with_name('test_libs_io_utils-test-file-2.tmp')

--- a/tests/test_libs_mm_utils.py
+++ b/tests/test_libs_mm_utils.py
@@ -13,6 +13,6 @@ class CustomMarshmallowDateFieldTest(unittest.TestCase):
 
 
 class FunctionsTest(unittest.TestCase):
-    def test_validate_no_unexpected_input_fields(self):
+    def test_validate_no_unexpected_input_fields(self) -> None:
         # TODO: implement for 'validate_no_unexpected_input_fields'.
         pass

--- a/tests/test_libs_rows_processing.py
+++ b/tests/test_libs_rows_processing.py
@@ -7,10 +7,10 @@ from cl_sii.libs.rows_processing import (  # noqa: F401
 
 
 class FunctionsTest(unittest.TestCase):
-    def test_csv_rows_mm_deserialization_iterator(self):
+    def test_csv_rows_mm_deserialization_iterator(self) -> None:
         # TODO: implement for 'csv_rows_mm_deserialization_iterator'.
         pass
 
-    def test_rows_mm_deserialization_iterator(self):
+    def test_rows_mm_deserialization_iterator(self) -> None:
         # TODO: implement for 'rows_mm_deserialization_iterator'.
         pass

--- a/tests/test_rcv_constants.py
+++ b/tests/test_rcv_constants.py
@@ -6,7 +6,7 @@ from cl_sii.rcv.constants import RcEstadoContable, RcvKind, RcvTipoDocto  # noqa
 
 
 class RcvKindTest(unittest.TestCase):
-    def test_members(self):
+    def test_members(self) -> None:
         self.assertSetEqual(
             {x for x in RcvKind},
             {
@@ -15,10 +15,10 @@ class RcvKindTest(unittest.TestCase):
             },
         )
 
-    def test_values_type(self):
+    def test_values_type(self) -> None:
         self.assertSetEqual({type(x.value) for x in RcvKind}, {str})
 
-    def test_is_estado_contable_compatible(self):
+    def test_is_estado_contable_compatible(self) -> None:
         self.assertTrue(RcvKind.VENTAS.is_estado_contable_compatible(None))
         self.assertTrue(RcvKind.COMPRAS.is_estado_contable_compatible(RcEstadoContable.REGISTRO))
         self.assertTrue(RcvKind.COMPRAS.is_estado_contable_compatible(RcEstadoContable.NO_INCLUIR))
@@ -33,7 +33,7 @@ class RcvKindTest(unittest.TestCase):
 
 
 class RcEstadoContableTest(unittest.TestCase):
-    def test_members(self):
+    def test_members(self) -> None:
         self.assertSetEqual(
             {x for x in RcEstadoContable},
             {
@@ -44,12 +44,12 @@ class RcEstadoContableTest(unittest.TestCase):
             },
         )
 
-    def test_values_type(self):
+    def test_values_type(self) -> None:
         self.assertSetEqual({type(x.value) for x in RcEstadoContable}, {str})
 
 
 class RcvTipoDoctoTest(unittest.TestCase):
-    def test_members(self):
+    def test_members(self) -> None:
         self.assertSetEqual(
             {x for x in RcvTipoDocto},
             {
@@ -105,16 +105,16 @@ class RcvTipoDoctoTest(unittest.TestCase):
             },
         )
 
-    def test_values_type(self):
+    def test_values_type(self) -> None:
         self.assertSetEqual({type(x.value) for x in RcvTipoDocto}, {int})
 
-    def test_of_some_member(self):
+    def test_of_some_member(self) -> None:
         value = RcvTipoDocto.FACTURA_ELECTRONICA
 
         self.assertEqual(value.name, 'FACTURA_ELECTRONICA')
         self.assertEqual(value.value, 33)
 
-    def test_as_tipo_dte(self):
+    def test_as_tipo_dte(self) -> None:
         self.assertEqual(
             RcvTipoDocto.FACTURA_ELECTRONICA.as_tipo_dte(),
             TipoDte.FACTURA_ELECTRONICA,

--- a/tests/test_rcv_data_models.py
+++ b/tests/test_rcv_data_models.py
@@ -212,7 +212,7 @@ class RvDetalleEntryTest(unittest.TestCase):
             ),
         )
 
-    def test_constants_match(self):
+    def test_constants_match(self) -> None:
         self.assertEqual(
             RvDetalleEntry.DATETIME_FIELDS_TZ,
             RcvDetalleEntry.DATETIME_FIELDS_TZ,
@@ -364,7 +364,7 @@ class RcRegistroDetalleEntryTest(unittest.TestCase):
             ),
         )
 
-    def test_constants_match(self):
+    def test_constants_match(self) -> None:
         self.assertEqual(
             RcRegistroDetalleEntry.DATETIME_FIELDS_TZ,
             RcvDetalleEntry.DATETIME_FIELDS_TZ,
@@ -487,7 +487,7 @@ class RcReclamadoDetalleEntryTest(unittest.TestCase):
             ),
         )
 
-    def test_constants_match(self):
+    def test_constants_match(self) -> None:
         self.assertEqual(
             RcReclamadoDetalleEntry.DATETIME_FIELDS_TZ,
             RcvDetalleEntry.DATETIME_FIELDS_TZ,

--- a/tests/test_rtc_data_models.py
+++ b/tests/test_rtc_data_models.py
@@ -614,7 +614,7 @@ class CesionL1Test(CesionL0Test):
         )
         self.assertEqual(obj.as_dict(), expected_output)
 
-    def test_as_cesion_l0(self):
+    def test_as_cesion_l0(self) -> None:
         self._set_obj_1()
 
         obj = self.obj_1
@@ -634,7 +634,7 @@ class CesionL1Test(CesionL0Test):
         )
         self.assertEqual(obj.as_cesion_l0(), expected_output)
 
-    def test_as_dte_data_l1(self):
+    def test_as_dte_data_l1(self) -> None:
         self._set_obj_1()
 
         obj = self.obj_1
@@ -833,7 +833,7 @@ class CesionL2Test(CesionL1Test):
         )
         self.assertEqual(obj.as_dict(), expected_output)
 
-    def test_as_cesion_l1(self):
+    def test_as_cesion_l1(self) -> None:
         self._set_obj_1()
 
         obj = self.obj_1
@@ -858,7 +858,7 @@ class CesionL2Test(CesionL1Test):
         )
         self.assertEqual(obj.as_cesion_l1(), expected_output)
 
-    def test_as_dte_data_l2(self):
+    def test_as_dte_data_l2(self) -> None:
         self._set_obj_1()
 
         obj = self.obj_1

--- a/tests/test_rtc_parse_aec.py
+++ b/tests/test_rtc_parse_aec.py
@@ -19,7 +19,7 @@ class AecXmlSchemaTest(unittest.TestCase):
     """
 
     @unittest.skip("TODO: Implement for 'AEC_XML_SCHEMA_OBJ'.")
-    def test_AEC_XML_SCHEMA_OBJ(self):
+    def test_AEC_XML_SCHEMA_OBJ(self) -> None:
         self.assertIsNotNone(AEC_XML_SCHEMA_OBJ)
 
 


### PR DESCRIPTION
- chore: Move Mypy configuration to separate configuration file.
- chore: Move list of files to be scanned by Mypy to Mypy configuration file.
- chore: Install Python package 'types-pytz'.
- chore: Enable type checking for `pytz`.
- chore: Enable type checking for `signxml`.
- chore: Add missing return type annotations to tests.