### PR TITLE
Release v0.78.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,7 @@
 [bumpversion]
-current_version = 0.77.0
+current_version = 0.78.0
 commit = True
 tag = False
 message = chore: Bump version from {current_version} to {new_version}
 
 [bumpversion:file:src/cl_sii/__init__.py]
-

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## 0.78.0 (2026-06-08)
+
+- (PR #1031, 2026-05-28) chore(deps): Bump build from 1.4.2 to 1.4.4 in the python-development group
+- (PR #1039, 2026-06-02) chore(deps): Bump the github-actions-production group with 2 updates
+- (PR #1040, 2026-06-05) dte: Add TipoDte 110, 111, 112
+- (PR #1042, 2026-06-08) chore(deps): Bump the codecov to 7.0.0 - actions/checkout to 6.0.3
+
 ## 0.77.0 (2026-05-28)
 
 - (PR #1030, 2026-05-11) chore(deps): Bump the github-actions-production group with 2 updates

--- a/src/cl_sii/__init__.py
+++ b/src/cl_sii/__init__.py
@@ -4,4 +4,4 @@ cl-sii Python lib
 
 """
 
-__version__ = '0.77.0'
+__version__ = '0.78.0'


### PR DESCRIPTION
- (PR #1031, 2026-05-28) chore(deps): Bump build from 1.4.2 to 1.4.4 in the python-development group
- (PR #1039, 2026-06-02) chore(deps): Bump the github-actions-production group with 2 updates
- (PR #1040, 2026-06-05) dte: Add TipoDte 110, 111, 112
- (PR #1042, 2026-06-08) chore(deps): Bump the codecov to 7.0.0 - actions/checkout to 6.0.3