### PR TITLE
Update Editor Configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,7 +28,8 @@ indent_style = ignore
 insert_final_newline = ignore
 
 [*.md]
-trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2
 
 [*.{diff,patch}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
For Markdown files:

- Enable trimming of trailing whitespace.
- Change indentation size from 4 (default) to 2.
- Explicitly set indentation style to *space*.