### PR TITLE
rcv: Make `iva_no_retenido` optional in data models and parsers

### DIFF
--- a/src/cl_sii/rcv/data_models.py
+++ b/src/cl_sii/rcv/data_models.py
@@ -526,7 +526,7 @@ class RcDetalleEntry(RcvDetalleEntry):
     Impto. Sin Derecho a Credito
     """
 
-    iva_no_retenido: int
+    iva_no_retenido: Optional[int]
     """
     IVA No Retenido
     """

--- a/src/cl_sii/rcv/parse_csv.py
+++ b/src/cl_sii/rcv/parse_csv.py
@@ -1074,7 +1074,7 @@ class RcvCompraRegistroCsvRowSchema(RcvCompraCsvRowSchema):
             iva_activo_fijo: Optional[int] = data.get('iva_activo_fijo')
             iva_uso_comun: Optional[int] = data.get('iva_uso_comun')
             impto_sin_derecho_a_credito: Optional[int] = data.get('impto_sin_derecho_a_credito')
-            iva_no_retenido: int = data['iva_no_retenido']
+            iva_no_retenido: Optional[int] = data.get('iva_no_retenido')
             nce_o_nde_sobre_factura_de_compra: Optional[str] = data.get(
                 'nce_o_nde_sobre_factura_de_compra'
             )
@@ -1194,7 +1194,7 @@ class RcvCompraNoIncluirCsvRowSchema(RcvCompraCsvRowSchema):
             iva_activo_fijo: Optional[int] = data.get('iva_activo_fijo')
             iva_uso_comun: Optional[int] = data.get('iva_uso_comun')
             impto_sin_derecho_a_credito: Optional[int] = data.get('impto_sin_derecho_a_credito')
-            iva_no_retenido: int = data['iva_no_retenido']
+            iva_no_retenido: Optional[int] = data.get('iva_no_retenido')
             nce_o_nde_sobre_factura_de_compra: Optional[str] = data.get(
                 'nce_o_nde_sobre_factura_de_compra'
             )
@@ -1314,7 +1314,7 @@ class RcvCompraReclamadoCsvRowSchema(RcvCompraCsvRowSchema):
             iva_activo_fijo: Optional[int] = data.get('iva_activo_fijo')
             iva_uso_comun: Optional[int] = data.get('iva_uso_comun')
             impto_sin_derecho_a_credito: Optional[int] = data.get('impto_sin_derecho_a_credito')
-            iva_no_retenido: int = data['iva_no_retenido']
+            iva_no_retenido: Optional[int] = data.get('iva_no_retenido')
             nce_o_nde_sobre_factura_de_compra: Optional[str] = data.get(
                 'nce_o_nde_sobre_factura_de_compra'
             )
@@ -1399,7 +1399,7 @@ class RcvCompraPendienteCsvRowSchema(RcvCompraCsvRowSchema):
             iva_activo_fijo: Optional[int] = data.get('iva_activo_fijo')
             iva_uso_comun: Optional[int] = data.get('iva_uso_comun')
             impto_sin_derecho_a_credito: Optional[int] = data.get('impto_sin_derecho_a_credito')
-            iva_no_retenido: int = data['iva_no_retenido']
+            iva_no_retenido: Optional[int] = data.get('iva_no_retenido')
             nce_o_nde_sobre_factura_de_compra: Optional[str] = data.get(
                 'nce_o_nde_sobre_factura_de_compra'
             )

--- a/src/tests/test_rcv_data_models.py
+++ b/src/tests/test_rcv_data_models.py
@@ -440,7 +440,7 @@ class RcRegistroDetalleEntryTest(unittest.TestCase):
             iva_activo_fijo=0,
             iva_uso_comun=0,
             impto_sin_derecho_a_credito=0,
-            iva_no_retenido=0,
+            iva_no_retenido=None,
             tabacos_puros=0,
             tabacos_cigarrillos=0,
             tabacos_elaborados=0,


### PR DESCRIPTION
- Updated `iva_no_retenido` to be optional in `RcDetalleEntry` and its variants.
- Adjusted CSV parser to handle cases where `iva_no_retenido` is missing or `None`.
- Updated tests to reflect changes in `iva_no_retenido` handling.

Ref: https://app.shortcut.com/cordada/story/16600/