### PR TITLE
Do not trigger Git Commit Linter and Dependency Review when draft PR is ready for review

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
 
 permissions:
   contents: read

--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -8,7 +8,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
 
 permissions:
   contents: read


### PR DESCRIPTION
Reverted commits b7ea3abdf29b65bc1df2fe75521ee13781c7bcff and 10f866febaba3aded7ed8a09645a9a185cecaea8 because that workaround is no longer needed after the change described in the GitHub Changelog on 2026-06-11:

From [GitHub Changelog → Bot-created pull requests can run workflows if approved](https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/):

> Pull requests created by the `github-actions[bot]` are now able to run
> your CI/CD workflows with user approval. Requiring approval is a security
> measure to ensure generated code does not automatically run workflows
> which may have access to sensitive information. […]
>
> Previously, pull requests generated by `github-actions[bot]` were not
> able to run CI/CD workflows, allowing pull requests to be accidentally
> merged without having gone through CI. This change allows all pull requests,
> even bot-generated changes, to run configured CI/CD workflows if approved
> by a user with write access to the repository.