### PR TITLE
Release v0.22.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.22.1
+current_version = 0.22.2
 commit = True
 tag = False
 message = chore: Bump version from {current_version} to {new_version}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 0.22.2 (2023-03-10)
+
+- (PR #427, 2023-03-10) chore(deps-dev): Bump black from 22.12.0 to 23.1.0
+- (PR #455, 2023-03-10) fix(data.cte): Add missing codes to files used by schema validator
+
 ## 0.22.1 (2023-03-09)
 
 - (PR #452, 2023-03-09) fix(data.cte): Add JSON files to MANIFEST.in

--- a/cl_sii/__init__.py
+++ b/cl_sii/__init__.py
@@ -5,4 +5,4 @@ cl-sii Python lib
 """
 
 
-__version__ = '0.22.1'
+__version__ = '0.22.2'


### PR DESCRIPTION
- (PR #427, 2023-03-10) chore(deps-dev): Bump black from 22.12.0 to 23.1.0
- (PR #455, 2023-03-10) fix(data.cte): Add missing codes to files used by schema validator