### PR TITLE
extras: Improve Django filters `FILTER_FOR_DBFIELD_DEFAULTS`

### DIFF
--- a/src/cl_sii/extras/dj_filters.py
+++ b/src/cl_sii/extras/dj_filters.py
@@ -23,8 +23,7 @@ import cl_sii.extras.dj_form_fields
 import cl_sii.extras.dj_model_fields
 
 
-FILTER_FOR_DBFIELD_DEFAULTS: Mapping[Type[django.db.models.Field], Mapping[str, object]]
-FILTER_FOR_DBFIELD_DEFAULTS = deepcopy(django_filters.filterset.FILTER_FOR_DBFIELD_DEFAULTS)
+FILTER_FOR_DBFIELD_DEFAULTS: Mapping[Type[django.db.models.Field], Mapping[str, object]] = {}
 
 
 class RutFilter(django_filters.filters.CharFilter):
@@ -90,4 +89,7 @@ class SiiFilterSet(django_filters.filterset.FilterSet):
     """
 
     FILTER_DEFAULTS: ClassVar[Mapping[Type[django.db.models.Field], Mapping[str, object]]]
-    FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
+    FILTER_DEFAULTS = {
+        **deepcopy(django_filters.FilterSet.FILTER_DEFAULTS),
+        **FILTER_FOR_DBFIELD_DEFAULTS,
+    }


### PR DESCRIPTION
Previously, `cl_sii.extras.dj_filters.FILTER_FOR_DBFIELD_DEFAULTS` consisted of the `FILTER_FOR_DBFIELD_DEFAULTS` from `django_filters`, with the addition of `RutFilter`. From now on,
`cl_sii.extras.dj_filters.FILTER_FOR_DBFIELD_DEFAULTS` will only include the filters provided by `cl_sii`, leaving the user to decide whether to merge it with the one from `django_filters`. ⚠️ **Warning**: Breaking change.