### PR TITLE
fix(data.cte): Add missing code `8020` to file used by schema validator

### DIFF
--- a/cl_sii/data/cte/f29_datos_obj_missing_key_fixes.json
+++ b/cl_sii/data/cte/f29_datos_obj_missing_key_fixes.json
@@ -2,11 +2,13 @@
   "glosa": {
     "049": "(Desconocido)",
     "156": "BASE IMPTO.A74,T.V.",
-    "157": "RET..ART74,T.VAR"
+    "157": "RET..ART74,T.VAR",
+    "8020": "(Desconocido)"
   },
   "tipos": {
     "049": "M",
     "156": "M",
-    "157": "M"
+    "157": "M",
+    "8020": "M"
   }
 }


### PR DESCRIPTION
Add code `8020` to file used by schema validator
:func:`cte_f29_datos_schema_best_effort_validator`,
since this code is currently missing in the `tipos`
and `glosa` sections of the F29 file.
    
Ref: https://cordada.aha.io/requirements/COMPCLDATA-215-1
Ref: https://cordada.aha.io/features/COMPCLDATA-215
Ref: https://github.com/fyntex/lib-cl-sii-python/pull/440
