### PR TITLE
deps: Install Python package `pip`

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -12,6 +12,7 @@ flake8==7.3.0
 isort==6.1.0
 mypy==1.19.1
 pip-tools==7.5.3
+pip==25.3
 tox==4.27.0
 twine==6.2.0
 types-jsonschema==4.25.1.20251009

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -220,7 +220,9 @@ zipp==3.20.2
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==25.3
-    # via pip-tools
+    # via
+    #   -r requirements-dev.in
+    #   pip-tools
 setuptools==80.9.0
     # via
     #   -c requirements.txt


### PR DESCRIPTION
> The PyPA recommended tool for installing Python packages.

- [Web Site](https://pip.pypa.io/)
- [VCS Repository](https://github.com/pypa/pip.git)
- [Documentation](https://pip.pypa.io/)
- [Software Repository](https://pypi.org/project/pip/)

Note: This package is already installed as a transitive dependency, but it is also a direct dependency (e.g. Make task `install-dev` installs `pip`), and direct dependencies should be in `requirements.in` (and `requirements.txt`) or `requirements-dev.in` (and `requirements-dev.txt`).