### PR TITLE
Improve type checking

### DIFF
--- a/cl_sii/libs/xml_utils.py
+++ b/cl_sii/libs/xml_utils.py
@@ -362,7 +362,7 @@ def write_xml_doc(xml_doc: XmlElement, output: IO[bytes]) -> None:
 
 def verify_xml_signature(
     xml_doc: XmlElement,
-    trusted_x509_cert: Union[crypto_utils.X509Cert, crypto_utils._X509CertOpenSsl] = None,
+    trusted_x509_cert: Optional[Union[crypto_utils.X509Cert, crypto_utils._X509CertOpenSsl]] = None,
     xml_verifier: Optional[signxml.XMLVerifier] = None,
     xml_verifier_supports_multiple_signatures: bool = False,
 ) -> Tuple[bytes, XmlElementTree, XmlElementTree]:

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,9 +25,6 @@ ignore_missing_imports = True
 [mypy-django.*]
 ignore_missing_imports = True
 
-[mypy-jsonschema]
-ignore_missing_imports = True
-
 [mypy-lxml.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,9 +37,6 @@ ignore_missing_imports = True
 [mypy-marshmallow.*]
 ignore_missing_imports = True
 
-[mypy-OpenSSL.*]
-ignore_missing_imports = True
-
 [mypy-rest_framework.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,9 +19,6 @@ show_error_codes = True
 show_error_context = True
 error_summary = True
 
-[mypy-cryptography.*]
-ignore_missing_imports = True
-
 [mypy-defusedxml.*]
 ignore_missing_imports = True
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -13,6 +13,7 @@ isort==5.10.1
 mypy==0.991
 tox==3.25.1
 twine==3.1.1
+types-jsonschema==4.17.0.3
 types-pyOpenSSL==23.0.0.2
 types-pytz==2022.7.1.0
 wheel==0.38.4

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -13,5 +13,6 @@ isort==5.10.1
 mypy==0.991
 tox==3.25.1
 twine==3.1.1
+types-pyOpenSSL==23.0.0.2
 types-pytz==2022.7.1.0
 wheel==0.38.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -130,6 +130,8 @@ typed-ast==1.5.4
     # via
     #   black
     #   mypy
+types-jsonschema==4.17.0.3
+    # via -r requirements-dev.in
 types-pyopenssl==23.0.0.2
     # via -r requirements-dev.in
 types-pytz==2022.7.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,6 +34,7 @@ cryptography==38.0.4
     # via
     #   -c requirements.txt
     #   secretstorage
+    #   types-pyopenssl
 distlib==0.3.6
     # via virtualenv
 docutils==0.19
@@ -129,6 +130,8 @@ typed-ast==1.5.4
     # via
     #   black
     #   mypy
+types-pyopenssl==23.0.0.2
+    # via -r requirements-dev.in
 types-pytz==2022.7.1.0
     # via -r requirements-dev.in
 typing-extensions==4.3.0


### PR DESCRIPTION
- chore: Install Python package 'types-pyOpenSSL'.
- chore: Enable type checking for `OpenSSL`.
- chore: Enable type checking for `cryptography`.
- chore: Install Python package 'types-jsonschema'.
- chore: Enable type checking for `jsonschema`.