### PR TITLE
fix(data.cte): Add missing codes to files used by schema validator

### DIFF
--- a/cl_sii/data/cte/f29_datos_obj_missing_key_fixes.json
+++ b/cl_sii/data/cte/f29_datos_obj_missing_key_fixes.json
@@ -1,8 +1,12 @@
 {
   "glosa": {
-    "049": "(Desconocido)"
+    "049": "(Desconocido)",
+    "156": "BASE IMPTO.A74,T.V.",
+    "157": "RET..ART74,T.VAR"
   },
   "tipos": {
-    "049": "M"
+    "049": "M",
+    "156": "M",
+    "157": "M"
   }
 }


### PR DESCRIPTION
Add codes `156` and `157` to file used by schema validator :func:`cte_f29_datos_schema_best_effort_validator`, since these codes are currently missing in the `tipos` section of the F29 file.

Ref: https://cordada.aha.io/requirements/COMPCLDATA-215-1
Ref: https://cordada.aha.io/features/COMPCLDATA-215
Ref: https://github.com/fyntex/lib-cl-sii-python/pull/440