### PR TITLE
Release v0.76.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.75.0
+current_version = 0.76.0
 commit = True
 tag = False
 message = chore: Bump version from {current_version} to {new_version}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 0.76.0 (2026-05-04)
+
+- (PR #1029, 2026-04-29) Drop support for Python 3.9
+- (PR #1028, 2026-04-30) Bump marshmallow from 4.0.1 to 4.3.0
+
 ## 0.75.0 (2026-04-15)
 
 - (PR #1024, 2026-04-15) Fix Python version and caching in CI/CD

--- a/src/cl_sii/__init__.py
+++ b/src/cl_sii/__init__.py
@@ -4,4 +4,4 @@ cl-sii Python lib
 
 """
 
-__version__ = '0.75.0'
+__version__ = '0.76.0'


### PR DESCRIPTION
- (PR #1029, 2026-04-29) Drop support for Python 3.9
- (PR #1028, 2026-04-30) Bump marshmallow from 4.0.1 to 4.3.0