### PR TITLE
Release v0.75.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.74.0
+current_version = 0.75.0
 commit = True
 tag = False
 message = chore: Bump version from {current_version} to {new_version}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 0.75.0 (2026-04-15)
+
+- (PR #1024, 2026-04-15) Fix Python version and caching in CI/CD
+- (PR #1014, 2026-04-15) chore(deps): Bump pygments from 2.15.0 to 2.20.0
+
 ## 0.74.0 (2026-04-15)
 
 - (PR #1011, 2026-03-24) Fix errors reported by Markdown linter

--- a/src/cl_sii/__init__.py
+++ b/src/cl_sii/__init__.py
@@ -4,4 +4,4 @@ cl-sii Python lib
 
 """
 
-__version__ = '0.74.0'
+__version__ = '0.75.0'


### PR DESCRIPTION
## Changes

- (PR #1024, 2026-04-15) Fix Python version and caching in CI/CD
- (PR #1014, 2026-04-15) chore(deps): Bump pygments from 2.15.0 to 2.20.0