### PR TITLE
deps: Update `pip` from 25.3 to 26.0.1

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -12,7 +12,7 @@ flake8==7.3.0
 isort==6.1.0
 mypy==1.19.1
 pip-tools==7.5.3
-pip==25.3
+pip==26.0.1
 tox==4.27.0
 twine==6.2.0
 types-jsonschema==4.25.1.20251009

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -220,7 +220,7 @@ zipp==3.20.2
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
+pip==26.0.1
     # via
     #   -r requirements-dev.in
     #   pip-tools


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/pip/26.0.1/)
- ~~[Release Notes]()~~
- [Changelog](https://github.com/pypa/pip/blob/26.0.1/NEWS.rst#2601-2026-02-04)
- [Commits](https://github.com/pypa/pip/compare/25.3...26.0.1)