### PR TITLE
deps: Update `signxml` from 4.2.0 to 4.3.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,5 +18,5 @@ pydantic==2.12.5
 pyOpenSSL==26.0.0
 pytz==2025.2
 setuptools==82.0.1
-signxml==4.2.0
+signxml==4.3.1
 typing-extensions==4.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing
-signxml==4.2.0
+signxml==4.3.1
     # via -r requirements.in
 sqlparse==0.5.4
     # via django


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/signxml/4.3.1/)
- [Release Notes](https://github.com/XML-Security/signxml/releases/tag/v4.3.1)
- [Changelog](https://github.com/XML-Security/signxml/blob/v4.3.1/Changes.rst#changes-for-v431-2026-02-17)
- [Commits](https://github.com/XML-Security/signxml/compare/v4.2.0...v4.3.1)