### PR TITLE
rcv: Add RvTipoVenta enum to represent "Tipo de Venta" in RCV

### DIFF
--- a/src/cl_sii/rcv/constants.py
+++ b/src/cl_sii/rcv/constants.py
@@ -318,3 +318,19 @@ class RcvTipoDocto(enum.IntEnum):
             ) from exc
 
         return value
+
+
+@enum.unique
+class RvTipoVenta(enum.Enum):
+    """
+    Enum of "Tipo de Venta" for the RCV domain.
+    """
+
+    DEL_GIRO = "DEL_GIRO"
+    """Del Giro"""
+
+    BIENES_RAICES = "BIENES_RAICES"
+    """Bienes Raíces"""
+
+    ACTIVO_FIJO = "ACTIVO_FIJO"
+    """Activo Fijo"""

--- a/src/tests/test_rcv_constants.py
+++ b/src/tests/test_rcv_constants.py
@@ -2,7 +2,7 @@ import unittest
 
 from cl_sii.dte.constants import TipoDte  # noqa: F401
 from cl_sii.rcv import constants  # noqa: F401
-from cl_sii.rcv.constants import RcEstadoContable, RcTipoCompra, RcvKind, RcvTipoDocto  # noqa: F401
+from cl_sii.rcv.constants import RcEstadoContable, RcTipoCompra, RcvKind, RcvTipoDocto, RvTipoVenta
 
 
 class RcvKindTest(unittest.TestCase):
@@ -139,3 +139,18 @@ class RcvTipoDoctoTest(unittest.TestCase):
         self.assertEqual(
             cm.exception.args, ("There is no equivalent 'TipoDte' for 'RcvTipoDocto.FACTURA'.",)
         )
+
+
+class RvTipoVentaTest(unittest.TestCase):
+    def test_members(self) -> None:
+        self.assertSetEqual(
+            {x for x in RvTipoVenta},
+            {
+                RvTipoVenta.DEL_GIRO,
+                RvTipoVenta.BIENES_RAICES,
+                RvTipoVenta.ACTIVO_FIJO,
+            },
+        )
+
+    def test_values_type(self) -> None:
+        self.assertSetEqual({type(x.value) for x in RvTipoVenta}, {str})


### PR DESCRIPTION
Ref: https://app.shortcut.com/cordada/story/16108/