### PR TITLE
deps: Update `cryptography` from 45.0.4 to 45.0.7

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -42,7 +42,7 @@ colorama==0.4.6
     # via tox
 coverage==7.10.6
     # via -r requirements-dev.in
-cryptography==45.0.4
+cryptography==45.0.7
     # via
     #   -c requirements.txt
     #   secretstorage

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@
 #   git+https://github.com/example/example.git@example-vcs-ref#egg=example-pkg[foo,bar]==1.42.3
 
 backports-zoneinfo==0.2.1 ; python_version < "3.9" # Used by `djangorestframework`.
-cryptography==45.0.4
+cryptography==45.0.7
 defusedxml==0.7.1
 django-filter>=24.2
 Django>=4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ certifi==2024.7.4
     # via signxml
 cffi==1.16.0
     # via cryptography
-cryptography==45.0.4
+cryptography==45.0.7
     # via
     #   -r requirements.in
     #   pyopenssl


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/cryptography/45.0.7/)
- ~~[Release Notes]()~~
- [Changelog](https://github.com/pyca/cryptography/blob/45.0.7/CHANGELOG.rst#4507---2025-09-01)
- [Commits](https://github.com/pyca/cryptography/compare/45.0.4...45.0.7)