### PR TITLE
cte: Add parser for "Carpeta Tributaria Electrónica"

### DIFF
--- a/src/cl_sii/cte/data_models.py
+++ b/src/cl_sii/cte/data_models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pydantic
+
+
+@pydantic.dataclasses.dataclass(
+    frozen=True,
+    config=pydantic.ConfigDict(
+        arbitrary_types_allowed=True,
+        extra='forbid',
+    ),
+)
+class TaxpayerProvidedInfo:
+    """
+    Información proporcionada por el contribuyente para fines tributarios (1)
+    """
+
+    legal_representatives: Sequence[LegalRepresentative]
+    company_formation: Sequence[LegalRepresentative]
+    participation_in_existing_companies: Sequence[LegalRepresentative]
+
+
+@pydantic.dataclasses.dataclass(
+    frozen=True,
+)
+class LegalRepresentative:
+    name: str
+    """
+    Nombre o Razón social.
+    """
+    rut: str
+    """
+    RUT.
+    """
+    incorporation_date: str
+    """
+    Fecha de incorporación.
+    """

--- a/src/cl_sii/cte/parsers.py
+++ b/src/cl_sii/cte/parsers.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+from .data_models import LegalRepresentative, TaxpayerProvidedInfo
+
+
+def parse_taxpayer_provided_info(html_content: str) -> TaxpayerProvidedInfo:
+    """
+    Parse the CTE HTML content to extract the content of the section:
+    "Información proporcionada por el contribuyente para fines tributarios (1)"
+
+    Args:
+        html_content: HTML string containing the taxpayer information table
+
+    Returns:
+        TaxpayerProvidedInfo instance with the parsed data
+    """
+    soup = BeautifulSoup(html_content, 'html.parser')
+
+    # Find the main table with id="tbl_sociedades"
+    table = soup.find('table', id='tbl_sociedades')
+
+    if not table:
+        raise ValueError("Could not find taxpayer information table in HTML")
+
+    # Initialize lists for each section
+    legal_representatives = []
+    company_formation = []
+    participation_in_companies = []
+
+    # Current section being parsed
+    current_section = None
+
+    # Iterate through rows to extract data
+    rows = table.find_all('tr')  # type: ignore[attr-defined]
+    for row in rows:
+        section_header = row.find(
+            'span', class_='textof', string=lambda s: s and 'Representante(s) Legal(es)' in s
+        )
+        if section_header:
+            current_section = 'legal_representatives'
+            continue
+
+        section_header = row.find(
+            'span',
+            class_='textof',
+            string=lambda s: s and 'Conformación de la sociedad' in s,
+        )
+        if section_header:
+            current_section = 'company_formation'
+            continue
+
+        section_header = row.find(
+            'span',
+            class_='textof',
+            string=lambda s: s and 'Participación en sociedades vigentes' in s,
+        )
+        if section_header:
+            current_section = 'participation_in_companies'
+            continue
+
+        # Skip rows without useful data
+        cells = row.find_all('td')
+        if len(cells) < 3:
+            continue
+
+        name_cell = cells[1].find('span', class_='textof')
+        rut_cell = cells[2].find('span', class_='textof')
+        date_cell = cells[3].find('span', class_='textof')
+
+        # If this is a data row with person information
+        if name_cell and rut_cell and date_cell and name_cell.text.strip():
+            name = name_cell.text.strip()
+            rut = rut_cell.text.strip()
+            incorporation_date = date_cell.text.strip()
+
+            person = LegalRepresentative(name=name, rut=rut, incorporation_date=incorporation_date)
+
+            if current_section == 'legal_representatives':
+                legal_representatives.append(person)
+            elif current_section == 'company_formation':
+                company_formation.append(person)
+            elif current_section == 'participation_in_companies':
+                participation_in_companies.append(person)
+
+    return TaxpayerProvidedInfo(
+        legal_representatives=legal_representatives,
+        company_formation=company_formation,
+        participation_in_existing_companies=participation_in_companies,
+    )

--- a/src/tests/test_cte_parsers.py
+++ b/src/tests/test_cte_parsers.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from cl_sii.cte import data_models, parsers
+from .utils import read_test_file_str_utf8
+
+
+class ParsersTest(TestCase):
+    def test_parse_taxpayer_provided_info(self) -> None:
+        html_content = read_test_file_str_utf8('test_data/sii-cte/cte_taxpayer_provided_info.html')
+
+        with self.subTest("Parsing ok"):
+            result = parsers.parse_taxpayer_provided_info(html_content)
+            expected_obj = data_models.TaxpayerProvidedInfo(
+                legal_representatives=[
+                    data_models.LegalRepresentative(
+                        name='DAVID USUARIO DE PRUEBA',
+                        rut='76354771-K',
+                        incorporation_date='20-09-2023',
+                    ),
+                    data_models.LegalRepresentative(
+                        name='JAVIERA USUARIO DE PRUEBA',
+                        rut='38855667-6',
+                        incorporation_date='20-09-2023',
+                    ),
+                ],
+                company_formation=[
+                    data_models.LegalRepresentative(
+                        name='JAVIERA USUARIO DE PRUEBA',
+                        rut='38855667-6',
+                        incorporation_date='20-09-2023',
+                    ),
+                    data_models.LegalRepresentative(
+                        name='MARÍA USUARIO DE PRUEBA',
+                        rut='34413183-k',
+                        incorporation_date='23-02-2024',
+                    ),
+                ],
+                participation_in_existing_companies=[],
+            )
+            self.assertEqual(result, expected_obj)
+
+        with self.subTest("Parsing emtpy content"):
+            with self.assertRaises(ValueError) as assert_raises_cm:
+                parsers.parse_taxpayer_provided_info("")
+
+            self.assertEqual(
+                assert_raises_cm.exception.args,
+                ("Could not find taxpayer information table in HTML",),
+            )

--- a/src/tests/test_data/sii-cte/cte_taxpayer_provided_info.html
+++ b/src/tests/test_data/sii-cte/cte_taxpayer_provided_info.html
@@ -1,0 +1,173 @@
+
+
+          <tbody><tr>
+            <td></td>
+          </tr>
+
+          <tr>
+            <td class="centeralign">
+              <table border="0" cellspacing="1">
+                <tbody><tr>
+                  <td class="leftalign">&nbsp;</td>
+                </tr>
+                <tr>
+                  <td class="td_tbl_carpeta_header">
+                    <p class="textofp justifyalign">Revise los datos contenidos en esta Carpeta Tributaria Electrónica y, si están correctos, seleccione el botón "Continuar". Si detecta información incorrecta, reporte esta situación llamando a nuestra Mesa de Ayuda Telefónica, al (02) 395 11 15, o ingresando a nuestra página Web, www.sii.cl, menú Contáctenos, opción Problemas y quejas.</p>
+                  </td>
+                </tr>
+              </tbody></table>
+            </td>
+          </tr>
+          <tr>
+            <td class="td_tbl_carpeta centeralign">
+              <table border="0" cellspacing="1" width="630">
+                <tbody><tr>
+                  <td class="centeralign">
+                    <span class="textof"><b>CARPETA TRIBUTARIA ELECTRÓNICA<br>PARA SOLICITAR CRÉDITOS</b></span>
+                  </td>
+                </tr>
+                <tr>
+                  <td><hr></td>
+                </tr>
+                <tr>
+                  <td class="leftalign">
+                    <p class="justifyalign">
+                      <span class="textof"><b>Importante:</b> Esta información es válida para la fecha y hora en que se generó la carpeta.<br><br>
+                      Toda declaración y pago que sea presentada en papel retrasa la actualización de las bases de datos del SII, por lo que, eventualmente, podrían no aparecer en esta carpeta.</span>
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td><hr></td>
+                </tr>
+              </tbody></table>
+              <table border="0" cellspacing="1" width="630" id="tbl_encabezado" class="leftalign">
+                <tbody><tr>
+                  <td width="30%"><span class="textof">Nombre del emisor:</span></td>
+                  <td id="td_nombre" width="70%"><span class="textof"> INVERSIONES SPA </span></td>
+                </tr>
+                <tr>
+                  <td><span class="textof">RUT del emisor:</span></td>
+                  <td id="td_rut"><span class="textof">47797573 - 9</span></td>
+                </tr>
+                <tr>
+                  <td nowrap=""><span class="textof">Fecha de generación de la carpeta:</span></td>
+                  <td><span class="textof">25/07/2025 07:21</span></td>
+                </tr>
+              </tbody></table>
+              <table class="table_collapsed leftalign" border="1" cellspacing="0" cellpadding="0" width="630" id="tbl_dbcontribuyente">
+                <tbody><tr>
+                  <td colspan="3" class="td_tbl_background_alt"><span class="textof"><b>Datos del Contribuyente</b></span></td>
+                </tr>
+                <tr>
+                  <td class="td_tbl_background"><span class="textof">Fecha de Inicio de Actividades:</span></td>
+                  <td colspan="2" id="td_fecha_inicio" width="70%"><span class="textof">15-11-2023</span></td>
+                </tr>
+                <tr>
+                  <td class="td_tbl_background"><span class="textof">Actividades Económicas:</span></td>
+                  <td colspan="2" id="td_actividades"><span class="textof"> SERVICIOS DE ASESORIA Y CONSULTORIA EN MATERIA DE ADMINISTRACION DE EMPRESAS Y OTROS SERVICIOS DE ASESORIA ADMINISTRATIVA Y DE NEGOCIOS N.C.P.<br>ACTIVIDADES DE OTRAS ORGANIZACIONES EMPRESARIALES N.C.P.<br>OTRAS ACTIVIDADES DE SERVICIOS PERSONALES N.C.P.<br></span></td>
+                </tr>
+                <tr>
+                  <td class="td_tbl_background"><span class="textof">Categoría tributaria:</span></td>
+                  <td colspan="2" id="td_categoria"><span class="textof">Primera categoría</span></td>
+                </tr>
+                <tr>
+                  <td class="td_tbl_background"><span class="textof">Domicilio:</span></td>
+                  <td colspan="2" id="td_domicilio"><span class="textof">AV REAL, LAS CONDES</span></td>
+                </tr>
+                <tr>
+                  <td class="td_tbl_background"><span class="textof">Sucursales:</span></td>
+                  <td colspan="2"><span class="textof"></span></td>
+                </tr>
+                <tr>
+                  <td class="td_tbl_background"><span class="textof">Últimos documentos timbrados:</span></td>
+                  <td id="td_tim_nombre" class="hidden_border_right"><span class="textof">FACTURA ELECTRONICA<br>FACTURA NO AFECTA O EXENTA ELECTRONICA<br>GUIA DESPACHO ELECTRONICA<br>NOTA CREDITO ELECTRONICA<br></span></td>
+                  <td id="td_tim_fecha" class="hidden_border_left"><span class="textof">24-07-2025<br>17-07-2025<br>14-05-2025<br>18-07-2025<br></span></td>
+                </tr>
+                <tr>
+                  <td class="td_tbl_background"><span class="textof">Observaciones tributarias:</span></td>
+                  <td colspan="2" id="td_observaciones">
+
+
+
+
+                    <p><span class="textof">No tiene observaciones.</span></p>
+
+                  </td>
+                </tr>
+              </tbody></table>
+              <br>
+              <table id="tbl_sociedades" class="table_collapsed" border="1" cellspacing="0" cellpadding="0" width="630">
+                <tbody><tr>
+                  <td colspan="4" class="td_tbl_background_alt"><span class="textof"><b>Información proporcionada por el contribuyente para fines tributarios (1)</b></span></td>
+                </tr>
+                <tr>
+                  <td width="30%" class="td_tbl_background"><span class="textof">&nbsp;</span></td>
+                  <td width="40%" class="td_tbl_background centeralign"><span class="textof">Nombre o Razón Social</span></td>
+                  <td width="15%" class="td_tbl_background centeralign"><span class="textof">RUT</span></td>
+                  <td width="15%" class="td_tbl_background" align="center"><span class="textof">Fecha de Incorporación</span></td>
+                </tr>
+                <tr>
+                  <td width="30%" class="td_tbl_background"><span class="textof">Representante(s) Legal(es)</span></td>
+                  <td width="40%"><span class="textof">&nbsp;</span></td>
+                  <td width="15%"><span class="textof">&nbsp;</span></td>
+                  <td width="15%"><span class="textof">&nbsp;</span></td>
+                </tr>
+
+                <tr>
+                  <td width="30%"><span class="textof">&nbsp;</span></td>
+                  <td width="40%"><span class="textof">DAVID USUARIO DE PRUEBA</span></td>
+                  <td width="15%" class="centeralign"><span class="textof">76354771-K</span></td>
+                  <td width="15%" class="centeralign"><span class="textof">20-09-2023</span></td>
+                </tr>
+
+                <tr>
+                  <td width="30%"><span class="textof">&nbsp;</span></td>
+                  <td width="40%"><span class="textof">JAVIERA USUARIO DE PRUEBA</span></td>
+                  <td width="15%" class="centeralign"><span class="textof">38855667-6</span></td>
+                  <td width="15%" class="centeralign"><span class="textof">20-09-2023               </span></td>
+                </tr>
+
+
+                <tr>
+                  <td width="30%" class="td_tbl_background"><span class="textof">Conformación de la sociedad</span></td>
+                  <td width="40%"></td>
+                  <td width="15%"></td>
+                  <td width="15%"></td>
+                </tr>
+
+                <tr>
+                  <td width="30%"></td>
+                  <td width="40%"><span class="textof">JAVIERA USUARIO DE PRUEBA</span></td>
+                  <td width="15%" class="centeralign"><span class="textof">38855667-6</span></td>
+                  <td width="15%" class="centeralign"><span class="textof">20-09-2023</span></td>
+                </tr>
+
+                <tr>
+                  <td width="30%"></td>
+                  <td width="40%"><span class="textof">MARÍA USUARIO DE PRUEBA</span></td>
+                  <td width="15%" class="centeralign"><span class="textof">34413183-k</span></td>
+                  <td width="15%" class="centeralign"><span class="textof">23-02-2024</span></td>
+                </tr>
+
+
+                <tr>
+                  <td width="30%" class="td_tbl_background"><span class="textof">Participación en sociedades vigentes(2)</span></td>
+                  <td width="40%"><span class="textof">&nbsp;</span></td>
+                  <td width="15%"><span class="textof">&nbsp;</span></td>
+                  <td width="15%"><span class="textof">&nbsp;</span></td>
+                </tr>
+
+
+                <tr>
+                  <td width="30%"><span class="textof">&nbsp;</span></td>
+                  <td colspan="3" class="leftalign"><span class="textof">- No existen sociedades para el RUT -</span></td>
+                </tr>
+
+                <tr>
+                  <td colspan="4" class="td_tbl_background"><p><span class="textof">(1): Información declarada por el contribuyente y que puede haber sufrido modificaciones.
+                  <br>(2): La vigencia de estas sociedades está asociada a la existencia de un Inicio de Actividades, sin Término de Giro.
+                  </span></p></td>
+                </tr>
+              </tbody></table>
+              <br>


### PR DESCRIPTION
- Implemented `parse_taxpayer_provided_info` to parse taxpayer-provided information from CTE HTML.
- Added `TaxpayerProvidedInfo` and `LegalRepresentative` data models.
- Created tests to validate parser functionality with sample HTML input.

Ref: https://app.shortcut.com/cordada/story/16535/