### PR TITLE
fix(data.cte): Add JSON files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include HISTORY.md
 include LICENSE
 include README.md
+include cl_sii/data/cte/*.json
 recursive-include cl_sii *py
 recursive-include cl_sii/data/cte/schemas-json *.schema.json
 recursive-include cl_sii/data/ref/factura_electronica/schemas-xml *.xsd


### PR DESCRIPTION
The file `f29_datos_obj_missing_key_fixes.json` was not being included in the library releases.

Ref: https://cordada.aha.io/requirements/COMPCLDATA-215-1
Ref: https://cordada.aha.io/features/COMPCLDATA-215
Ref: https://github.com/fyntex/lib-cl-sii-python/pull/440