### PR TITLE
Fix Python version and caching in CI/CD

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,12 +45,14 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version-file: "pyproject.toml"
+          check-latest: true
 
       - name: Restoring/Saving Cache
         uses: actions/cache@v5.0.4
         with:
           path: "venv"
           key: py-v1-deps-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'requirements-dev.txt', 'Makefile', 'make/**.mk') }}
+          fail-on-cache-miss: true
 
       - name: Restore Artifacts (Release)
         uses: actions/download-artifact@v8.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version-file: "pyproject.toml"
+          check-latest: true
 
       - name: Create Python Virtual Environment
         run: make python-virtualenv PYTHON_VIRTUALENV_DIR="venv"


### PR DESCRIPTION
- In the `deploy` job, fail when the Python virtual environment could not be restored from the cache, as the subsequent steps do not work without that virtual environment.
- In the `release` and `deploy` jobs, ensure that the latest Python version is installed to prevent both jobs from having different Python versions and therefore different cache keys.