### PR TITLE
rtc: Add CSV parser for "Cesiones Periodo"

### DIFF
--- a/src/cl_sii/libs/charset_utils.py
+++ b/src/cl_sii/libs/charset_utils.py
@@ -1,0 +1,60 @@
+import unicodedata
+
+import chardet
+
+
+_DEFAULT_FILE_ENCODING = 'utf-8'
+
+
+def clean_unicode(value: str) -> str:
+    """
+    Normalize and compose a unicode string.
+
+    Handy when dealing with text that was transmitted/stored encoded
+    in legacy encoding such as "Windows-1252".
+
+    NFKC ("Normalization Form Compatibility Composition") will normalize
+    characters that **may look different**, but are semantically the same
+    as others.
+
+    .. warning::
+        NFKC was explicitly chosen over NFD, NFC and NFKD.
+
+    .. seealso::
+        https://docs.python.org/3/howto/unicode.html#comparing-strings
+
+    .. seealso::
+        https://en.wikipedia.org/wiki/Unicode_equivalence#Normal_forms
+
+    .. seealso::
+        https://www.fileformat.info/info/unicode/char/00c9/index.htm
+
+    >>> clean_unicode('La \u00e9lite y\xa0la Vergüenza')
+    'La élite y la Vergüenza'
+
+    >>>> print('\u00c9', '\u0045\u0301')
+    É É
+    >>> '\u00c9' == 'É', '\u0045\u0301' == 'É'
+    (True, False)
+    >>> len('\u00c9'), len( '\u0045\u0301')
+    (1, 2)
+    >>> '\u00c9' == '\N{LATIN CAPITAL LETTER E WITH ACUTE}'
+    True
+    >>> '\u0045\u0301' == '\N{LATIN CAPITAL LETTER E}\N{COMBINING ACUTE ACCENT}'
+    True
+    >>> clean_unicode('\u0045\u0301') == 'É' == '\N{LATIN CAPITAL LETTER E WITH ACUTE}'
+    True
+
+    """
+    return unicodedata.normalize('NFKC', value)
+
+
+def detect_file_encoding(file_path: str) -> str:
+    with open(file_path, 'rb') as f:
+        raw_data = f.read(512 * 1024)  # Read up to 512 KB
+    result = chardet.detect(raw_data)
+
+    encoding = result['encoding']
+    if encoding is None or encoding == 'ascii':
+        encoding = _DEFAULT_FILE_ENCODING
+    return encoding

--- a/src/cl_sii/rtc/parse_cesiones_periodo.py
+++ b/src/cl_sii/rtc/parse_cesiones_periodo.py
@@ -1,0 +1,545 @@
+"""
+Parse RTC files (CSV)
+=====================
+
+Example:
+
+>>> import pathlib
+>>> input_file_path = pathlib.Path('CESIONES_76389992-6_1_01062019_01072019.txt'):
+>>> output_file_path = input_file_path.with_suffix('.cleaned.txt')
+>>> clean_cesiones_periodo_csv_file(str(input_file_path), str(output_file_path))
+>>> g = parse_cesiones_periodo_csv_file(input_file_path=str(output_file_path))
+>>> row_ix = 0
+>>> for entry_struct, row_ix, row_data, row_parsing_errors in g:
+...     if entry_struct is None or row_parsing_errors:
+...         print(f"Error for '{output_file_path}':")
+...     print(entry_struct, row_ix, row_data, row_parsing_errors)
+
+"""
+
+import csv
+import logging
+from collections.abc import Mapping
+from datetime import date, datetime
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple, TypedDict
+
+import marshmallow
+import marshmallow.experimental.context
+
+from cl_sii.base.constants import SII_OFFICIAL_TZ
+from cl_sii.extras import mm_fields
+from cl_sii.libs import csv_utils, mm_utils, rows_processing, tz_utils
+from cl_sii.libs.charset_utils import detect_file_encoding
+from cl_sii.rtc import data_models_cesiones_periodo
+from cl_sii.rut import Rut
+
+
+logger = logging.getLogger(__name__)
+
+
+_CESIONES_PERIODO_CSV_HEADERS_LINE = 'VENDEDOR;ESTADO_CESION;DEUDOR;MAIL_DEUDOR;TIPO_DOC;NOMBRE_DOC;FOLIO_DOC;FCH_EMIS_DTE;MNT_TOTAL;CEDENTE;RZ_CEDENTE;MAIL_CEDENTE;CESIONARIO;RZ_CESIONARIO;MAIL_CESIONARIO;FCH_CESION;MNT_CESION;FCH_VENCIMIENTO'  # noqa: E501
+_CESIONES_PERIODO_CSV_HEADERS_N = 1 + _CESIONES_PERIODO_CSV_HEADERS_LINE.count(';')
+assert _CESIONES_PERIODO_CSV_HEADERS_N == 18
+
+
+def parse_cesiones_periodo_csv_file(
+    input_file_path: str,
+    n_rows_offset: int = 0,
+    max_n_rows: Optional[int] = None,
+) -> Iterable[
+    Tuple[
+        Optional[data_models_cesiones_periodo.CesionesPeriodoEntry],
+        int,
+        Dict[str, object],
+        Dict[str, object],
+    ]
+]:
+    """
+    Parse entries from the list of "cesiones" in a period (CSV file).
+
+    The original text file must be cleaned up with
+    :func:`clean_cesiones_periodo_csv_file` before parsing.
+
+    """
+    # warning: this looks like it would be executed before the iteration begins but it is not.
+    input_csv_row_schema_class = CesionesPeriodoCsvRowSchema
+    input_file_encoding = detect_file_encoding(input_file_path)
+    csv_headers_n = _CESIONES_PERIODO_CSV_HEADERS_N
+    csv_headers_line = _CESIONES_PERIODO_CSV_HEADERS_LINE
+
+    expected_input_field_names = (
+        'VENDEDOR',  # 'dte_vendedor_rut'
+        'ESTADO_CESION',  # 'estado'
+        'DEUDOR',  # 'dte_deudor_rut'
+        'MAIL_DEUDOR',  # 'deudor_email'
+        'TIPO_DOC',  # 'dte_tipo_dte'
+        'NOMBRE_DOC',
+        'FOLIO_DOC',  # 'dte_folio'
+        'FCH_EMIS_DTE',  # 'dte_fecha_emision'
+        'MNT_TOTAL',  # 'dte_monto_total'
+        'CEDENTE',  # 'cedente_rut'
+        'RZ_CEDENTE',  # 'cedente_razon_social'
+        'MAIL_CEDENTE',  # 'cedente_email'
+        'CESIONARIO',  # 'cesionario_rut'
+        'RZ_CESIONARIO',  # 'cesionario_razon_social'
+        'MAIL_CESIONARIO',  # 'cesionario_emails'
+        'FCH_CESION',  # 'fecha_cesion_dt'
+        'MNT_CESION',  # 'monto_cedido'
+        'FCH_VENCIMIENTO',  # 'fecha_ultimo_vencimiento'
+    )
+    fields_to_remove_names = (
+        # note: value is redundant with 'TIPO_DOC'
+        'NOMBRE_DOC',
+    )
+    fields_names_map: Dict[str, str] = {
+        'VENDEDOR': 'dte_vendedor_rut',
+        'ESTADO_CESION': 'estado',
+        'DEUDOR': 'dte_deudor_rut',
+        'MAIL_DEUDOR': 'deudor_email',
+        'TIPO_DOC': 'dte_tipo_dte',
+        'FOLIO_DOC': 'dte_folio',
+        'FCH_EMIS_DTE': 'dte_fecha_emision',
+        'MNT_TOTAL': 'dte_monto_total',
+        'CEDENTE': 'cedente_rut',
+        'RZ_CEDENTE': 'cedente_razon_social',
+        'MAIL_CEDENTE': 'cedente_email',
+        'CESIONARIO': 'cesionario_rut',
+        'RZ_CESIONARIO': 'cesionario_razon_social',
+        'MAIL_CESIONARIO': 'cesionario_emails',
+        'FCH_CESION': 'fecha_cesion_dt',
+        'MNT_CESION': 'monto_cedido',
+        'FCH_VENCIMIENTO': 'fecha_ultimo_vencimiento',
+    }
+
+    assert len(expected_input_field_names) == csv_headers_n
+    assert ';'.join(expected_input_field_names) == csv_headers_line
+
+    # Assert that all map keys exist in 'expected_input_field_names'.
+    assert set(fields_names_map.keys()).issubset(set(expected_input_field_names))
+    # Assert that all map values are unique.
+    assert len(set(fields_names_map.values())) == len(fields_names_map)
+    # Assert that all map values corresponds to a field name of the 'input_csv_row_schema'.
+    schema_declared_fields_names = set(input_csv_row_schema_class._declared_fields.keys())
+    assert set(fields_names_map.values()).issubset(schema_declared_fields_names)
+
+    schema_context: _CesionesPeriodoCsvRowContext = {
+        'fields_names_map': fields_names_map,
+    }
+    input_csv_row_schema = input_csv_row_schema_class()
+
+    with _CesionesPeriodoCsvRowSchemaContext(schema_context):
+        yield from _parse_cesiones_periodo_csv_file(
+            input_csv_row_schema,
+            expected_input_field_names,
+            fields_to_remove_names,
+            input_file_path,
+            input_file_encoding,
+            n_rows_offset,
+            max_n_rows,
+        )
+
+
+def clean_cesiones_periodo_csv_file(
+    input_file_path: str,
+    output_file_path: str,
+) -> Tuple[Optional[str], int]:
+    """
+    Clean CSV file of "cesiones" in a period.
+
+    * Sort all lines except the first two (query params; CSV headers).
+    * Remove the first line (query params), if it exists.
+    * Change newlines to ``\n``.
+    * Replace with ``,`` the unescaped ``;`` character used in email fields
+      when there are multiple values.
+
+    >>> clean_cesiones_periodo_csv_file('CESIONES_76389992-6_1_01062019_01072019.txt', 'output.txt')
+    ('RUT=76389992-6;TIPO_CONSULTA=CEDENTE;DESDE_DDMMAAAA=01062019;HASTA_DDMMAAAA=01072019',
+     1700)
+
+    :return: query params and number of "cesiones"
+
+    """
+
+    def _clean_line(original: str) -> str:
+        # Merge consecutive fields that look like they are email addresses (e.g. have the '@' char),
+        #   setting a ',' as separator.
+        #   e.g. convert this:
+        #       'whatever;x@a.com;y@b.cl;2019'
+        #   to:
+        #       'whatever;x@a.com,y@b.cl;2019'
+        last_match_ix = None
+        fields_values = original.split(';')
+        new_fields_values = []
+
+        for field_ix, field_value in enumerate(fields_values):
+            if '@' in field_value:
+                if last_match_ix is not None and field_ix == last_match_ix + 1:
+                    new_fields_values[-1] += f',{field_value}'
+                else:
+                    new_fields_values.append(field_value)
+                last_match_ix = field_ix
+            else:
+                new_fields_values.append(field_value)
+
+        modified = ';'.join(new_fields_values)
+
+        return modified
+
+    def _line_needs_cleaning(original_line: str) -> bool:
+        # The line needs to be cleaned if it does not have the expected number of columns.
+        return original_line.count(';') != _CESIONES_PERIODO_CSV_HEADERS_N - 1
+
+    file_encoding = detect_file_encoding(input_file_path)
+    output_new_line_str = '\n'
+
+    # note: reading text with `newline=None` means line endings will be autodetected
+    #   (both '\n' and '\r\n' work), and the output of `readline()` includes '\n'
+    #   (in Linux at least) at the end.
+    with open(input_file_path, mode='rt', encoding=file_encoding, newline=None) as input_f:
+        query_params: Optional[str] = None
+        # e.g. 'DATOS_CONSULTA; RUT=76389992-6;TIPO_CONSULTA=CEDENTE;DESDE_DDMMAAAA=01062019;HASTA_DDMMAAAA=01072019'  # noqa: E501
+        query_params_line = input_f.readline().upper().strip()
+        csv_headers_line = None
+
+        if query_params_line.startswith('DATOS_CONSULTA;'):
+            query_params = query_params_line.partition('DATOS_CONSULTA;')[2].strip()
+        elif query_params_line == _CESIONES_PERIODO_CSV_HEADERS_LINE:
+            csv_headers_line = query_params_line
+        else:
+            # TODO: use a new custom exception for this kind of cases.
+            raise Exception(
+                "First line is not the query params line ('DATOS_CONSULTA;'...) "
+                "nor the expected CSV headers line ('%s...'): %s",
+                _CESIONES_PERIODO_CSV_HEADERS_LINE[:30],
+                query_params_line,
+            )
+
+        if csv_headers_line is None:
+            csv_headers_line = input_f.readline().upper().strip()
+            if not csv_headers_line == _CESIONES_PERIODO_CSV_HEADERS_LINE:
+                # TODO: use a new custom exception for this kind of cases.
+                raise Exception(
+                    "CSV headers line does not match what is expected ('%s...'): %s",
+                    _CESIONES_PERIODO_CSV_HEADERS_LINE[:30],
+                    csv_headers_line,
+                )
+
+        sorted_lines = sorted(input_f)
+        n_sorted_lines = len(sorted_lines)
+        sorted_clean_lines = []
+        for line in sorted_lines:
+            sorted_clean_lines.append(_clean_line(line) if _line_needs_cleaning(line) else line)
+
+        with open(output_file_path, mode='wt', encoding=file_encoding, newline=None) as output_f:
+            output_f.writelines(
+                [
+                    csv_headers_line + output_new_line_str,
+                ]
+            )
+            output_f.writelines(sorted_clean_lines)
+
+    return query_params, n_sorted_lines
+
+
+###############################################################################
+# schemas
+###############################################################################
+
+
+class _CesionesPeriodoCsvRowContext(TypedDict):
+    fields_names_map: Mapping[str, str]
+
+
+_CesionesPeriodoCsvRowSchemaContext = marshmallow.experimental.context.Context[
+    _CesionesPeriodoCsvRowContext
+]
+
+
+class CesionesPeriodoCsvRowSchema(marshmallow.Schema):
+    FIELD_FECHA_CESION_DT_TZ = SII_OFFICIAL_TZ
+
+    ###########################################################################
+    # fields of DTE
+    ###########################################################################
+
+    dte_vendedor_rut = mm_fields.RutField(
+        required=True,
+    )
+    dte_deudor_rut = mm_fields.RutField(
+        required=True,
+    )
+    dte_tipo_dte = mm_fields.TipoDteField(
+        required=True,
+    )
+    dte_folio = marshmallow.fields.Integer(
+        required=True,
+    )
+    dte_fecha_emision = mm_utils.CustomMarshmallowDateField(
+        format='%Y-%m-%d',  # e.g. '2018-11-19'
+        required=True,
+    )
+    dte_monto_total = marshmallow.fields.Integer(
+        required=True,
+    )
+
+    ###########################################################################
+    # fields of "cesion"
+    ###########################################################################
+
+    cedente_rut = mm_fields.RutField(
+        required=True,
+    )
+    cedente_razon_social = marshmallow.fields.String(
+        required=True,
+    )
+    cedente_email = marshmallow.fields.String(
+        allow_none=True,
+        load_default=None,
+    )
+    cesionario_rut = mm_fields.RutField(
+        required=True,
+    )
+    cesionario_razon_social = marshmallow.fields.String(
+        required=True,
+    )
+    cesionario_emails = marshmallow.fields.String(
+        allow_none=True,
+        load_default=None,
+    )
+    # note: this is not a field of the DTE even though 'dte_deudor_rut' is.
+    deudor_email = marshmallow.fields.String(
+        allow_none=True,
+        load_default=None,
+    )
+    fecha_cesion_dt = marshmallow.fields.DateTime(
+        # warning: input does not include seconds
+        format='%Y-%m-%d %H:%M',  # e.g. '2019-06-13 14:31'
+        required=True,
+    )
+    # note: parsed directly from a copy of the input 'fecha_cesion_dt'.
+    fecha_cesion = mm_utils.CustomMarshmallowDateField(
+        # note: even though the time is parsed, it will be discarded.
+        format='%Y-%m-%d %H:%M',  # e.g. '2019-06-13 14:31'
+        required=True,
+    )
+    monto_cedido = marshmallow.fields.Integer(
+        required=True,
+    )
+    fecha_ultimo_vencimiento = mm_utils.CustomMarshmallowDateField(
+        format='%Y-%m-%d',  # e.g. '2018-11-19'
+        required=True,
+    )
+
+    estado = marshmallow.fields.String(
+        required=True,
+    )
+
+    @marshmallow.validates_schema(pass_original=True)
+    def validate_schema(self, data: dict, original_data: dict, **kwargs: Any) -> None:
+        mm_utils.validate_no_unexpected_input_fields(self, data, original_data)
+
+    # @marshmallow.validates('field_x')
+    # def validate_field_x(self, value):
+    #     pass
+
+    @marshmallow.pre_load
+    def preprocess(self, in_data: dict, **kwargs: Any) -> dict:
+        # note: required fields checks are run later on automatically thus we may not assume that
+        #   values of required fields (`required=True`) exist.
+
+        # Rename fields according to the map defined in 'fields_names_map'.
+        fields_names_map: Mapping[str, str] = _CesionesPeriodoCsvRowSchemaContext.get()[
+            'fields_names_map'
+        ]
+        for original_field_name, new_field_name in fields_names_map.items():
+            if original_field_name in in_data:
+                in_data[new_field_name] = in_data.pop(original_field_name)
+
+        # Copy values.
+        if 'fecha_cesion' not in in_data and 'fecha_cesion_dt' in in_data:
+            in_data['fecha_cesion'] = in_data['fecha_cesion_dt']
+
+        # Fix some values.
+        if 'cedente_email' in in_data:
+            if in_data['cedente_email'] in ('', 'null'):
+                in_data['cedente_email'] = None
+        if 'cesionario_emails' in in_data:
+            if in_data['cesionario_emails'] in ('', 'null'):
+                in_data['cesionario_emails'] = None
+        if 'deudor_email' in in_data:
+            if in_data['deudor_email'] in ('', 'null'):
+                in_data['deudor_email'] = None
+
+        return in_data
+
+    @marshmallow.post_load
+    def postprocess(self, data: dict, **kwargs: Any) -> dict:
+        # >>> data['fecha_cesion_dt'].isoformat()
+        # '2019-02-26T22:24:00'
+        data['fecha_cesion_dt'] = tz_utils.convert_naive_dt_to_tz_aware(
+            dt=data['fecha_cesion_dt'], tz=self.FIELD_FECHA_CESION_DT_TZ
+        )
+        # >>> data['fecha_cesion_dt'].isoformat()
+        # '2019-02-26T22:24:00-03:00'
+        # >>> data['fecha_cesion_dt'].astimezone(pytz.UTC).isoformat()
+        # '2019-02-27T01:24:00+00:00'
+
+        # note: to express this value in another timezone (but the value does not change), do
+        #   `dt_obj.astimezone(pytz.timezone('some timezone'))`
+
+        return data
+
+    def as_data_model(self, data: dict) -> data_models_cesiones_periodo.CesionesPeriodoEntry:
+        try:
+            dte_vendedor_rut: Rut = data['dte_vendedor_rut']
+            dte_deudor_rut: Rut = data['dte_deudor_rut']
+            dte_tipo_dte = data['dte_tipo_dte']
+            dte_folio: int = data['dte_folio']
+            dte_fecha_emision: date = data['dte_fecha_emision']
+            dte_monto_total: int = data['dte_monto_total']
+
+            cedente_rut: Rut = data['cedente_rut']
+            cedente_razon_social: str = data['cedente_razon_social']
+            cedente_email: Optional[str] = data['cedente_email']
+            cesionario_rut: Rut = data['cesionario_rut']
+            cesionario_razon_social: str = data['cesionario_razon_social']
+            cesionario_emails: Optional[str] = data['cesionario_emails']
+            deudor_email: Optional[str] = data['deudor_email']
+
+            fecha_cesion_dt: datetime = data['fecha_cesion_dt']
+            fecha_cesion: datetime = data['fecha_cesion']
+            monto_cedido: int = data['monto_cedido']
+            fecha_ultimo_vencimiento: date = data['fecha_ultimo_vencimiento']
+            estado: str = data['estado']
+        except KeyError as exc:
+            raise ValueError("Programming error: a referenced field is missing.") from exc
+
+        try:
+            detalle_entry = data_models_cesiones_periodo.CesionesPeriodoEntry(
+                dte_vendedor_rut=dte_vendedor_rut,
+                dte_deudor_rut=dte_deudor_rut,
+                dte_tipo_dte=dte_tipo_dte,
+                dte_folio=dte_folio,
+                dte_fecha_emision=dte_fecha_emision,
+                dte_monto_total=dte_monto_total,
+                cedente_rut=cedente_rut,
+                cedente_razon_social=cedente_razon_social,
+                cedente_email=cedente_email,
+                cesionario_rut=cesionario_rut,
+                cesionario_razon_social=cesionario_razon_social,
+                cesionario_emails=cesionario_emails,
+                deudor_email=deudor_email,
+                fecha_cesion_dt=fecha_cesion_dt,
+                fecha_cesion=fecha_cesion,
+                monto_cedido=monto_cedido,
+                fecha_ultimo_vencimiento=fecha_ultimo_vencimiento,
+                estado=estado,
+            )
+        except (TypeError, ValueError):
+            raise
+
+        return detalle_entry
+
+
+###############################################################################
+# helpers
+###############################################################################
+
+
+class _CesionesPeriodoCsvDialect(csv.Dialect):
+    """
+    CSV dialect of "cesiones" in a period CSV files.
+
+    The properties of this dialect were determined with the help of
+    :class:`csv.Sniffer`.
+
+    >>> filename = 'CESIONES_76389992-6_1_01062019_01072019.txt'
+    >>> with open(filename, 'rt', encoding='utf-8') as f:
+    ...     dialect = csv.Sniffer().sniff(f.read(50 * 1024))
+
+    """
+
+    delimiter = ';'
+    quotechar = '"'
+    escapechar = None
+    doublequote = False
+    skipinitialspace = False
+    # note: the original file uses '\r\n' for new lines but we replace them with '\n'
+    lineterminator = '\n'
+    quoting = csv.QUOTE_MINIMAL
+
+
+def _parse_cesiones_periodo_csv_file(
+    input_csv_row_schema: CesionesPeriodoCsvRowSchema,
+    expected_input_field_names: Sequence[str],
+    fields_to_remove_names: Sequence[str],
+    input_file_path: str,
+    input_file_encoding: str,
+    n_rows_offset: int,
+    max_n_rows: Optional[int] = None,
+) -> Iterable[
+    Tuple[
+        Optional[data_models_cesiones_periodo.CesionesPeriodoEntry],
+        int,
+        Dict[str, object],
+        Dict[str, object],
+    ]
+]:
+    """
+    Parse entries from the list of "cesiones" in a period (CSV file).
+
+    """
+    for field_to_remove_name in fields_to_remove_names:
+        if field_to_remove_name not in expected_input_field_names:
+            raise Exception(
+                "Programming error: field to remove is not one of the expected ones.",
+                field_to_remove_name,
+            )
+
+    _CSV_ROW_DICT_EXTRA_FIELDS_KEY = '_extra_csv_fields_data'
+
+    fields_to_remove_names += (_CSV_ROW_DICT_EXTRA_FIELDS_KEY,)  # type: ignore
+
+    # note:
+    #   > If csvfile is a file object, it should be opened with newline=''
+    #   https://docs.python.org/3/library/csv.html#csv.reader
+    with open(input_file_path, mode='rt', encoding=input_file_encoding, newline='') as input_f:
+        # Create a CSV reader, with auto-detection of header names (first row).
+        csv_reader = csv_utils.create_csv_dict_reader(
+            input_f,
+            csv_dialect=_CesionesPeriodoCsvDialect,
+            row_dict_extra_fields_key=_CSV_ROW_DICT_EXTRA_FIELDS_KEY,
+            expected_fields_strict=True,
+            expected_field_names=expected_input_field_names,
+        )
+
+        g = rows_processing.csv_rows_mm_deserialization_iterator(
+            csv_reader,
+            row_schema=input_csv_row_schema,
+            n_rows_offset=n_rows_offset,
+            max_n_rows=max_n_rows,
+            fields_to_remove_names=fields_to_remove_names,
+        )
+
+        for row_ix, row_data, deserialized_row_data, validation_errors in g:
+            entry: Optional[data_models_cesiones_periodo.CesionesPeriodoEntry] = None
+            row_errors: Dict[str, object] = {}
+            conversion_error = None
+
+            if not validation_errors:
+                try:
+                    entry = input_csv_row_schema.as_data_model(deserialized_row_data)
+                except Exception as exc:
+                    conversion_error = str(exc)
+                    logger.exception(
+                        "Deserialized data to data model instance conversion failed "
+                        "(probably a programming error)."
+                    )
+
+            # Instead of empty dicts, lists, str, etc, we want to have None.
+            if validation_errors:
+                row_errors['validation'] = validation_errors
+            if conversion_error:
+                row_errors['other'] = conversion_error
+
+            yield entry, row_ix, row_data, row_errors

--- a/src/tests/test_libs_charset_utils.py
+++ b/src/tests/test_libs_charset_utils.py
@@ -1,13 +1,23 @@
 import tempfile
 import unittest
 
-from cl_sii.libs.charset_utils import clean_unicode, detect_file_encoding  # noqa: F401
+from cl_sii.libs.charset_utils import clean_unicode, detect_file_encoding
 
 
 class FunctionsTest(unittest.TestCase):
     def test_clean_unicode(self) -> None:
-        # TODO: implement for function 'clean_unicode'.
-        pass
+        expected = 'É'
+        self.assertEqual(clean_unicode('É'), expected)
+        self.assertEqual(clean_unicode('\u00c9'), expected)
+        self.assertEqual(clean_unicode('\u0045\u0301'), expected)
+        self.assertEqual(clean_unicode('\N{LATIN CAPITAL LETTER E WITH ACUTE}'), expected)
+        self.assertEqual(
+            clean_unicode('\N{LATIN CAPITAL LETTER E}\N{COMBINING ACUTE ACCENT}'), expected
+        )
+
+    def test_clean_unicode_empty_string(self) -> None:
+        empty_string = ''
+        self.assertEqual(clean_unicode(empty_string), empty_string)
 
     def test_detect_encoding_utf8(self) -> None:
         content = 'Este es un texto en español con acentos y ñ'.encode('utf-8')

--- a/src/tests/test_libs_charset_utils.py
+++ b/src/tests/test_libs_charset_utils.py
@@ -1,0 +1,35 @@
+import tempfile
+import unittest
+
+from cl_sii.libs.charset_utils import clean_unicode, detect_file_encoding  # noqa: F401
+
+
+class FunctionsTest(unittest.TestCase):
+    def test_clean_unicode(self) -> None:
+        # TODO: implement for function 'clean_unicode'.
+        pass
+
+    def test_detect_encoding_utf8(self) -> None:
+        content = 'Este es un texto en español con acentos y ñ'.encode('utf-8')
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(content)
+            temp_file_path = temp_file.name
+        self.assertEqual(detect_file_encoding(temp_file_path), 'utf-8')
+
+    def test_detect_encoding_ascii(self) -> None:
+        content = 'This is a simple ASCII text.'.encode('ascii')
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(content)
+            temp_file_path = temp_file.name
+        self.assertEqual(detect_file_encoding(temp_file_path), 'utf-8')
+
+    def test_detect_encoding_default(self) -> None:
+        """
+        The file does not have a valid encoding
+        so the default encoding should be returned
+        """
+        content = b'\x80\x81\x82\x83\x84\x85'
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(content)
+            temp_file_path = temp_file.name
+        self.assertEqual(detect_file_encoding(temp_file_path), 'utf-8')

--- a/src/tests/test_rtc_parse_cesiones_periodo.py
+++ b/src/tests/test_rtc_parse_cesiones_periodo.py
@@ -1,0 +1,512 @@
+import tempfile
+import unittest
+from collections import OrderedDict
+from datetime import date, datetime
+
+from cl_sii.base.constants import SII_OFFICIAL_TZ
+from cl_sii.dte.constants import TipoDte
+from cl_sii.libs.tz_utils import convert_naive_dt_to_tz_aware
+from cl_sii.rtc.data_models_cesiones_periodo import CesionesPeriodoEntry
+from cl_sii.rtc.parse_cesiones_periodo import (
+    clean_cesiones_periodo_csv_file,
+    parse_cesiones_periodo_csv_file,
+)
+from cl_sii.rut import Rut
+
+
+_CESIONES_PERIODO_CSV_FILE_1 = (
+    b'DATOS_CONSULTA; RUT=75320502-0;TIPO_CONSULTA=DEUDOR;DESDE_DDMMAAAA=01032019;'
+    b'HASTA_DDMMAAAA=31032019\r\n'
+    b'VENDEDOR;ESTADO_CESION;DEUDOR;MAIL_DEUDOR;TIPO_DOC;NOMBRE_DOC;FOLIO_DOC;'
+    b'FCH_EMIS_DTE;MNT_TOTAL;CEDENTE;RZ_CEDENTE;MAIL_CEDENTE;CESIONARIO;'
+    b'RZ_CESIONARIO;MAIL_CESIONARIO;FCH_CESION;MNT_CESION;FCH_VENCIMIENTO\r\n'
+    b'51532520-4;Cesion Vigente;75320502-0;null;33;Factura Electronica;3608534;'
+    b'2019-02-15;96628;51532520-4;MI CAMPITO SA;mi@campito.cl;96667560-8;'
+    b'POBRES SERVICIOS FINANCIEROS S.A.;ejecutivo@pobres.cl;super.ejecutivo@pobres.cl;muy@pobres.cl;'  # noqa: E501
+    b'2019-03-07 13:31;96628;2019-04-16\r\n'
+    b'51532520-4;Cesion Vigente;75320502-0;null;33;Factura Electronica;3608460;'
+    b'2019-02-11;256357;51532520-4;MI CAMPITO SA;mi@campito.cl;96667560-8;'
+    b'POBRES SERVICIOS FINANCIEROS S.A.;un-poco@pobres.cl;super.ejecutivo@pobres.cl;'
+    b'2019-03-07 13:32;256357;2019-04-12\r\n'
+    b'83564146-5;Cesion Vigente;75320502-0;null;33;Factura Electronica;1113465;'
+    b'2019-03-07;703771;83564146-5;MOYA S A;paga@moya.xyz;96932010-K;'
+    b'Ricky S.A.;whatever@ricky.cl;'
+    b'2019-03-26 09:27;703771;2019-07-05\r\n'
+)
+_CESIONES_PERIODO_CSV_FILE_2 = (
+    b'DATOS_CONSULTA; RUT=75320502-0;TIPO_CONSULTA=DEUDOR;DESDE_DDMMAAAA=01032019;'
+    b'HASTA_DDMMAAAA=31032019\r\n'
+    b'VENDEDOR;ESTADO_CESION;DEUDOR;MAIL_DEUDOR;TIPO_DOC;NOMBRE_DOC;FOLIO_DOC;'
+    b'FCH_EMIS_DTE;MNT_TOTAL;CEDENTE;RZ_CEDENTE;MAIL_CEDENTE;CESIONARIO;'
+    b'RZ_CESIONARIO;MAIL_CESIONARIO;FCH_CESION;MNT_CESION;FCH_VENCIMIENTO\r\n'
+    b'51532520-4;Cesion Vigente;75320502-0;null;1;Factura Electronica;3608460;'
+    b'2019-02-11;1.0;51532520-4;MI CAMPITO SA;mi@campito.cl;96667560-8;'
+    b'POBRES SERVICIOS FINANCIEROS S.A.;un-poco@pobres.cl;super.ejecutivo@pobres.cl;'
+    b'2019-03-07 13:32;1.0;2019\r\n'
+    b'83564146-5;Cesion Vigente;75320502-0;null;33;Factura Electronica;1113465;'
+    b'2019-03-07;703771;83564146-5;MOYA S A;paga@moya.xyz;96932010-K;'
+    b'Ricky S.A.;whatever@ricky.cl;'
+    b'2019-03-26 09:27;703771;2019-07-05\r\n'
+    b'83564146-5;Cesion Vigente;75320502-0;null;33;Factura Electronica;1113465;'
+    b'2019-03-07;703771;83564146-5;MOYA S A;paga@moya.xyz;96932010-K;'
+    b'Ricky S.A.;whatever@ricky.cl;'
+    b'2019-03-26 23:00;703771;2019-07-05\r\n'
+)
+_CESIONES_PERIODO_CSV_FILE_3 = (
+    'DATOS_CONSULTA; RUT=75320502-0;TIPO_CONSULTA=DEUDOR;DESDE_DDMMAAAA=01032019;'
+    'HASTA_DDMMAAAA=31032019\r\n'
+    'VENDEDOR;ESTADO_CESION;DEUDOR;MAIL_DEUDOR;TIPO_DOC;NOMBRE_DOC;FOLIO_DOC;'
+    'FCH_EMIS_DTE;MNT_TOTAL;CEDENTE;RZ_CEDENTE;MAIL_CEDENTE;CESIONARIO;'
+    'RZ_CESIONARIO;MAIL_CESIONARIO;FCH_CESION;MNT_CESION;FCH_VENCIMIENTO\r\n'
+    '51532520-4;Cesión Vigente;75320502-0;null;1;Factura Electrónica;3608460;'
+    '2019-02-11;1.0;51532520-4;MI CAÑOPITO SA;mi@campito.cl;96667560-8;'
+    'POBRES SERVICIOS FINANCIEROS S.A.;un-poco@pobres.cl;super.ejecutivo@pobres.cl;'
+    '2019-03-07 13:32;1.0;2019\r\n'
+).encode('iso-8859-1')
+_CESIONES_PERIODO_CSV_FILE_4 = (
+    'DATOS_CONSULTA; RUT=75320502-0;TIPO_CONSULTA=DEUDOR;DESDE_DDMMAAAA=01032019;'
+    'HASTA_DDMMAAAA=31032019\r\n'
+    'VENDEDOR;ESTADO_CESION;DEUDOR;MAIL_DEUDOR;TIPO_DOC;NOMBRE_DOC;FOLIO_DOC;'
+    'FCH_EMIS_DTE;MNT_TOTAL;CEDENTE;RZ_CEDENTE;MAIL_CEDENTE;CESIONARIO;'
+    'RZ_CESIONARIO;MAIL_CESIONARIO;FCH_CESION;MNT_CESION;FCH_VENCIMIENTO\r\n'
+    '51532520-4;Cesión Vigente;75320502-0;null;1;Factura Electrónica;3608460;'
+    '2019-02-11;1.0;51532520-4;MI CAÑOPITO SA;mi@campito.cl;96667560-8;'
+    'POBRES SERVICIOS FINANCIEROS S.A.;un-poco@pobres.cl;super.ejecutivo@pobres.cl;'
+    '2019-03-07 13:32;1.0;2019\r\n'
+).encode('utf-16')
+
+# - sorted
+# - without the query params line
+# - '\r\n' -> '\n'
+# - replace with ',' the unescaped ';' character used in email fields when there are
+#   multiple values.
+_CESIONES_PERIODO_CSV_FILE_1_CLEANED = (
+    b'VENDEDOR;ESTADO_CESION;DEUDOR;MAIL_DEUDOR;TIPO_DOC;NOMBRE_DOC;FOLIO_DOC;'
+    b'FCH_EMIS_DTE;MNT_TOTAL;CEDENTE;RZ_CEDENTE;MAIL_CEDENTE;CESIONARIO;'
+    b'RZ_CESIONARIO;MAIL_CESIONARIO;FCH_CESION;MNT_CESION;FCH_VENCIMIENTO\n'
+    b'51532520-4;Cesion Vigente;75320502-0;null;33;Factura Electronica;3608460;'
+    b'2019-02-11;256357;51532520-4;MI CAMPITO SA;mi@campito.cl;96667560-8;'
+    b'POBRES SERVICIOS FINANCIEROS S.A.;un-poco@pobres.cl,super.ejecutivo@pobres.cl;'
+    b'2019-03-07 13:32;256357;2019-04-12\n'
+    b'51532520-4;Cesion Vigente;75320502-0;null;33;Factura Electronica;3608534;'
+    b'2019-02-15;96628;51532520-4;MI CAMPITO SA;mi@campito.cl;96667560-8;'
+    b'POBRES SERVICIOS FINANCIEROS S.A.;ejecutivo@pobres.cl,super.ejecutivo@pobres.cl,muy@pobres.cl;'  # noqa: E501
+    b'2019-03-07 13:31;96628;2019-04-16\n'
+    b'83564146-5;Cesion Vigente;75320502-0;null;33;Factura Electronica;1113465;'
+    b'2019-03-07;703771;83564146-5;MOYA S A;paga@moya.xyz;96932010-K;'
+    b'Ricky S.A.;whatever@ricky.cl;'
+    b'2019-03-26 09:27;703771;2019-07-05\n'
+)
+_CESIONES_PERIODO_CSV_FILE_2_CLEANED = (
+    b'VENDEDOR;ESTADO_CESION;DEUDOR;MAIL_DEUDOR;TIPO_DOC;NOMBRE_DOC;FOLIO_DOC;'
+    b'FCH_EMIS_DTE;MNT_TOTAL;CEDENTE;RZ_CEDENTE;MAIL_CEDENTE;CESIONARIO;'
+    b'RZ_CESIONARIO;MAIL_CESIONARIO;FCH_CESION;MNT_CESION;FCH_VENCIMIENTO\n'
+    b'51532520-4;Cesion Vigente;75320502-0;null;1;Factura Electronica;3608460;'
+    b'2019-02-11;1.0;51532520-4;MI CAMPITO SA;mi@campito.cl;96667560-8;'
+    b'POBRES SERVICIOS FINANCIEROS S.A.;un-poco@pobres.cl,super.ejecutivo@pobres.cl;'
+    b'2019-03-07 13:32;1.0;2019\n'
+    b'83564146-5;Cesion Vigente;75320502-0;null;33;Factura Electronica;1113465;'
+    b'2019-03-07;703771;83564146-5;MOYA S A;paga@moya.xyz;96932010-K;'
+    b'Ricky S.A.;whatever@ricky.cl;'
+    b'2019-03-26 09:27;703771;2019-07-05\n'
+    b'83564146-5;Cesion Vigente;75320502-0;null;33;Factura Electronica;1113465;'
+    b'2019-03-07;703771;83564146-5;MOYA S A;paga@moya.xyz;96932010-K;'
+    b'Ricky S.A.;whatever@ricky.cl;'
+    b'2019-03-26 23:00;703771;2019-07-05\n'
+)
+_CESIONES_PERIODO_CSV_FILE_3_CLEANED = (
+    'VENDEDOR;ESTADO_CESION;DEUDOR;MAIL_DEUDOR;TIPO_DOC;NOMBRE_DOC;FOLIO_DOC;'
+    'FCH_EMIS_DTE;MNT_TOTAL;CEDENTE;RZ_CEDENTE;MAIL_CEDENTE;CESIONARIO;'
+    'RZ_CESIONARIO;MAIL_CESIONARIO;FCH_CESION;MNT_CESION;FCH_VENCIMIENTO\n'
+    '51532520-4;Cesión Vigente;75320502-0;null;1;Factura Electrónica;3608460;'
+    '2019-02-11;1.0;51532520-4;MI CAÑOPITO SA;mi@campito.cl;96667560-8;'
+    'POBRES SERVICIOS FINANCIEROS S.A.;un-poco@pobres.cl,super.ejecutivo@pobres.cl;'
+    '2019-03-07 13:32;1.0;2019\n'
+).encode('iso-8859-1')
+_CESIONES_PERIODO_CSV_FILE_4_CLEANED = (
+    'VENDEDOR;ESTADO_CESION;DEUDOR;MAIL_DEUDOR;TIPO_DOC;NOMBRE_DOC;FOLIO_DOC;'
+    'FCH_EMIS_DTE;MNT_TOTAL;CEDENTE;RZ_CEDENTE;MAIL_CEDENTE;CESIONARIO;'
+    'RZ_CESIONARIO;MAIL_CESIONARIO;FCH_CESION;MNT_CESION;FCH_VENCIMIENTO\n'
+    '51532520-4;Cesión Vigente;75320502-0;null;1;Factura Electrónica;3608460;'
+    '2019-02-11;1.0;51532520-4;MI CAÑOPITO SA;mi@campito.cl;96667560-8;'
+    'POBRES SERVICIOS FINANCIEROS S.A.;un-poco@pobres.cl,super.ejecutivo@pobres.cl;'
+    '2019-03-07 13:32;1.0;2019\n'
+).encode('utf-16')
+
+
+class FunctionsTest(unittest.TestCase):
+    def test_clean_cesiones_periodo_csv_file_ok_1(self) -> None:
+        input_file_content = _CESIONES_PERIODO_CSV_FILE_1
+        expected_output_file_content = _CESIONES_PERIODO_CSV_FILE_1_CLEANED
+
+        # note: for the output we need 'w+b' to be able to read and write data.
+        with tempfile.NamedTemporaryFile(mode='w+b') as output_tmp_file:
+            with tempfile.NamedTemporaryFile(mode='wb') as input_tmp_file:
+                input_tmp_file.write(input_file_content)
+                input_tmp_file.flush()
+                clean_cesiones_periodo_csv_file(input_tmp_file.name, output_tmp_file.name)
+            output_tmp_file.seek(0)
+            output_file_content = output_tmp_file.read()
+        self.assertEqual(output_file_content, expected_output_file_content)
+
+    def test_clean_cesiones_periodo_csv_file_ok_2(self) -> None:
+        input_file_content = _CESIONES_PERIODO_CSV_FILE_2
+        expected_output_file_content = _CESIONES_PERIODO_CSV_FILE_2_CLEANED
+
+        # note: for the output we need 'w+b' to be able to read and write data.
+        with tempfile.NamedTemporaryFile(mode='w+b') as output_tmp_file:
+            with tempfile.NamedTemporaryFile(mode='wb') as input_tmp_file:
+                input_tmp_file.write(input_file_content)
+                input_tmp_file.flush()
+                clean_cesiones_periodo_csv_file(input_tmp_file.name, output_tmp_file.name)
+            output_tmp_file.seek(0)
+            output_file_content = output_tmp_file.read()
+        self.assertEqual(output_file_content, expected_output_file_content)
+
+    def test_clean_cesiones_periodo_csv_file_ok_3(self) -> None:
+        input_file_content = _CESIONES_PERIODO_CSV_FILE_3
+        expected_output_file_content = _CESIONES_PERIODO_CSV_FILE_3_CLEANED
+
+        # note: for the output we need 'w+b' to be able to read and write data.
+        with tempfile.NamedTemporaryFile(mode='w+b') as output_tmp_file:
+            with tempfile.NamedTemporaryFile(mode='wb') as input_tmp_file:
+                input_tmp_file.write(input_file_content)
+                input_tmp_file.flush()
+                clean_cesiones_periodo_csv_file(input_tmp_file.name, output_tmp_file.name)
+            output_tmp_file.seek(0)
+            output_file_content = output_tmp_file.read()
+        self.assertEqual(output_file_content, expected_output_file_content)
+
+    def test_clean_cesiones_periodo_csv_file_ok_4(self) -> None:
+        input_file_content = _CESIONES_PERIODO_CSV_FILE_4
+        expected_output_file_content = _CESIONES_PERIODO_CSV_FILE_4_CLEANED
+
+        # note: for the output we need 'w+b' to be able to read and write data.
+        with tempfile.NamedTemporaryFile(mode='w+b') as output_tmp_file:
+            with tempfile.NamedTemporaryFile(mode='wb') as input_tmp_file:
+                input_tmp_file.write(input_file_content)
+                input_tmp_file.flush()
+                clean_cesiones_periodo_csv_file(input_tmp_file.name, output_tmp_file.name)
+            output_tmp_file.seek(0)
+            output_file_content = output_tmp_file.read()
+        self.assertEqual(output_file_content, expected_output_file_content)
+
+    def test_clean_cesiones_periodo_csv_file_ok_1_twice(self) -> None:
+        # Clean the file already cleaned up.
+        input_file_content = _CESIONES_PERIODO_CSV_FILE_1_CLEANED
+        expected_output_file_content = _CESIONES_PERIODO_CSV_FILE_1_CLEANED
+
+        # note: for the output we need 'w+b' to be able to read and write data.
+        with tempfile.NamedTemporaryFile(mode='w+b') as output_tmp_file:
+            with tempfile.NamedTemporaryFile(mode='wb') as input_tmp_file:
+                input_tmp_file.write(input_file_content)
+                input_tmp_file.flush()
+                clean_cesiones_periodo_csv_file(input_tmp_file.name, output_tmp_file.name)
+            output_tmp_file.seek(0)
+            output_file_content = output_tmp_file.read()
+        self.assertEqual(output_file_content, expected_output_file_content)
+
+    def test_parse_cesiones_periodo_csv_file_ok_1(self) -> None:
+        with tempfile.NamedTemporaryFile(mode='wb') as input_tmp_file:
+            input_tmp_file.write(_CESIONES_PERIODO_CSV_FILE_1_CLEANED)
+            input_tmp_file.flush()
+
+            results = list(parse_cesiones_periodo_csv_file(input_tmp_file.name, n_rows_offset=0))
+
+        self.assertEqual(
+            results,
+            [
+                (
+                    CesionesPeriodoEntry(
+                        dte_vendedor_rut=Rut('51532520-4'),
+                        dte_deudor_rut=Rut('75320502-0'),
+                        dte_tipo_dte=TipoDte.FACTURA_ELECTRONICA,
+                        dte_folio=3608460,
+                        dte_fecha_emision=date(2019, 2, 11),
+                        dte_monto_total=256357,
+                        cedente_rut=Rut('51532520-4'),
+                        cedente_razon_social='MI CAMPITO SA',
+                        cedente_email='mi@campito.cl',
+                        cesionario_rut=Rut('96667560-8'),
+                        cesionario_razon_social='POBRES SERVICIOS FINANCIEROS S.A.',
+                        cesionario_emails='un-poco@pobres.cl,super.ejecutivo@pobres.cl',
+                        deudor_email=None,
+                        fecha_cesion_dt=convert_naive_dt_to_tz_aware(
+                            datetime(2019, 3, 7, 13, 32), tz=SII_OFFICIAL_TZ
+                        ),
+                        fecha_cesion=date(2019, 3, 7),
+                        monto_cedido=256357,
+                        fecha_ultimo_vencimiento=date(2019, 4, 12),
+                        estado='Cesion Vigente',
+                    ),
+                    1,
+                    OrderedDict(
+                        [
+                            ('dte_vendedor_rut', '51532520-4'),
+                            ('estado', 'Cesion Vigente'),
+                            ('dte_deudor_rut', '75320502-0'),
+                            ('deudor_email', None),
+                            ('dte_tipo_dte', '33'),
+                            ('dte_folio', '3608460'),
+                            ('dte_fecha_emision', '2019-02-11'),
+                            ('dte_monto_total', '256357'),
+                            ('cedente_rut', '51532520-4'),
+                            ('cedente_razon_social', 'MI CAMPITO SA'),
+                            ('cedente_email', 'mi@campito.cl'),
+                            ('cesionario_rut', '96667560-8'),
+                            ('cesionario_razon_social', 'POBRES SERVICIOS FINANCIEROS S.A.'),
+                            ('cesionario_emails', 'un-poco@pobres.cl,super.ejecutivo@pobres.cl'),
+                            ('fecha_cesion_dt', '2019-03-07 13:32'),
+                            ('monto_cedido', '256357'),
+                            ('fecha_ultimo_vencimiento', '2019-04-12'),
+                            ('fecha_cesion', '2019-03-07 13:32'),
+                        ]
+                    ),
+                    {},
+                ),
+                (
+                    CesionesPeriodoEntry(
+                        dte_vendedor_rut=Rut('51532520-4'),
+                        dte_deudor_rut=Rut('75320502-0'),
+                        dte_tipo_dte=TipoDte.FACTURA_ELECTRONICA,
+                        dte_folio=3608534,
+                        dte_fecha_emision=date(2019, 2, 15),
+                        dte_monto_total=96628,
+                        cedente_rut=Rut('51532520-4'),
+                        cedente_razon_social='MI CAMPITO SA',
+                        cedente_email='mi@campito.cl',
+                        cesionario_rut=Rut('96667560-8'),
+                        cesionario_razon_social='POBRES SERVICIOS FINANCIEROS S.A.',
+                        cesionario_emails=(
+                            'ejecutivo@pobres.cl,super.ejecutivo@pobres.cl,muy@pobres.cl'
+                        ),
+                        deudor_email=None,
+                        fecha_cesion_dt=convert_naive_dt_to_tz_aware(
+                            datetime(2019, 3, 7, 13, 31), tz=SII_OFFICIAL_TZ
+                        ),
+                        fecha_cesion=date(2019, 3, 7),
+                        monto_cedido=96628,
+                        fecha_ultimo_vencimiento=date(2019, 4, 16),
+                        estado='Cesion Vigente',
+                    ),
+                    2,
+                    OrderedDict(
+                        [
+                            ('dte_vendedor_rut', '51532520-4'),
+                            ('estado', 'Cesion Vigente'),
+                            ('dte_deudor_rut', '75320502-0'),
+                            ('deudor_email', None),
+                            ('dte_tipo_dte', '33'),
+                            ('dte_folio', '3608534'),
+                            ('dte_fecha_emision', '2019-02-15'),
+                            ('dte_monto_total', '96628'),
+                            ('cedente_rut', '51532520-4'),
+                            ('cedente_razon_social', 'MI CAMPITO SA'),
+                            ('cedente_email', 'mi@campito.cl'),
+                            ('cesionario_rut', '96667560-8'),
+                            ('cesionario_razon_social', 'POBRES SERVICIOS FINANCIEROS S.A.'),
+                            (
+                                'cesionario_emails',
+                                'ejecutivo@pobres.cl,super.ejecutivo@pobres.cl,muy@pobres.cl',
+                            ),
+                            ('fecha_cesion_dt', '2019-03-07 13:31'),
+                            ('monto_cedido', '96628'),
+                            ('fecha_ultimo_vencimiento', '2019-04-16'),
+                            ('fecha_cesion', '2019-03-07 13:31'),
+                        ]
+                    ),
+                    {},
+                ),
+                (
+                    CesionesPeriodoEntry(
+                        dte_vendedor_rut=Rut('83564146-5'),
+                        dte_deudor_rut=Rut('75320502-0'),
+                        dte_tipo_dte=TipoDte.FACTURA_ELECTRONICA,
+                        dte_folio=1113465,
+                        dte_fecha_emision=date(2019, 3, 7),
+                        dte_monto_total=703771,
+                        cedente_rut=Rut('83564146-5'),
+                        cedente_razon_social='MOYA S A',
+                        cedente_email='paga@moya.xyz',
+                        cesionario_rut=Rut('96932010-K'),
+                        cesionario_razon_social='Ricky S.A.',
+                        cesionario_emails='whatever@ricky.cl',
+                        deudor_email=None,
+                        fecha_cesion_dt=convert_naive_dt_to_tz_aware(
+                            datetime(2019, 3, 26, 9, 27), tz=SII_OFFICIAL_TZ
+                        ),
+                        fecha_cesion=date(2019, 3, 26),
+                        monto_cedido=703771,
+                        fecha_ultimo_vencimiento=date(2019, 7, 5),
+                        estado='Cesion Vigente',
+                    ),
+                    3,
+                    OrderedDict(
+                        [
+                            ('dte_vendedor_rut', '83564146-5'),
+                            ('estado', 'Cesion Vigente'),
+                            ('dte_deudor_rut', '75320502-0'),
+                            ('deudor_email', None),
+                            ('dte_tipo_dte', '33'),
+                            ('dte_folio', '1113465'),
+                            ('dte_fecha_emision', '2019-03-07'),
+                            ('dte_monto_total', '703771'),
+                            ('cedente_rut', '83564146-5'),
+                            ('cedente_razon_social', 'MOYA S A'),
+                            ('cedente_email', 'paga@moya.xyz'),
+                            ('cesionario_rut', '96932010-K'),
+                            ('cesionario_razon_social', 'Ricky S.A.'),
+                            ('cesionario_emails', 'whatever@ricky.cl'),
+                            ('fecha_cesion_dt', '2019-03-26 09:27'),
+                            ('monto_cedido', '703771'),
+                            ('fecha_ultimo_vencimiento', '2019-07-05'),
+                            ('fecha_cesion', '2019-03-26 09:27'),
+                        ]
+                    ),
+                    {},
+                ),
+            ],
+        )
+
+    def test_parse_cesiones_periodo_csv_file_fail_1(self) -> None:
+        with tempfile.NamedTemporaryFile(mode='wb') as input_tmp_file:
+            input_tmp_file.write(_CESIONES_PERIODO_CSV_FILE_2_CLEANED)
+            input_tmp_file.flush()
+
+            results = list(parse_cesiones_periodo_csv_file(input_tmp_file.name, n_rows_offset=0))
+
+        self.assertEqual(
+            results,
+            [
+                (
+                    None,
+                    1,
+                    OrderedDict(
+                        [
+                            ('dte_vendedor_rut', '51532520-4'),
+                            ('estado', 'Cesion Vigente'),
+                            ('dte_deudor_rut', '75320502-0'),
+                            ('deudor_email', None),
+                            ('dte_tipo_dte', '1'),
+                            ('dte_folio', '3608460'),
+                            ('dte_fecha_emision', '2019-02-11'),
+                            ('dte_monto_total', '1.0'),
+                            ('cedente_rut', '51532520-4'),
+                            ('cedente_razon_social', 'MI CAMPITO SA'),
+                            ('cedente_email', 'mi@campito.cl'),
+                            ('cesionario_rut', '96667560-8'),
+                            ('cesionario_razon_social', 'POBRES SERVICIOS FINANCIEROS S.A.'),
+                            ('cesionario_emails', 'un-poco@pobres.cl,super.ejecutivo@pobres.cl'),
+                            ('fecha_cesion_dt', '2019-03-07 13:32'),
+                            ('monto_cedido', '1.0'),
+                            ('fecha_ultimo_vencimiento', '2019'),
+                            ('fecha_cesion', '2019-03-07 13:32'),
+                        ]
+                    ),
+                    {
+                        'validation': {
+                            'dte_tipo_dte': ['Not a valid Tipo DTE.'],
+                            'dte_monto_total': ['Not a valid integer.'],
+                            'monto_cedido': ['Not a valid integer.'],
+                            'fecha_ultimo_vencimiento': ['Not a valid date.'],
+                        }
+                    },
+                ),
+                (
+                    CesionesPeriodoEntry(
+                        dte_vendedor_rut=Rut('83564146-5'),
+                        dte_deudor_rut=Rut('75320502-0'),
+                        dte_tipo_dte=TipoDte.FACTURA_ELECTRONICA,
+                        dte_folio=1113465,
+                        dte_fecha_emision=date(2019, 3, 7),
+                        dte_monto_total=703771,
+                        cedente_rut=Rut('83564146-5'),
+                        cedente_razon_social='MOYA S A',
+                        cedente_email='paga@moya.xyz',
+                        cesionario_rut=Rut('96932010-K'),
+                        cesionario_razon_social='Ricky S.A.',
+                        cesionario_emails='whatever@ricky.cl',
+                        deudor_email=None,
+                        fecha_cesion_dt=convert_naive_dt_to_tz_aware(
+                            datetime(2019, 3, 26, 9, 27), tz=SII_OFFICIAL_TZ
+                        ),
+                        fecha_cesion=date(2019, 3, 26),
+                        monto_cedido=703771,
+                        fecha_ultimo_vencimiento=date(2019, 7, 5),
+                        estado='Cesion Vigente',
+                    ),
+                    2,
+                    OrderedDict(
+                        [
+                            ('dte_vendedor_rut', '83564146-5'),
+                            ('estado', 'Cesion Vigente'),
+                            ('dte_deudor_rut', '75320502-0'),
+                            ('deudor_email', None),
+                            ('dte_tipo_dte', '33'),
+                            ('dte_folio', '1113465'),
+                            ('dte_fecha_emision', '2019-03-07'),
+                            ('dte_monto_total', '703771'),
+                            ('cedente_rut', '83564146-5'),
+                            ('cedente_razon_social', 'MOYA S A'),
+                            ('cedente_email', 'paga@moya.xyz'),
+                            ('cesionario_rut', '96932010-K'),
+                            ('cesionario_razon_social', 'Ricky S.A.'),
+                            ('cesionario_emails', 'whatever@ricky.cl'),
+                            ('fecha_cesion_dt', '2019-03-26 09:27'),
+                            ('monto_cedido', '703771'),
+                            ('fecha_ultimo_vencimiento', '2019-07-05'),
+                            ('fecha_cesion', '2019-03-26 09:27'),
+                        ]
+                    ),
+                    {},
+                ),
+                (
+                    CesionesPeriodoEntry(
+                        dte_vendedor_rut=Rut('83564146-5'),
+                        dte_deudor_rut=Rut('75320502-0'),
+                        dte_tipo_dte=TipoDte.FACTURA_ELECTRONICA,
+                        dte_folio=1113465,
+                        dte_fecha_emision=date(2019, 3, 7),
+                        dte_monto_total=703771,
+                        cedente_rut=Rut('83564146-5'),
+                        cedente_razon_social='MOYA S A',
+                        cedente_email='paga@moya.xyz',
+                        cesionario_rut=Rut('96932010-K'),
+                        cesionario_razon_social='Ricky S.A.',
+                        cesionario_emails='whatever@ricky.cl',
+                        deudor_email=None,
+                        fecha_cesion_dt=convert_naive_dt_to_tz_aware(
+                            datetime(2019, 3, 26, 23, 00), tz=SII_OFFICIAL_TZ
+                        ),
+                        fecha_cesion=date(2019, 3, 26),
+                        monto_cedido=703771,
+                        fecha_ultimo_vencimiento=date(2019, 7, 5),
+                        estado='Cesion Vigente',
+                    ),
+                    3,
+                    OrderedDict(
+                        [
+                            ('dte_vendedor_rut', '83564146-5'),
+                            ('estado', 'Cesion Vigente'),
+                            ('dte_deudor_rut', '75320502-0'),
+                            ('deudor_email', None),
+                            ('dte_tipo_dte', '33'),
+                            ('dte_folio', '1113465'),
+                            ('dte_fecha_emision', '2019-03-07'),
+                            ('dte_monto_total', '703771'),
+                            ('cedente_rut', '83564146-5'),
+                            ('cedente_razon_social', 'MOYA S A'),
+                            ('cedente_email', 'paga@moya.xyz'),
+                            ('cesionario_rut', '96932010-K'),
+                            ('cesionario_razon_social', 'Ricky S.A.'),
+                            ('cesionario_emails', 'whatever@ricky.cl'),
+                            ('fecha_cesion_dt', '2019-03-26 23:00'),
+                            ('monto_cedido', '703771'),
+                            ('fecha_ultimo_vencimiento', '2019-07-05'),
+                            ('fecha_cesion', '2019-03-26 23:00'),
+                        ]
+                    ),
+                    {},
+                ),
+            ],
+        )


### PR DESCRIPTION
Add a parser for "Cesiones Periodo" files in CSV format. "Cesiones Periodo" can be downloaded from the SII web site in CSV or XML format.

The commits were taken from:

- https://github.com/cordada/lib-cl-sii-api-python/commit/0bafb09711cfe1695e27f82eeeb8686b8f8626d3
- https://github.com/cordada/lib-cl-sii-api-python/commit/7629e3bcdf4b144ff0a3c6088ed8e8e98474515a
- https://github.com/cordada/lib-cl-sii-api-python/commit/7b5857cab904d1dc0cab611449461d96c93eb14c
- https://github.com/cordada/lib-cl-sii-api-python/commit/d36ba58a8d5b7373f94faa7c86aadc9817ce68cb
- https://github.com/cordada/lib-cl-sii-api-python/commit/fe812e6e853e03735250ed23cdc96382281856a5